### PR TITLE
fix: cachedMessage content on messageUpdate

### DIFF
--- a/src/api/controllers/messages.ts
+++ b/src/api/controllers/messages.ts
@@ -85,8 +85,6 @@ export async function handleInternalMessageUpdate(data: DiscordPayload) {
   const cachedMessage = await cacheHandlers.get("messages", payload.id);
   if (!cachedMessage) return;
 
-  cachedMessage.content = payload.content;
-
   const oldMessage = {
     attachments: cachedMessage.attachments,
     content: cachedMessage.content,
@@ -95,6 +93,8 @@ export async function handleInternalMessageUpdate(data: DiscordPayload) {
     tts: cachedMessage.tts,
     pinned: cachedMessage.pinned,
   };
+  
+  cachedMessage.content = payload.content;
 
   // Messages with embeds can trigger update but they wont have edited_timestamp
   if (

--- a/src/api/controllers/messages.ts
+++ b/src/api/controllers/messages.ts
@@ -85,6 +85,8 @@ export async function handleInternalMessageUpdate(data: DiscordPayload) {
   const cachedMessage = await cacheHandlers.get("messages", payload.id);
   if (!cachedMessage) return;
 
+  cachedMessage.content = payload.content;
+
   const oldMessage = {
     attachments: cachedMessage.attachments,
     content: cachedMessage.content,
@@ -93,8 +95,6 @@ export async function handleInternalMessageUpdate(data: DiscordPayload) {
     tts: cachedMessage.tts,
     pinned: cachedMessage.pinned,
   };
-  
-  cachedMessage.content = payload.content;
 
   // Messages with embeds can trigger update but they wont have edited_timestamp
   if (

--- a/src/api/controllers/messages.ts
+++ b/src/api/controllers/messages.ts
@@ -85,6 +85,8 @@ export async function handleInternalMessageUpdate(data: DiscordPayload) {
   const cachedMessage = await cacheHandlers.get("messages", payload.id);
   if (!cachedMessage) return;
 
+  cachedMessage.content = payload.content;
+
   const oldMessage = {
     attachments: cachedMessage.attachments,
     content: cachedMessage.content,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Upon firing a messageUpdate event, cachedMessage's content was not reflected

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
