### PR TITLE
remove(types): previewAsset from MessageSticker

### DIFF
--- a/src/types/messages/message_sticker.ts
+++ b/src/types/messages/message_sticker.ts
@@ -17,11 +17,6 @@ export interface MessageSticker {
    * Note: The URL for fetching sticker assets is currently private.
    */
   asset: string;
-  /**
-   * Sticker preview asset hash
-   * Note: The URL for fetching sticker assets is currently private.
-   */
-  previewAsset?: string | null;
   /** Type of sticker format */
   formatType: DiscordMessageStickerFormatTypes;
 }


### PR DESCRIPTION
Reference: https://github.com/discord/discord-api-docs/commit/b9b8db2ed548dded2a50824a68ea638d735737c6