### PR TITLE
docs(types): add clarification for guild stickers for MessageSticker#tags

### DIFF
--- a/src/types/messages/message_sticker.ts
+++ b/src/types/messages/message_sticker.ts
@@ -10,7 +10,7 @@ export interface MessageSticker {
   name: string;
   /** Description of the sticker */
   description: string;
-  /** A comma-separated list of tags for the sticker */
+  /** For guild stickers, a unicode emoji representing the sticker's expression. For Nitro stickers, a comma-separated list of related expressions */
   tags?: string;
   /**
    * Sticker asset hash


### PR DESCRIPTION
Reference: https://github.com/discord/discord-api-docs/commit/82e238645e5b80dbb898396fccaf1101716650eb﻿
