### PR TITLE
fix: cachedMessage content on messageUpdate

### DIFF
--- a/src/api/controllers/messages.ts
+++ b/src/api/controllers/messages.ts
@@ -94,6 +94,8 @@ export async function handleInternalMessageUpdate(data: DiscordPayload) {
     pinned: cachedMessage.pinned,
   };
 
+  cachedMessage.content = payload.content;
+
   // Messages with embeds can trigger update but they wont have edited_timestamp
   if (
     !payload.edited_timestamp ||

--- a/src/api/controllers/messages.ts
+++ b/src/api/controllers/messages.ts
@@ -99,7 +99,7 @@ export async function handleInternalMessageUpdate(data: DiscordPayload) {
   // Messages with embeds can trigger update but they wont have edited_timestamp
   if (
     !payload.edited_timestamp ||
-    (cachedMessage.content !== payload.content)
+    (oldMessage.content !== payload.content)
   ) {
     return;
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Upon firing a messageUpdate event, cachedMessage's content was not reflected

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
