### PR TITLE
fix(controllers): delete role from cache before emitting the event

### DIFF
--- a/src/api/controllers/roles.ts
+++ b/src/api/controllers/roles.ts
@@ -29,9 +29,9 @@ export async function handleInternalGuildRoleDelete(data: DiscordPayload) {
   if (!guild) return;
 
   const cachedRole = guild.roles.get(payload.role_id)!;
-  if (cachedRole) eventHandlers.roleDelete?.(guild, cachedRole);
-
   guild.roles.delete(payload.role_id);
+
+  if (cachedRole) eventHandlers.roleDelete?.(guild, cachedRole);
 
   // For bots without GUILD_MEMBERS member.roles is never updated breaking permissions checking.
   cacheHandlers.forEach("members", (member) => {


### PR DESCRIPTION
My bad, I accidently reverted that one. The role needs to be deleted from cache before emitting the event.