### PR TITLE
feat(controllers): add membershipScreeningPassed event

### DIFF
--- a/src/api/controllers/members.ts
+++ b/src/api/controllers/members.ts
@@ -81,7 +81,7 @@ export async function handleInternalGuildMemberUpdate(data: DiscordPayload) {
     );
   }
 
-  if (guildMember?.pending === false) {
+  if (guildMember?.pending === false && cachedMember?.pending) {
     eventHandlers.membershipScreeningPassed?.(guild, member);
   }
 

--- a/src/api/controllers/members.ts
+++ b/src/api/controllers/members.ts
@@ -81,7 +81,7 @@ export async function handleInternalGuildMemberUpdate(data: DiscordPayload) {
     );
   }
 
-  if (guildMember?.pending === false && cachedMember?.pending) {
+  if (payload.pending === false && guildMember?.pending === true) {
     eventHandlers.membershipScreeningPassed?.(guild, member);
   }
 

--- a/src/api/controllers/members.ts
+++ b/src/api/controllers/members.ts
@@ -81,7 +81,7 @@ export async function handleInternalGuildMemberUpdate(data: DiscordPayload) {
     );
   }
 
-  if (guildMember?.pending) {
+  if (guildMember?.pending === false) {
     eventHandlers.membershipScreeningPassed?.(guild, member);
   }
 

--- a/src/api/controllers/members.ts
+++ b/src/api/controllers/members.ts
@@ -80,6 +80,11 @@ export async function handleInternalGuildMemberUpdate(data: DiscordPayload) {
       guildMember?.nick,
     );
   }
+
+  if (guildMember?.pending) {
+    eventHandlers.membershipScreeningPassed?.(guild, member);
+  }
+
   const roleIDs = guildMember?.roles || [];
 
   roleIDs.forEach((id) => {

--- a/src/api/structures/member.ts
+++ b/src/api/structures/member.ts
@@ -156,8 +156,6 @@ export interface Member {
   premiumType?: number;
   /** The guild related data mapped by guild id */
   guilds: Collection<string, GuildMember>;
-  /** whether the user has not yet passed the guild's Membership Screening requirements */
-  pending?: boolean;
 
   // GETTERS
   /** The avatar url using the default format and size. */

--- a/src/api/structures/member.ts
+++ b/src/api/structures/member.ts
@@ -156,6 +156,8 @@ export interface Member {
   premiumType?: number;
   /** The guild related data mapped by guild id */
   guilds: Collection<string, GuildMember>;
+  /** whether the user has not yet passed the guild's Membership Screening requirements */
+  pending?: boolean;
 
   // GETTERS
   /** The avatar url using the default format and size. */

--- a/src/types/guild.ts
+++ b/src/types/guild.ts
@@ -49,6 +49,8 @@ export interface GuildMemberUpdatePayload {
   nick: string;
   /** When the user used their nitro boost on the guild. */
   premium_since: string | null;
+  /** whether the user has not yet passed the guild's Membership Screening requirements */
+  pending?: boolean;
 }
 
 export interface GuildMemberAddPayload extends MemberCreatePayload {

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -208,6 +208,8 @@ export interface EventHandlers {
   ) => unknown;
   /** Sent when a guild channel's webhook is created, updated, or deleted. */
   webhooksUpdate?: (channelID: string, guildID: string) => unknown;
+  /** Sent when a member has passed the guild's Membership Screening requirements */
+  membershipScreeningPassed?: (guild: Guild, member: Member) => unknown;
 }
 
 /** https://discord.com/developers/docs/topics/gateway#list-of-intents */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- Added "membershipScreeningPassed" event to `EventHandlers`.
- Emit "membershipScreeningPassed" event when the `member.pending` field is true in "GUILD_MEMBER_UPDATE" event.

Closes: #462 