### PR TITLE
v11.0.3

### DIFF
--- a/src/types/messages/components/action_row.ts
+++ b/src/types/messages/components/action_row.ts
@@ -1,7 +1,7 @@
 import { ButtonComponent } from "./button_component.ts";
 import { SelectMenuComponent } from "./select_menu.ts";
 
-// TODO: add docs link
+/** https://discord.com/developers/docs/interactions/message-components#actionrow */
 export interface ActionRow {
   /** Action rows are a group of buttons. */
   type: 1;

--- a/src/types/messages/components/button_component.ts
+++ b/src/types/messages/components/button_component.ts
@@ -2,7 +2,7 @@ import { SnakeCasedPropertiesDeep } from "../../util.ts";
 import { ButtonStyles } from "./button_styles.ts";
 import { DiscordMessageComponentTypes } from "./message_component_types.ts";
 
-// TODO: add docs link
+/** https://discord.com/developers/docs/interactions/message-components#buttons-button-object */
 export interface ButtonComponent {
   /** All button components have type 2 */
   type: DiscordMessageComponentTypes.Button;
@@ -29,4 +29,5 @@ export interface ButtonComponent {
   disabled?: boolean;
 }
 
+// TODO: v12 remove this
 export type DiscordButtonComponent = SnakeCasedPropertiesDeep<ButtonComponent>;

--- a/src/types/messages/components/button_component.ts
+++ b/src/types/messages/components/button_component.ts
@@ -1,10 +1,11 @@
 import { SnakeCasedPropertiesDeep } from "../../util.ts";
 import { ButtonStyles } from "./button_styles.ts";
+import { DiscordMessageComponentTypes } from "./message_component_types.ts";
 
 // TODO: add docs link
 export interface ButtonComponent {
   /** All button components have type 2 */
-  type: 2;
+  type: DiscordMessageComponentTypes.Button;
   /** for what the button says (max 80 characters) */
   label: string;
   /** a dev-defined unique string sent on click (max 100 characters). type 5 Link buttons can not have a custom_id */

--- a/src/types/messages/components/button_data.ts
+++ b/src/types/messages/components/button_data.ts
@@ -1,6 +1,8 @@
+import { DiscordMessageComponentTypes } from "./message_component_types.ts";
+
 export interface ButtonData {
   /** with the value you defined for this component */
   customId: string;
   /** The type of this component */
-  componentType: 2;
+  componentType: DiscordMessageComponentTypes.Button;
 }

--- a/src/types/messages/components/button_styles.ts
+++ b/src/types/messages/components/button_styles.ts
@@ -1,4 +1,4 @@
-// TODO: add docs link
+/** https://discord.com/developers/docs/interactions/message-components#buttons-button-styles */
 export enum DiscordButtonStyles {
   /** A blurple button */
   Primary = 1,

--- a/src/types/messages/components/message_component_types.ts
+++ b/src/types/messages/components/message_component_types.ts
@@ -1,4 +1,4 @@
-// TODO: add docs link
+/** https://discord.com/developers/docs/interactions/message-components#component-types */
 export enum DiscordMessageComponentTypes {
   /** A row of components at the bottom of a message */
   ActionRow = 1,

--- a/src/types/messages/components/select_data.ts
+++ b/src/types/messages/components/select_data.ts
@@ -1,5 +1,6 @@
 import { DiscordMessageComponentTypes } from "./message_component_types.ts";
 
+// TODO: add dock link
 export interface SelectMenuData {
   /** The type of component */
   componentType: DiscordMessageComponentTypes.SelectMenu;

--- a/src/types/messages/components/select_menu.ts
+++ b/src/types/messages/components/select_menu.ts
@@ -1,6 +1,7 @@
 import { DiscordMessageComponentTypes } from "./message_component_types.ts";
 import { SelectOption } from "./select_option.ts";
 
+// TODO: add dock link
 export interface SelectMenuComponent {
   type: DiscordMessageComponentTypes.SelectMenu;
   /** A custom identifier for this component. Maximum 100 characters. */

--- a/src/types/messages/components/select_option.ts
+++ b/src/types/messages/components/select_option.ts
@@ -1,3 +1,4 @@
+// TODO: add dock link
 export interface SelectOption {
   /** The user-facing name of the option. Maximum 25 characters. */
   label: string;

--- a/src/util/dispatch_requirements.ts
+++ b/src/util/dispatch_requirements.ts
@@ -81,7 +81,10 @@ export async function dispatchRequirements(data: DiscordGatewayPayload, shardId:
     );
   }
 
-  const guild = await structures.createDiscordenoGuild(rawGuild, shardId);
+  const guild = await structures.createDiscordenoGuild(
+    { ...rawGuild, memberCount: rawGuild.approximateMemberCount },
+    shardId
+  );
 
   // Add to cache
   cache.guilds.set(id, guild);

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -236,11 +236,11 @@ export function validateComponents(components: MessageComponents) {
 
       // 5 Link buttons can not have a customId
       if (isButton(subcomponent)) {
-        if (subcomponent.type === ButtonStyles.Link && subcomponent.customId) {
+        if (subcomponent.style === ButtonStyles.Link && subcomponent.customId) {
           throw new Error(Errors.LINK_BUTTON_CANNOT_HAVE_CUSTOM_ID);
         }
         // Other buttons must have a customId
-        if (!subcomponent.customId && subcomponent.type !== ButtonStyles.Link) {
+        if (!subcomponent.customId && subcomponent.style !== ButtonStyles.Link) {
           throw new Error(Errors.BUTTON_REQUIRES_CUSTOM_ID);
         }
 


### PR DESCRIPTION
## [11.0.3] - 2021-06-09

### Fixed
- ButtonComponent#type not using enum for the value
- ButtonData#componentType not using enum for the value 
- dispatchRequirements not caching guild#memberCount properly
- validateComponents button subcomponents check not using subcomponent#style prop to validate