### PR TITLE
fix(ws/shard): use WebSocket#close() instead of WebSocket#send() to close connection

### DIFF
--- a/src/ws/shard.ts
+++ b/src/ws/shard.ts
@@ -229,7 +229,7 @@ async function heartbeat(
         },
       );
 
-      shard.ws.close(4009, "Session timed out");
+      return shard.ws.close(4009, "Session timed out");
     }
   }
 

--- a/src/ws/shard.ts
+++ b/src/ws/shard.ts
@@ -228,7 +228,8 @@ async function heartbeat(
           },
         },
       );
-      return shard.ws.send(JSON.stringify({ op: 4009 }));
+
+      shard.ws.close(4009, "Session timed out");
     }
   }
 


### PR DESCRIPTION
I am still confused as to why the WebSocket connection is closed with close code `4009`... any particular reason why this is done? @Skillz4Killz 