### PR TITLE
handlers(guild): rename guild functions

### DIFF
--- a/src/api/handlers/guild.ts
+++ b/src/api/handlers/guild.ts
@@ -585,7 +585,7 @@ export async function unban(guildID: string, id: string) {
 }
 
 /** Modify a guilds settings. Requires the MANAGE_GUILD permission. */
-export async function editGuild(guildID: string, options: GuildEditOptions) {
+export async function editServer(guildID: string, options: GuildEditOptions) {
   const hasPerm = await botHasPermission(guildID, ["MANAGE_GUILD"]);
   if (!hasPerm) {
     throw new Error(Errors.MISSING_MANAGE_GUILD);
@@ -617,7 +617,7 @@ export async function getInvites(guildID: string) {
 }
 
 /** Leave a guild */
-export function leaveGuild(guildID: string) {
+export function leaveServer(guildID: string) {
   return RequestManager.delete(endpoints.GUILD_LEAVE(guildID));
 }
 
@@ -651,7 +651,7 @@ export function getUser(userID: string) {
  * This function fetches a guild's data. This is not the same data as a GUILD_CREATE.
  * So it does not cache the guild, you must do it manually.
  * */
-export function getGuild(guildID: string, counts = true) {
+export function getServer(guildID: string, counts = true) {
   return RequestManager.get(
     endpoints.GUILD(guildID),
     { with_counts: counts },

--- a/src/api/structures/guild.ts
+++ b/src/api/structures/guild.ts
@@ -22,14 +22,14 @@ import { createNewProp } from "../../util/utils.ts";
 import {
   ban,
   deleteServer,
-  editGuild,
+  editServer,
   getAuditLogs,
   getBan,
   getBans,
   getInvites,
   guildBannerURL,
   guildIconURL,
-  leaveGuild,
+  leaveServer,
   unban,
 } from "../handlers/guild.ts";
 import { Member } from "./member.ts";
@@ -81,7 +81,7 @@ const baseGuild: Partial<Guild> = {
     return deleteServer(this.id!);
   },
   edit(options) {
-    return editGuild(this.id!, options);
+    return editServer(this.id!, options);
   },
   auditLogs(options) {
     return getAuditLogs(this.id!, options);
@@ -105,7 +105,7 @@ const baseGuild: Partial<Guild> = {
     return guildIconURL(this as Guild, size, format);
   },
   leave() {
-    return leaveGuild(this.id!);
+    return leaveServer(this.id!);
   },
 };
 
@@ -330,9 +330,9 @@ export interface Guild {
   /** Delete a guild permanently. User must be owner. Returns 204 No Content on success. Fires a Guild Delete Gateway event. */
   delete(): ReturnType<typeof deleteServer>;
   /** Leave a guild */
-  leave(): ReturnType<typeof leaveGuild>;
+  leave(): ReturnType<typeof leaveServer>;
   /** Edit the server. Requires the MANAGE_GUILD permission. */
-  edit(options: GuildEditOptions): ReturnType<typeof editGuild>;
+  edit(options: GuildEditOptions): ReturnType<typeof editServer>;
   /** Returns the audit logs for the guild. Requires VIEW AUDIT LOGS permission */
   auditLogs(options: GetAuditLogsOptions): ReturnType<typeof getAuditLogs>;
   /** Returns a ban object for the given user or a 404 not found if the ban cannot be found. Requires the BAN_MEMBERS permission. */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
For more consistency in the lib function names like `leaveGuild` should be changed to `leaveServer`

Note: This is a breaking change don't merge this before v11!

**Status**

- [ ] Code changes have been tested against the Discord API, or there are no code changes

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
