### PR TITLE
fix(handlers/webhook): do not add Date.now() to 900000 ms in executeSlashCommand()

### DIFF
--- a/src/api/handlers/webhook.ts
+++ b/src/api/handlers/webhook.ts
@@ -461,7 +461,7 @@ export async function executeSlashCommand(
   cache.executedSlashCommands.set(token, id);
   setTimeout(
     () => cache.executedSlashCommands.delete(token),
-    Date.now() + 900000,
+    900000,
   );
 
   // If no mentions are provided, force disable mentions


### PR DESCRIPTION
Related #589