### PR TITLE
fix: hasChannelPermissions

### DIFF
--- a/src/util/permissions.ts
+++ b/src/util/permissions.ts
@@ -191,7 +191,7 @@ export async function hasChannelPermissions(
   if (permissions.every((perm) => allowedPermissions.has(perm))) return true;
 
   // Some permission was not explicitly allowed so we default to checking role perms directly
-  const hasPerms = await botHasPermission(guild.id, permissions);
+  const hasPerms = await memberIDHasPermission(memberID, guild.id, permissions);
   return hasPerms;
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
hasChannelPermissions is using a wrong function at the end. It should check for the member permission and not for the bot permission.

**Status**

- [ ] Code changes have been tested against the Discord API, or there are no code changes

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
