### PR TITLE
Allow/Deny changed to Strings in v8

### DIFF
--- a/src/types/guild.ts
+++ b/src/types/guild.ts
@@ -469,9 +469,9 @@ export interface RawOverwrite {
   /** Whether this is a role or a member */
   type: OverwriteType;
   /** The permissions that this id is allowed to do. (This will mark it as a green check.) */
-  allow: number;
+  allow: string;
   /** The permissions that this id is NOT allowed to do. (This will mark it as a red x.) */
-  deny: number;
+  deny: string;
 }
 
 export interface ChannelCreateOptions {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Since Discords v8 update permission allow/deny are send as strings now. Change was requested by Skillz4Killz.

**Status**

- [ ] Code changes have been tested against the Discord API, or there are no code changes

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
