### PR TITLE
feat(handlers/message): change getReactions() to use collection

### DIFF
--- a/src/api/controllers/CHANNEL_PINS_UPDATE.ts
+++ b/src/api/controllers/CHANNEL_PINS_UPDATE.ts
@@ -11,7 +11,9 @@ export async function handleChannelPinsUpdate(data: DiscordPayload) {
   const channel = await cacheHandlers.get("channels", payload.channel_id);
   if (!channel) return;
 
-  const guild = payload.guild_id ? await cacheHandlers.get("guilds", payload.guild_id) : undefined;
+  const guild = payload.guild_id
+    ? await cacheHandlers.get("guilds", payload.guild_id)
+    : undefined;
 
   eventHandlers.channelPinsUpdate?.(channel, guild, payload.last_pin_timestamp);
 }

--- a/src/api/handlers/message.ts
+++ b/src/api/handlers/message.ts
@@ -7,6 +7,7 @@ import {
   MessageCreateOptions,
   UserPayload,
 } from "../../types/mod.ts";
+import { Collection } from "../../util/collection.ts";
 import { endpoints } from "../../util/constants.ts";
 import { botHasChannelPermissions } from "../../util/permissions.ts";
 import { delay } from "../../util/utils.ts";
@@ -270,15 +271,12 @@ export async function getReactions(
   reaction: string,
   options?: DiscordGetReactionsParams,
 ) {
-  const result = (await RequestManager.get(
+  const users = (await RequestManager.get(
     endpoints.CHANNEL_MESSAGE_REACTION(message.channelID, message.id, reaction),
     options,
   )) as UserPayload[];
 
-  return Promise.all(result.map(async (res) => {
-    const member = await cacheHandlers.get("members", res.id);
-    return member || res;
-  }));
+  return new Collection(users.map((user) => [user.id, user]));
 }
 
 /** Edit the message. */


### PR DESCRIPTION
Changes:
- Return a promise that resolves to collection of UserPayload mapped by their ID prop
- To maintain consistency, the return type is only a collection of UserPayload as values, not a mixture of Member objects and UserPayload objects

Closes #606 