### PR TITLE
fix: outdated pin & unpin handlers and endpoints

### DIFF
--- a/src/api/handlers/message.ts
+++ b/src/api/handlers/message.ts
@@ -68,7 +68,8 @@ export async function pin(channelID: string, messageID: string) {
   ) {
     throw new Error(Errors.MISSING_MANAGE_MESSAGES);
   }
-  return RequestManager.put(endpoints.CHANNEL_MESSAGE(channelID, messageID));
+
+  return RequestManager.put(endpoints.CHANNEL_PIN(channelID, messageID));
 }
 
 /** Unpin a message in a channel. Requires MANAGE_MESSAGES. */
@@ -82,8 +83,9 @@ export async function unpin(channelID: string, messageID: string) {
   ) {
     throw new Error(Errors.MISSING_MANAGE_MESSAGES);
   }
+
   return RequestManager.delete(
-    endpoints.CHANNEL_MESSAGE(channelID, messageID),
+    endpoints.CHANNEL_PIN(channelID, messageID),
   );
 }
 

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -31,6 +31,8 @@ export const endpoints = {
     `${baseEndpoints.BASE_URL}/channels/${id}/messages/${messageID}`,
   CHANNEL_MESSAGES: (id: string) =>
     `${baseEndpoints.BASE_URL}/channels/${id}/messages`,
+  CHANNEL_PIN: (channelID: string, messageID: string) =>
+    `${baseEndpoints.BASE_URL}/channels/${channelID}/pins/${messageID}`,
   CHANNEL_PINS: (id: string) => `${baseEndpoints.BASE_URL}/channels/${id}/pins`,
   CHANNEL_BULK_DELETE: (id: string) =>
     `${baseEndpoints.BASE_URL}/channels/${id}/messages/bulk-delete`,


### PR DESCRIPTION
Reference: https://discord.com/developers/docs/resources/channel#add-pinned-channel-message