### PR TITLE
feat(types/codes): add 20035 code to DiscordJsonErrorCodes

### DIFF
--- a/src/types/codes/json_error_codes.ts
+++ b/src/types/codes/json_error_codes.ts
@@ -42,6 +42,7 @@ export enum DiscordJsonErrorCodes {
   ThisMessageCannotBeEditedDueToAnnouncementRateLimits = 20022,
   TheChannelYouAreWritingHasHitTheWriteRateLimit = 20028,
   YourStageTopicContainsWordsThatAreNotAllowedForPublicStages = 20031,
+  GuildPremiumSubscriptionLevelTooLow = 20035,
   MaximumNumberOfGuildsReached = 30001,
   MaximumNumberOfFriendsReached,
   MaximumNumberOfPinsReachedForTheChannel,


### PR DESCRIPTION
> Added code `20035`, which can be obtained in the following ways:
> 
>     * Creating a private thread in a server that has only public thread support.
> 
>     * Using `auto_archive_duration: 4320`/`10080` for public threads (without `THREE_DAY_AUTO_ARCHIVE` nor `SEVEN_DAY_AUTO_ARCHIVE`).
> 
> 
> * Both cases happen when running them in a library testing server (which has `THREADS_ENABLED`) that doesn't meet the criteria for the `THREADS_ENABLED_TESTING` feature. I'm not aware of this being reproducible elsewhere until general release.
> 
> Credits to @ckohen for finding the error code and the routes in which they appear.

Reference: discord/discord-api-docs#3189﻿
