### PR TITLE
fix(types): mark id, userId as optional in ThreadMember

### DIFF
--- a/src/types/channels/threads/thread_member.ts
+++ b/src/types/channels/threads/thread_member.ts
@@ -1,8 +1,8 @@
 export interface ThreadMember {
   /** The id of the thread */
-  id: string;
+  id?: string;
   /** The id of the user */
-  userId: string;
+  userId?: string;
   /** The time the current user last joined the thread */
   joinTimestamp: string;
   /** Any user-thread settings, currently only used for notifications */


### PR DESCRIPTION
The id and user_id fields are omitted on the member sent within each thread in the `GUILD_CREATE` event.

## Links

- Reference: https://github.com/discord/discord-api-docs/pull/3097﻿
- Files Diff: https://github.com/discord/discord-api-docs/pull/3097/files#diff-160acb4654c611c67c4ee46b2ce5dda2be82212af8d1d00cd0256ef6edda1e95R543
