### PR TITLE
fix: slash command edit functions

### DIFF
--- a/src/api/handlers/webhook.ts
+++ b/src/api/handlers/webhook.ts
@@ -9,7 +9,6 @@ import {
   ExecuteSlashCommandOptions,
   ExecuteWebhookOptions,
   MessageCreateOptions,
-  UpsertSlashCommandOptions,
   WebhookCreateOptions,
   WebhookPayload,
 } from "../../types/mod.ts";
@@ -227,11 +226,14 @@ export function getSlashCommands(guildID?: string) {
 /**
  * Edit an existing slash command. If this command did not exist, it will create it.
  */
-export function upsertSlashCommand(options: UpsertSlashCommandOptions) {
+export function upsertSlashCommand(
+  commandID: string,
+  options: CreateSlashCommandOptions,
+) {
   return RequestManager.post(
     options.guildID
-      ? endpoints.COMMANDS_GUILD_ID(botID, options.id, options.guildID)
-      : endpoints.COMMANDS_ID(botID, options.id),
+      ? endpoints.COMMANDS_GUILD_ID(botID, commandID, options.guildID)
+      : endpoints.COMMANDS_ID(botID, commandID),
     {
       ...options,
     },

--- a/src/api/handlers/webhook.ts
+++ b/src/api/handlers/webhook.ts
@@ -241,11 +241,14 @@ export function upsertSlashCommand(
 }
 
 /** Edit an existing slash command. */
-export function editSlashCommand(options: EditSlashCommandOptions) {
+export function editSlashCommand(
+  commandID: string,
+  options: CreateSlashCommandOptions,
+) {
   return RequestManager.patch(
     options.guildID
-      ? endpoints.COMMANDS_GUILD_ID(botID, options.id, options.guildID)
-      : endpoints.COMMANDS_ID(botID, options.id),
+      ? endpoints.COMMANDS_GUILD_ID(botID, commandID, options.guildID)
+      : endpoints.COMMANDS_ID(botID, commandID),
     {
       ...options,
     },

--- a/src/types/webhook.ts
+++ b/src/types/webhook.ts
@@ -213,8 +213,3 @@ export interface EditSlashResponseOptions extends SlashCommandCallbackData {
   /** If this is not provided, it will default to editing the original response. */
   messageID?: string;
 }
-
-export interface UpsertSlashCommandOptions {
-  id: string;
-  guildID?: string;
-}


### PR DESCRIPTION
Please describe the changes this PR makes and why it should be merged:

upsertSlashCommand() does not actually edit the slash command. This is fixing this issue
Status

 Code changes have been tested against the Discord API, or there are no code changes
Semantic versioning classification:

 This PR changes the library's interface (methods or parameters added)
 This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
 This PR only includes non-code changes, like changes to documentation, README, etc.