### PR TITLE
Update MessageSticker fields and deprecate Message#sticker

### DIFF
--- a/src/types/messages/message.ts
+++ b/src/types/messages/message.ts
@@ -78,7 +78,10 @@ export interface Message {
   messageReference?: Omit<MessageReference, "failIfNotExists">;
   /** Message flags combined as a bitfield */
   flags?: number;
-  /** The stickers sent with the message (bots currently can only receive messages with stickers, not send) */
+  /**
+   * The stickers sent with the message (bots currently can only receive messages with stickers, not send)
+   * @deprecated
+   */
   stickers?: MessageSticker[];
   /**
    * The message associated with the `message_reference`

--- a/src/types/messages/message_sticker.ts
+++ b/src/types/messages/message_sticker.ts
@@ -3,19 +3,20 @@ import type { User } from "../users/user.ts";
 
 /** https://discord.com/developers/docs/resources/channel#message-object-message-sticker-structure */
 export interface MessageSticker {
-  /** id of the sticker */
+  /** Id of the sticker */
   id: string;
-  /** id of the pack the sticker is from */
-  packId: string;
+  /** Id of the pack the sticker is from */
+  packId?: string;
   /** Name of the sticker */
   name: string;
   /** Description of the sticker */
   description: string;
   /** For guild stickers, a unicode emoji representing the sticker's expression. For Nitro stickers, a comma-separated list of related expressions */
-  tags?: string;
+  tags: string;
   /**
    * Sticker asset hash
    * Note: The URL for fetching sticker assets is currently private.
+   * @deprecated the value of the asset field will an empty string.
    */
   asset: string;
   /** Type of sticker format */


### PR DESCRIPTION
- docs(types): deprecate stickers field in Message
- fix(types): update MessageSticker fields

Reference:	https://github.com/discord/discord-api-docs/pull/3127
Commit:		https://github.com/discord/discord-api-docs/commit/9c3577f6ca35904462adf8d57c4346afd2a6bcf0
