### PR TITLE
remove(types): System user flag

### DIFF
--- a/src/types/users/user_flags.ts
+++ b/src/types/users/user_flags.ts
@@ -10,7 +10,6 @@ export enum DiscordUserFlags {
   HouseBalance = 1 << 8,
   EarlySupporter = 1 << 9,
   TeamUser = 1 << 10,
-  System = 1 << 12,
   BugHunterLevel2 = 1 << 14,
   VerifiedBot = 1 << 16,
   EarlyVerifiedBotDeveloper = 1 << 17,


### PR DESCRIPTION
Reference: https://github.com/discord/discord-api-docs/commit/9293f0d490ac6acf9d627e429e5a8131b303b528

BREAKING: The flag "System" has been removed from the documentation on 9 April 2021