### PR TITLE
change: createDiscordenoMember make guild member optional

### DIFF
--- a/src/handlers/interactions/INTERACTION_CREATE.ts
+++ b/src/handlers/interactions/INTERACTION_CREATE.ts
@@ -3,15 +3,18 @@ import { cacheHandlers } from "../../cache.ts";
 import { structures } from "../../structures/mod.ts";
 import type { DiscordGatewayPayload } from "../../types/gateway/gateway_payload.ts";
 import type { Interaction } from "../../types/interactions/interaction.ts";
-import type { GuildMemberWithUser } from "../../types/members/guild_member.ts";
 import { snowflakeToBigint } from "../../util/bigint.ts";
 
 export async function handleInteractionCreate(data: DiscordGatewayPayload) {
   const payload = data.d as Interaction;
   const discordenoMember = payload.guildId
-    ? await structures.createDiscordenoMember(payload.member as GuildMemberWithUser, snowflakeToBigint(payload.guildId))
-    : undefined;
-  if (discordenoMember) {
+    ? await structures.createDiscordenoMember(payload.member!.user, {
+        member: payload.member!,
+        guildId: snowflakeToBigint(payload.guildId),
+      })
+    : await structures.createDiscordenoMember(payload.member!.user);
+
+  if (payload.guildId) {
     await cacheHandlers.set("members", discordenoMember.id, discordenoMember);
     eventHandlers.interactionGuildCreate?.(payload, discordenoMember);
   } else {

--- a/src/handlers/members/GUILD_MEMBERS_CHUNK.ts
+++ b/src/handlers/members/GUILD_MEMBERS_CHUNK.ts
@@ -12,7 +12,7 @@ export async function handleGuildMembersChunk(data: DiscordGatewayPayload) {
 
   const members = await Promise.all(
     payload.members.map(async (member) => {
-      const discordenoMember = await structures.createDiscordenoMember(member, guildId);
+      const discordenoMember = await structures.createDiscordenoMember(member.user, { member, guildId });
       await cacheHandlers.set("members", discordenoMember.id, discordenoMember);
 
       return discordenoMember;

--- a/src/handlers/members/GUILD_MEMBER_ADD.ts
+++ b/src/handlers/members/GUILD_MEMBER_ADD.ts
@@ -11,7 +11,10 @@ export async function handleGuildMemberAdd(data: DiscordGatewayPayload) {
   if (!guild) return;
 
   guild.memberCount++;
-  const discordenoMember = await structures.createDiscordenoMember(payload, guild.id);
+  const discordenoMember = await structures.createDiscordenoMember(payload.user, {
+    member: payload,
+    guildId: guild.id,
+  });
   await cacheHandlers.set("members", discordenoMember.id, discordenoMember);
 
   eventHandlers.guildMemberAdd?.(guild, discordenoMember);

--- a/src/handlers/members/GUILD_MEMBER_UPDATE.ts
+++ b/src/handlers/members/GUILD_MEMBER_UPDATE.ts
@@ -21,7 +21,10 @@ export async function handleGuildMemberUpdate(data: DiscordGatewayPayload) {
     mute: guildMember?.mute || false,
     roles: payload.roles,
   };
-  const discordenoMember = await structures.createDiscordenoMember(newMemberData, guild.id);
+  const discordenoMember = await structures.createDiscordenoMember(newMemberData.user, {
+    member: newMemberData,
+    guildId: guild.id,
+  });
   await cacheHandlers.set("members", discordenoMember.id, discordenoMember);
 
   if (guildMember) {

--- a/src/handlers/messages/MESSAGE_CREATE.ts
+++ b/src/handlers/messages/MESSAGE_CREATE.ts
@@ -2,7 +2,7 @@ import { eventHandlers } from "../../bot.ts";
 import { cacheHandlers } from "../../cache.ts";
 import { structures } from "../../structures/mod.ts";
 import type { DiscordGatewayPayload } from "../../types/gateway/gateway_payload.ts";
-import type { GuildMemberWithUser } from "../../types/members/guild_member.ts";
+import type { GuildMember } from "../../types/members/guild_member.ts";
 import type { Message } from "../../types/messages/message.ts";
 import { snowflakeToBigint } from "../../util/bigint.ts";
 
@@ -15,10 +15,10 @@ export async function handleMessageCreate(data: DiscordGatewayPayload) {
 
   if (payload.member && guild) {
     // If in a guild cache the author as a member
-    const discordenoMember = await structures.createDiscordenoMember(
-      { ...payload.member, user: payload.author } as GuildMemberWithUser,
-      guild.id
-    );
+    const discordenoMember = await structures.createDiscordenoMember(payload.author, {
+      member: payload.member as GuildMember,
+      guildId: guild.id,
+    });
     await cacheHandlers.set("members", discordenoMember.id, discordenoMember);
   }
 
@@ -27,10 +27,10 @@ export async function handleMessageCreate(data: DiscordGatewayPayload) {
       payload.mentions.map(async (mention) => {
         // Cache the member if its a valid member
         if (mention.member) {
-          const discordenoMember = await structures.createDiscordenoMember(
-            { ...mention.member, user: mention } as GuildMemberWithUser,
-            guild.id
-          );
+          const discordenoMember = await structures.createDiscordenoMember(mention, {
+            member: mention.member as GuildMember,
+            guildId: guild.id,
+          });
 
           return cacheHandlers.set("members", snowflakeToBigint(mention.id), discordenoMember);
         }

--- a/src/handlers/messages/MESSAGE_REACTION_ADD.ts
+++ b/src/handlers/messages/MESSAGE_REACTION_ADD.ts
@@ -30,7 +30,10 @@ export async function handleMessageReactionAdd(data: DiscordGatewayPayload) {
   if (payload.member && payload.guildId) {
     const guild = await cacheHandlers.get("guilds", snowflakeToBigint(payload.guildId));
     if (guild) {
-      const discordenoMember = await structures.createDiscordenoMember(payload.member, guild.id);
+      const discordenoMember = await structures.createDiscordenoMember(payload.member.user, {
+        member: payload.member,
+        guildId: guild.id,
+      });
       await cacheHandlers.set("members", discordenoMember.id, discordenoMember);
     }
   }

--- a/src/handlers/misc/USER_UPDATE.ts
+++ b/src/handlers/misc/USER_UPDATE.ts
@@ -1,5 +1,6 @@
 import { eventHandlers } from "../../bot.ts";
 import { cacheHandlers } from "../../cache.ts";
+import { structures } from "../../structures/mod.ts";
 import type { DiscordGatewayPayload } from "../../types/gateway/gateway_payload.ts";
 import type { User } from "../../types/users/user.ts";
 import { snowflakeToBigint } from "../../util/bigint.ts";
@@ -7,14 +8,7 @@ import { snowflakeToBigint } from "../../util/bigint.ts";
 export async function handleUserUpdate(data: DiscordGatewayPayload) {
   const userData = data.d as User;
 
-  const member = await cacheHandlers.get("members", snowflakeToBigint(userData.id));
-  if (!member) return;
-
-  Object.entries(userData).forEach(([key, value]) => {
-    eventHandlers.debug?.("loop", `Running forEach loop in USER_UPDATE file.`);
-    // @ts-ignore index signatures
-    if (member[key] !== value) return (member[key] = value);
-  });
+  const member = await structures.createDiscordenoMember(userData);
 
   await cacheHandlers.set("members", snowflakeToBigint(userData.id), member);
 

--- a/src/handlers/voice/VOICE_STATE_UPDATE.ts
+++ b/src/handlers/voice/VOICE_STATE_UPDATE.ts
@@ -13,7 +13,7 @@ export async function handleVoiceStateUpdate(data: DiscordGatewayPayload) {
   if (!guild) return;
 
   const member = payload.member
-    ? await structures.createDiscordenoMember(payload.member, guild.id)
+    ? await structures.createDiscordenoMember(payload.member.user, { member: payload.member, guildId: guild.id })
     : await cacheHandlers.get("members", snowflakeToBigint(payload.userId));
   if (!member) return;
 

--- a/src/helpers/members/edit_member.ts
+++ b/src/helpers/members/edit_member.ts
@@ -67,7 +67,7 @@ export async function editMember(
     }) as ModifyGuildMember
   );
 
-  const member = await structures.createDiscordenoMember(result, guildId);
+  const member = await structures.createDiscordenoMember(result.user, { member: result, guildId });
 
   return member;
 }

--- a/src/helpers/members/get_member.ts
+++ b/src/helpers/members/get_member.ts
@@ -14,7 +14,7 @@ export async function getMember(guildId: bigint, id: bigint, options?: { force?:
 
   const data = await rest.runMethod<GuildMemberWithUser>("get", endpoints.GUILD_MEMBER(guildId, id));
 
-  const discordenoMember = await structures.createDiscordenoMember(data, guildId);
+  const discordenoMember = await structures.createDiscordenoMember(data.user, { member: data, guildId });
   await cacheHandlers.set("members", discordenoMember.id, discordenoMember);
 
   return discordenoMember;

--- a/src/helpers/members/get_members.ts
+++ b/src/helpers/members/get_members.ts
@@ -48,7 +48,7 @@ export async function getMembers(guildId: bigint, options?: ListGuildMembers & {
 
     const discordenoMembers = await Promise.all(
       result.map(async (member) => {
-        const discordenoMember = await structures.createDiscordenoMember(member, guildId);
+        const discordenoMember = await structures.createDiscordenoMember(member.user, { member, guildId });
 
         if (options?.addToCache !== false) {
           await cacheHandlers.set("members", discordenoMember.id, discordenoMember);

--- a/src/helpers/members/search_members.ts
+++ b/src/helpers/members/search_members.ts
@@ -31,7 +31,7 @@ export async function searchMembers(
 
   const members = await Promise.all(
     result.map(async (member) => {
-      const discordenoMember = await structures.createDiscordenoMember(member, guildId);
+      const discordenoMember = await structures.createDiscordenoMember(member.user, { member, guildId });
       if (options?.cache) {
         await cacheHandlers.set("members", discordenoMember.id, discordenoMember);
       }

--- a/src/util/cache_members.ts
+++ b/src/util/cache_members.ts
@@ -24,10 +24,8 @@ async function startQueue() {
 
   while (guildMemberQueue.size) {
     eventHandlers.debug?.("loop", "Running whille loop in cache_members file.");
-    const [guildId, queue]: [
-      bigint,
-      { members: GuildMemberWithUser[]; resolve: (value?: unknown) => void }
-    ] = guildMemberQueue.entries().next().value;
+    const [guildId, queue]: [bigint, { members: GuildMemberWithUser[]; resolve: (value?: unknown) => void }] =
+      guildMemberQueue.entries().next().value;
 
     await Promise.allSettled([
       queue.members.map(async (member) => {

--- a/src/util/cache_members.ts
+++ b/src/util/cache_members.ts
@@ -24,12 +24,14 @@ async function startQueue() {
 
   while (guildMemberQueue.size) {
     eventHandlers.debug?.("loop", "Running whille loop in cache_members file.");
-    const [guildId, queue]: [bigint, { members: GuildMemberWithUser[]; resolve: (value?: unknown) => void }] =
-      guildMemberQueue.entries().next().value;
+    const [guildId, queue]: [
+      bigint,
+      { members: GuildMemberWithUser[]; resolve: (value?: unknown) => void }
+    ] = guildMemberQueue.entries().next().value;
 
     await Promise.allSettled([
       queue.members.map(async (member) => {
-        const discordenoMember = await structures.createDiscordenoMember(member, guildId);
+        const discordenoMember = await structures.createDiscordenoMember(member.user, { member, guildId });
 
         await cacheHandlers.set("members", discordenoMember.id, discordenoMember);
       }),


### PR DESCRIPTION
Just some way of thinking. Since we don't have anything which depends on at least having one guildMember we can just make it optional.

Why:
- usage of message.member in dms
- members in discordeno are users just with getters so making guild member optional makes sense imo
- getters for users which is pretty neat

also closes: #955