### PR TITLE
docs(README): fix grammatical error

### DIFF
--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -54,5 +54,5 @@ resources:
 - [TypeScript Crash Course by Traversy
   Media](https://www.youtube.com/watch?v=rAy_3SIqT-E)
 
-There is always more resources... Take your time and don't fret! Come back when
-you are ready, we can't wait to see what your Discordeno created bot does!
+There are always more resources... Take your time and don't fret! Come back when
+you're ready, we can't wait to see what your Discordeno created bot does!

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -55,4 +55,4 @@ resources:
   Media](https://www.youtube.com/watch?v=rAy_3SIqT-E)
 
 There are always more resources... Take your time and don't fret! Come back when
-you're ready, we can't wait to see what your Discordeno created bot does!
+you are ready, we can't wait to see what your Discordeno created bot does!


### PR DESCRIPTION
resources is a plural word but is being used as a singular word here