### PR TITLE
Discordeno Repository URL got changed again.

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -2,7 +2,7 @@
   "name": "discordeno",
   "version": "0.0.1",
   "description": "Docs for Discordeno",
-  "repository": "https://github.com/discordeno/Discordeno",
+  "repository": "https://github.com/discordeno/discordeno",
   "scripts": {
     "docs:dev": "vuepress dev src --host localhost",
     "docs:build": "vuepress build src"


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Since it was decided to change the Repository name to a small "d" the Repository base URL for the Documentation is outdated again.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
