### PR TITLE
docs(README): mention usage of SemVer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Discord API library for [Deno](https://deno.land)
 
+Discordeno follows [Semantic Versioning](https://semver.org/)
+
 [![Discord](https://img.shields.io/discord/785384884197392384?color=7289da&logo=discord&logoColor=dark)](https://discord.com/invite/5vBgXk3UcZ)
 ![Lint](https://github.com/discordeno/discordeno/workflows/Lint/badge.svg)
 ![Test](https://github.com/discordeno/discordeno/workflows/Test/badge.svg)


### PR DESCRIPTION
It is ambiguous or vague to the users whether Discordeno follows Semver or not... this changes that; explicitly state that Discordeno follows SemVer to enable backward compatibility.