### PR TITLE
x.nest.land to deno.land/x/

### DIFF
--- a/docs/src/djs.md
+++ b/docs/src/djs.md
@@ -102,13 +102,13 @@ Discordeno Version:
 ```ts
 import Client, {
   updateEventHandlers,
-} from "https://x.nest.land/Discordeno@9.0.1/src/module/client.ts";
+} from "https://deno.land/x/discordeno@9.4.0/src/module/client.ts";
 import { configs } from "./configs.ts";
-import { Intents } from "https://x.nest.land/Discordeno@9.0.1/src/types/options.ts";
+import { Intents } from "https://deno.land/x/discordeno@9.4.0/src/types/options.ts";
 import { eventHandlers } from "./src/events/eventHandlers.ts";
-import { Message } from "https://x.nest.land/Discordeno@9.0.1/src/structures/message.ts";
+import { Message } from "https://deno.land/x/discordeno@9.4.0/src/structures/message.ts";
 import { Command } from "./src/types/commands.ts";
-import { Guild } from "https://x.nest.land/Discordeno@9.0.1/src/structures/guild.ts";
+import { Guild } from "https://deno.land/x/discordeno@9.4.0/src/structures/guild.ts";
 
 export const botCache = {
   commands: new Map<string, Command>(),
@@ -158,10 +158,10 @@ In our `ready.ts` file we can add the `ready` event listener.
 ```ts
 import { botCache } from "../../mod.ts";
 import { configs } from "../../configs.ts";
-import { cache } from "https://x.nest.land/Discordeno@9.0.1/src/utils/cache.ts";
-import { editBotsStatus, chooseRandom } from "https://x.nest.land/Discordeno@9.0.1/src/utils/utils.ts";
-import { StatusType } from "https://x.nest.land/Discordeno@9.0.1/src/types/discord.ts";
-import { ActivityType } from "https://x.nest.land/Discordeno@9.0.1/src/types/activity.ts";
+import { cache } from "https://deno.land/x/discordeno@9.4.0/src/utils/cache.ts";
+import { editBotsStatus, chooseRandom } from "https://deno.land/x/discordeno@9.4.0/src/utils/utils.ts";
+import { StatusType } from "https://deno.land/x/discordeno@9.4.0/src/types/discord.ts";
+import { ActivityType } from "https://deno.land/x/discordeno@9.4.0/src/types/activity.ts";
 
 botCache.eventHandlers.ready = function () {
   console.log(`[READY] Bot is online and ready in ${cache.guilds.size} guild(s)!`);
@@ -237,7 +237,7 @@ module.exports = class addRoleCommand extends Command {
 This is how to do it with Discordeno:
 ```ts
 import { botCache } from "../../mod.ts";
-import { addRole } from "https://x.nest.land/Discordeno@9.0.1/src/handlers/member.ts";
+import { addRole } from "https://deno.land/x/discordeno@9.4.0/src/handlers/member.ts";
 import { sendAlertResponse, sendResponse } from "../utils/helpers.ts";
 
 botCache.commands.set(`addrole`, {
@@ -341,10 +341,10 @@ module.exports = class kickCommand extends Command {
 
 Discordeno Version
 ```ts
-import { sendMessage } from "https://x.nest.land/Discordeno@9.0.1/src/handlers/channel.ts";
-import { Member } from "https://x.nest.land/Discordeno@9.0.1/src/structures/member.ts";
-import { kick } from "https://x.nest.land/Discordeno@9.0.1/src/handlers/member.ts";
-import { deleteMessage } from "https://x.nest.land/Discordeno@9.0.1/src/handlers/message.ts";
+import { sendMessage } from "https://deno.land/x/discordeno@9.4.0/src/handlers/channel.ts";
+import { Member } from "https://deno.land/x/discordeno@9.4.0/src/structures/member.ts";
+import { kick } from "https://deno.land/x/discordeno@9.4.0/src/handlers/member.ts";
+import { deleteMessage } from "https://deno.land/x/discordeno@9.4.0/src/handlers/message.ts";
 import { botCache } from "../../mod.ts";
 import { createCommandAliases, sendResponse } from "../utils/helpers.ts";
 import { Embed } from "../utils/Embed.ts";

--- a/docs/src/gettingstarted.md
+++ b/docs/src/gettingstarted.md
@@ -32,7 +32,7 @@ Now you've created an Application but it will need some code in order for it to 
 
 You can install Discordeno by importing:
 ```ts
-import Client from "https://x.nest.land/Discordeno@9.0.1/src/module/client.ts";
+import Client from "https://deno.land/x/discordeno@9.4.0/src/module/client.ts";
 ```
 
 ## Example Usage
@@ -40,7 +40,7 @@ import Client from "https://x.nest.land/Discordeno@9.0.1/src/module/client.ts";
 Starting with Discordeno is very simple, you can start from scratch without any boilerplates/frameworks: Add this snippet of code into a new TypeScript file:
 
 ```ts
-import StartBot, { sendMessage, Intents } from "https://x.nest.land/Discordeno@9.0.1/src/module/client.ts";
+import StartBot, { sendMessage, Intents } from "https://deno.land/x/discordeno@9.4.0/src/module/client.ts";
 import config from "./config.ts";
 
 StartBot({

--- a/docs/src/stepbystep/createcommand.md
+++ b/docs/src/stepbystep/createcommand.md
@@ -8,8 +8,8 @@ Let's first start by taking an existing command and slightly modifying it to you
 
 ```ts
 import { botCache } from "../../mod.ts";
-import { sendMessage } from "https://x.nest.land/Discordeno@9.0.1/src/handlers/channel.ts";
-import { botID } from "https://x.nest.land/Discordeno@9.0.1/src/module/client.ts";
+import { sendMessage } from "https://deno.land/x/discordeno@9.4.0/src/handlers/channel.ts";
+import { botID } from "https://deno.land/x/discordeno@9.4.0/src/module/client.ts";
 import { createCommand } from "../utils/helpers.ts"
 
 createCommand({
@@ -114,7 +114,7 @@ Let's make a command that will allow guild admins to give or take roles from a m
 
 ```ts
 import { botCache } from "../../mod.ts";
-import { sendMessage } from "https://x.nest.land/Discordeno@9.0.1/src/handlers/channel.ts";
+import { sendMessage } from "https://deno.land/x/discordeno@9.4.0/src/handlers/channel.ts";
 import { PermissionLevels } from "../types/commands.ts";
 import { createCommandAliases } from "../utils/helpers";
 

--- a/docs/src/stepbystep/createevent.md
+++ b/docs/src/stepbystep/createevent.md
@@ -12,7 +12,7 @@ Go ahead and open up the `src/events/ready.ts` file. When you open this file, yo
 
 ```ts
 import { botCache } from "../../mod.ts";
-import { cache } from "https://x.nest.land/Discordeno@9.0.1/src/utils/cache.ts";
+import { cache } from "https://deno.land/x/discordeno@9.4.0/src/utils/cache.ts";
 
 botCache.eventHandlers.ready = function () {
   console.log(`Loaded ${botCache.arguments.size} Argument(s)`);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Since the discordeno support for x.nest.land gets officially dropped all links may be changed to deno.land/x/

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
