### PR TITLE
change: make RestRequest.reject required

### DIFF
--- a/src/rest/process_queue.ts
+++ b/src/rest/process_queue.ts
@@ -98,12 +98,12 @@ export async function processQueue(id: string) {
 
         // If Rate limited should not remove from queue
         if (response.status !== 429) {
-          queuedRequest.request.reject?.(new Error(`[${response.status}] ${error}`));
+          queuedRequest.request.reject(new Error(`[${response.status}] ${error}`));
           queue.shift();
         } else {
           if (queuedRequest.payload.retryCount++ >= rest.maxRetryCount) {
             rest.eventHandlers.retriesMaxed(queuedRequest.payload);
-            queuedRequest.request.reject?.(
+            queuedRequest.request.reject(
               new Error(`[${response.status}] The request was rate limited and it maxed out the retries limit.`)
             );
             // REMOVE ITEM FROM QUEUE TO PREVENT RETRY
@@ -155,7 +155,7 @@ export async function processQueue(id: string) {
     } catch (error) {
       // SOMETHING WENT WRONG, LOG AND RESPOND WITH ERROR
       rest.eventHandlers.fetchFailed(queuedRequest.payload, error);
-      queuedRequest.request.reject?.(error);
+      queuedRequest.request.reject(error);
       // REMOVE FROM QUEUE
       queue.shift();
     }

--- a/src/rest/rest.ts
+++ b/src/rest/rest.ts
@@ -56,7 +56,7 @@ export interface RestRequest {
   url: string;
   method: string;
   respond: (payload: { status: number; body?: string }) => unknown;
-  reject?: (error: unknown) => unknown;
+  reject: (error: unknown) => unknown;
 }
 
 export interface RestPayload {


### PR DESCRIPTION
This is important so failed requests do actually get rejected. This PR is just to make it typesafe too.