### PR TITLE
Remove PR title examples

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,21 +12,6 @@
 ## Submitting a Pull Request
 
 - Give the PR a descriptive title.
-
-Examples of good PR title:
-
-- fix(handlers/INTERACTION_CREATE): cache member object
-- docs: improve wording
-- feat: add cache manager module
-- feat(helpers): add editGuild()
-- refactor(ws/shard): remove redundant checks
-
-Examples of bad PR title:
-
-- fix #7123
-- update docs
-- fix bugs
-
 - Ensure there is a related issue and it is referenced in the pull request text.
 - Ensure there are tests that cover the changes.
 - Ensure all of the checks (lint and test) are passing.


### PR DESCRIPTION
From what I can see, majority of the contributors are not familiar with Conventional Commits and some of the commits are merged without proper guidelines (going against Contributing), we should just remove this altogether.