### PR TITLE
fix: replace incorrect check for GUILD_UPDATE controller

### DIFF
--- a/src/api/controllers/guilds.ts
+++ b/src/api/controllers/guilds.ts
@@ -65,7 +65,7 @@ export async function handleInternalGuildDelete(data: DiscordPayload) {
 }
 
 export async function handleInternalGuildUpdate(data: DiscordPayload) {
-  if (data.t !== "GUILD_CREATE") return;
+  if (data.t !== "GUILD_UPDATE") return;
 
   const payload = data.d as UpdateGuildPayload;
   const cachedGuild = await cacheHandlers.get("guilds", payload.id);


### PR DESCRIPTION
- The `GUILD_UPDATE` controller checks if the `data.t` is NOT `GUILD_CREATE`, this PR replaces `GUILD_CREATE` to `GUILD_UPDATE`.