### PR TITLE
fix(cache): emojis to use bigint for key

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -31,7 +31,7 @@ export const cache = {
   >(),
   executedSlashCommands: new Set<string>(),
   get emojis() {
-    return new Collection<string, Emoji>(
+    return new Collection<bigint, Emoji>(
       this.guilds.reduce(
         (a, b) => [...a, ...b.emojis.map((e) => [e.id, e])],
         [] as any[],


### PR DESCRIPTION
The title explains it. The cache was using string to key emojis, made that bigints since it's already converted to bigints from string-snowflakes.