### PR TITLE
remove(types): privateChannels field from Ready

### DIFF
--- a/src/types/gateway/ready.ts
+++ b/src/types/gateway/ready.ts
@@ -9,8 +9,6 @@ export interface Ready {
   v: number;
   /** Information about the user including email */
   user: User;
-  /** Empty array */
-  privateChannels: [];
   /** The guilds the user is in */
   guilds: UnavailableGuild[];
   /** Used for resuming connections */


### PR DESCRIPTION
BREAKING: since Tuesday, 6 April 2021, private_channels field has been undocumented by @night. Reference commit: https://github.com/discord/discord-api-docs/commit/f36156dbb641f5c4d4f4593f345bfd6e27fdee08