### PR TITLE
types(message): make attachment dimensions optional

### DIFF
--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -32,9 +32,9 @@ export interface Attachment {
   /** A proxied url of file */
   proxy_url: string;
   /** The height of file if an image */
-  height: number | null;
+  height?: number | null;
   /** The width of the file if an image */
-  width: number | null;
+  width?: number | null;
 }
 
 export interface Embed {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- Make `Attachment.height` and `Attachment.width` optional.

Reference: https://github.com/discord/discord-api-docs/pull/2214 (NOT MERGED)

**Status**

- [ ] Code changes have been tested against the Discord API, or there are no code changes

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
