### PR TITLE
feat(guild): change Guild#emojis to use Collection

### DIFF
--- a/src/api/controllers/guilds.ts
+++ b/src/api/controllers/guilds.ts
@@ -8,6 +8,7 @@ import {
   UpdateGuildPayload,
 } from "../../types/mod.ts";
 import { cache } from "../../util/cache.ts";
+import { Collection } from "../../util/collection.ts";
 import { structures } from "../structures/mod.ts";
 import { cacheHandlers } from "./cache.ts";
 
@@ -112,7 +113,9 @@ export async function handleInternalGuildEmojisUpdate(data: DiscordPayload) {
   if (!guild) return;
 
   const cachedEmojis = guild.emojis;
-  guild.emojis = payload.emojis;
+  guild.emojis = new Collection(
+    payload.emojis.map((emoji) => [emoji.id ?? emoji.name, emoji]),
+  );
 
   return eventHandlers.guildEmojisUpdate?.(
     guild,

--- a/src/api/controllers/guilds.ts
+++ b/src/api/controllers/guilds.ts
@@ -119,7 +119,7 @@ export async function handleInternalGuildEmojisUpdate(data: DiscordPayload) {
 
   return eventHandlers.guildEmojisUpdate?.(
     guild,
-    payload.emojis,
+    guild.emojis,
     cachedEmojis,
   );
 }

--- a/src/api/structures/guild.ts
+++ b/src/api/structures/guild.ts
@@ -139,6 +139,7 @@ export async function createGuild(data: CreateGuildPayload, shardID: number) {
     voice_states: voiceStates = [],
     channels = [],
     members,
+    emojis,
     presences = [],
     ...rest
   } = data;
@@ -188,6 +189,9 @@ export async function createGuild(data: CreateGuildPayload, shardID: number) {
     presences: createNewProp(
       new Collection(presences.map((p: Presence) => [p.user.id, p])),
     ),
+    emojis: createNewProp(
+      new Collection(emojis.map((emoji) => [emoji.id ?? emoji.name, emoji])),
+    ),
     memberCount: createNewProp(memberCount),
     voiceStates: createNewProp(
       new Collection(
@@ -231,7 +235,7 @@ export interface Guild {
   /** Explicit content filter level */
   explicitContentFilter: number;
   /** The custom guild emojis */
-  emojis: Emoji[];
+  emojis: Collection<string, Emoji>;
   /** Enabled guild features */
   features: GuildFeatures[];
   /** System channel flags */

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -93,7 +93,7 @@ export interface EventHandlers {
   guildDelete?: (guild: Guild) => unknown;
   guildEmojisUpdate?: (
     guild: Guild,
-    emojis: Emoji[],
+    emojis: Collection<string, Emoji>,
     cachedEmojis: Collection<string, Emoji>,
   ) => unknown;
   guildMemberAdd?: (guild: Guild, member: Member) => unknown;

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -5,6 +5,7 @@ import {
   Message,
   Role,
 } from "../api/structures/mod.ts";
+import { Collection } from "../util/collection.ts";
 import {
   DiscordPayload,
   Emoji,
@@ -93,7 +94,7 @@ export interface EventHandlers {
   guildEmojisUpdate?: (
     guild: Guild,
     emojis: Emoji[],
-    cachedEmojis: Emoji[],
+    cachedEmojis: Collection<string, Emoji>,
   ) => unknown;
   guildMemberAdd?: (guild: Guild, member: Member) => unknown;
   guildMemberRemove?: (


### PR DESCRIPTION
# For v11 (DO NOT MERGE)

**Please describe the changes this PR makes and why it should be merged:**
- Convert `guild.emojis` to `Collection<string (emoji ID), Emoji>` from `Emoji[]`

Closes #373

**Status**

- [ ] Code changes have been tested against the Discord API, or there are no code changes

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
