### PR TITLE
feat: requiredStructureProperties

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -8,6 +8,12 @@ import type { PresenceUpdate } from "./types/activity/presence_update.ts";
 import type { Emoji } from "./types/emojis/emoji.ts";
 import { DiscordenoThread } from "./util/transformers/channel_to_thread.ts";
 import { Collection } from "./util/collection.ts";
+import { Channel } from "./types/channels/channel.ts";
+import { Guild } from "./types/guilds/guild.ts";
+import { GuildMemberWithUser } from "./types/members/guild_member.ts";
+import { Message } from "./types/messages/message.ts";
+import { Role } from "./types/permissions/role.ts";
+import { VoiceState } from "./types/voice/voice_state.ts";
 
 export const cache = {
   isReady: false,
@@ -37,6 +43,21 @@ export const cache = {
   dispatchedGuildIds: new Set<bigint>(),
   dispatchedChannelIds: new Set<bigint>(),
   threads: new Collection<bigint, DiscordenoThread>(),
+  /** ADVANCED USER ONLY: Please ask for help before modifying these. The properties that you want to use for your bot's structures. If you do not set any properties, all properties will be used by default. */
+  requiredStructureProperties: {
+    /** Only these properties will be added to memory for your channels. */
+    channels: new Set<keyof Channel>(),
+    /** Only these properties will be added to memory for your guilds. */
+    guilds: new Set<keyof Guild>(),
+    /** Only these properties will be added to memory for your members. */
+    members: new Set<keyof GuildMemberWithUser>(),
+    /** Only these properties will be added to memory for your messages. */
+    messages: new Set<keyof Message>(),
+    /** Only these properties will be added to memory for your roles. */
+    roles: new Set<keyof Role>(),
+    /** Only these properties will be added to memory for your voice states. */
+    voiceStates: new Set<keyof VoiceState>(),
+  },
 };
 
 function messageSweeper(message: DiscordenoMessage) {

--- a/src/structures/member.ts
+++ b/src/structures/member.ts
@@ -147,19 +147,19 @@ export async function createDiscordenoMember(
     const toggleBits = memberToggles[key as keyof typeof memberToggles];
     if (toggleBits) {
       bitfield |= user[key] ? toggleBits : 0n;
-      return;
+      continue;
     }
 
     if (key === "avatar") {
       const transformed = user[key] ? iconHashToBigInt(user[key] as string) : undefined;
       if (transformed?.animated) bitfield |= memberToggles.animatedAvatar;
       props.avatar = createNewProp(transformed?.bigint);
-      return;
+      continue;
     }
 
     if (key === "discriminator") {
       props.discriminator = createNewProp(Number(user[key]));
-      return;
+      continue;
     }
 
     props[key] = createNewProp(

--- a/src/structures/message.ts
+++ b/src/structures/message.ts
@@ -225,12 +225,12 @@ export async function createDiscordenoMessage(data: Message) {
     const toggleBits = messageToggles[key as keyof typeof messageToggles];
     if (toggleBits) {
       bitfield |= rest[key] ? toggleBits : 0n;
-      return;
+      continue;
     }
 
     // Don't add member to props since it would overwrite the message.member getter
     // thread should not be cached on a message
-    if (["member", "thread"].includes(key)) return;
+    if (["member", "thread"].includes(key)) continue;
 
     props[key] = createNewProp(
       MESSAGE_SNOWFLAKES.includes(key) ? (rest[key] ? snowflakeToBigint(rest[key] as string) : undefined) : rest[key]
@@ -303,11 +303,7 @@ export async function createDiscordenoMessage(data: Message) {
   if (!requiredPropsSize || cache.requiredStructureProperties.messages.has("bitfield"))
     props.bitfield = createNewProp(bitfield);
 
-  const message: DiscordenoMessage = Object.create(baseMessage, {
-    ...props,
-  });
-
-  return message;
+  return Object.create(baseMessage, props) as DiscordenoMessage;
 }
 
 export interface DiscordenoMessage

--- a/src/structures/message.ts
+++ b/src/structures/message.ts
@@ -116,16 +116,16 @@ const baseMessage: Partial<DiscordenoMessage> = {
   async alert(content, timeout = 10, reason = "") {
     if (this.guildId) {
       return await sendMessage(this.channelId!, content).then((response) => {
-        response.delete(reason, timeout * 1000).catch(console.error);
+        response?.delete(reason, timeout * 1000).catch(console.error);
       });
     }
 
     return await sendDirectMessage(this.authorId!, content).then((response) => {
-      response.delete(reason, timeout * 1000).catch(console.error);
+      response?.delete(reason, timeout * 1000).catch(console.error);
     });
   },
   async alertReply(content, timeout = 10, reason = "") {
-    return await this.reply!(content).then((response) => response.delete(reason, timeout * 1000).catch(console.error));
+    return await this.reply!(content).then((response) => response?.delete(reason, timeout * 1000).catch(console.error));
   },
   removeAllReactions() {
     return removeAllReactions(this.channelId!, this.id!);
@@ -213,8 +213,14 @@ export async function createDiscordenoMessage(data: Message) {
   let bitfield = 0n;
 
   const props: Record<string, ReturnType<typeof createNewProp>> = {};
-  (Object.keys(rest) as (keyof typeof rest)[]).forEach((key) => {
+
+  const requiredPropsSize = cache.requiredStructureProperties.messages.size;
+
+  for (const key of Object.keys(rest) as (keyof typeof rest)[]) {
     eventHandlers.debug?.("loop", `Running for of loop in createDiscordenoMessage function.`);
+
+    // If empty all are allowed, otherwise check if this prop is allowed
+    if (requiredPropsSize && !cache.requiredStructureProperties.messages.has(key)) continue;
 
     const toggleBits = messageToggles[key as keyof typeof messageToggles];
     if (toggleBits) {
@@ -229,13 +235,19 @@ export async function createDiscordenoMessage(data: Message) {
     props[key] = createNewProp(
       MESSAGE_SNOWFLAKES.includes(key) ? (rest[key] ? snowflakeToBigint(rest[key] as string) : undefined) : rest[key]
     );
-  });
+  }
 
   if (rest.thread) await cacheHandlers.set("threads", snowflakeToBigint(data.id), channelToThread(rest.thread));
 
-  props.authorId = createNewProp(snowflakeToBigint(author.id));
-  props.isBot = createNewProp(author.bot || false);
-  props.tag = createNewProp(`${author.username}#${author.discriminator.toString().padStart(4, "0")}`);
+  // @ts-ignore allow this prop
+  if (!requiredPropsSize || cache.requiredStructureProperties.messages.has("authorId"))
+    props.authorId = createNewProp(snowflakeToBigint(author.id));
+  // @ts-ignore allow this prop
+  if (!requiredPropsSize || cache.requiredStructureProperties.messages.has("isBot"))
+    props.isBot = createNewProp(author.bot || false);
+  // @ts-ignore allow this prop
+  if (!requiredPropsSize || cache.requiredStructureProperties.messages.has("tag"))
+    props.tag = createNewProp(`${author.username}#${author.discriminator.toString().padStart(4, "0")}`);
 
   // Discord doesnt give guild id for getMessage() so this will fill it in
   const guildIdFinal =
@@ -243,13 +255,28 @@ export async function createDiscordenoMessage(data: Message) {
     (await cacheHandlers.get("channels", snowflakeToBigint(data.channelId)))?.guildId ||
     0n;
 
-  const message: DiscordenoMessage = Object.create(baseMessage, {
-    ...props,
-    content: createNewProp(data.content || ""),
-    guildId: createNewProp(guildIdFinal),
-    mentionedUserIds: createNewProp(mentions.map((m) => snowflakeToBigint(m.id))),
-    mentionedRoleIds: createNewProp(mentionRoles.map((id) => snowflakeToBigint(id))),
-    mentionedChannelIds: createNewProp([
+  if (!requiredPropsSize || cache.requiredStructureProperties.messages.has("content"))
+    props.content = createNewProp(data.content || "");
+  if (!requiredPropsSize || cache.requiredStructureProperties.messages.has("guildId"))
+    props.guildId = createNewProp(guildIdFinal);
+  if (
+    !requiredPropsSize ||
+    // @ts-ignore allow this prop
+    cache.requiredStructureProperties.messages.has("mentionedUserIds")
+  )
+    props.mentionedUserIds = createNewProp(mentions.map((m) => snowflakeToBigint(m.id)));
+  if (
+    !requiredPropsSize ||
+    // @ts-ignore allow this prop
+    cache.requiredStructureProperties.messages.has("mentionedRoleIds")
+  )
+    props.mentionedRoleIds = createNewProp(mentionRoles.map((id) => snowflakeToBigint(id)));
+  if (
+    !requiredPropsSize ||
+    // @ts-ignore allow this prop
+    cache.requiredStructureProperties.messages.has("mentionedChannelIds")
+  )
+    props.mentionedChannelIds = createNewProp([
       // Keep any ids that discord sends
       ...mentionChannels.map((m) => snowflakeToBigint(m.id)),
       // Add any other ids that can be validated in a channel mention format
@@ -257,10 +284,13 @@ export async function createDiscordenoMessage(data: Message) {
         // converts the <#123> into 123
         snowflakeToBigint(text.substring(2, text.length - 1))
       ),
-    ]),
-    timestamp: createNewProp(Date.parse(data.timestamp)),
-    editedTimestamp: createNewProp(editedTimestamp ? Date.parse(editedTimestamp) : undefined),
-    messageReference: createNewProp(
+    ]);
+  if (!requiredPropsSize || cache.requiredStructureProperties.messages.has("timestamp"))
+    props.timestamp = createNewProp(Date.parse(data.timestamp));
+  if (!requiredPropsSize || cache.requiredStructureProperties.messages.has("editedTimestamp"))
+    props.editedTimestamp = createNewProp(editedTimestamp ? Date.parse(editedTimestamp) : undefined);
+  if (!requiredPropsSize || cache.requiredStructureProperties.messages.has("messageReference"))
+    props.messageReference = createNewProp(
       messageReference
         ? {
             messageId: messageReference.messageId ? snowflakeToBigint(messageReference.messageId) : undefined,
@@ -268,8 +298,13 @@ export async function createDiscordenoMessage(data: Message) {
             guildId: messageReference.guildId ? snowflakeToBigint(messageReference.guildId) : undefined,
           }
         : undefined
-    ),
-    bitfield: createNewProp(bitfield),
+    );
+  // @ts-ignore allow this prop
+  if (!requiredPropsSize || cache.requiredStructureProperties.messages.has("bitfield"))
+    props.bitfield = createNewProp(bitfield);
+
+  const message: DiscordenoMessage = Object.create(baseMessage, {
+    ...props,
   });
 
   return message;

--- a/src/structures/role.ts
+++ b/src/structures/role.ts
@@ -115,30 +115,36 @@ export async function createDiscordenoRole(
   let bitfield = 0n;
 
   const props: Record<string, ReturnType<typeof createNewProp>> = {};
-  (Object.keys(rest) as (keyof typeof rest)[]).forEach((key) => {
+  for (const key of Object.keys(rest) as (keyof typeof rest)[]) {
     eventHandlers.debug?.("loop", `Running for of loop in createDiscordenoRole function.`);
 
     const toggleBits = roleToggles[key as keyof typeof roleToggles];
     if (toggleBits) {
       bitfield |= rest[key] ? toggleBits : 0n;
-      return;
+      continue;
     }
 
     props[key] = createNewProp(
       ROLE_SNOWFLAKES.includes(key) ? (rest[key] ? snowflakeToBigint(rest[key] as string) : undefined) : rest[key]
     );
-  });
+  }
 
-  const role: DiscordenoRole = Object.create(baseRole, {
-    ...props,
-    permissions: createNewProp(BigInt(rest.permissions)),
-    botId: createNewProp(tags.botId ? snowflakeToBigint(tags.botId) : undefined),
-    isNitroBoostRole: createNewProp("premiumSubscriber" in tags),
-    integrationId: createNewProp(tags.integrationId ? snowflakeToBigint(tags.integrationId) : undefined),
-    bitfield: createNewProp(bitfield),
-  });
+  if (!cache.requiredStructureProperties.roles.size || cache.requiredStructureProperties.roles.has("permissions"))
+    props.permissions = createNewProp(BigInt(rest.permissions));
+  // @ts-ignore allow this prop
+  if (!cache.requiredStructureProperties.roles.size || cache.requiredStructureProperties.roles.has("botId"))
+    props.botId = createNewProp(tags.botId ? snowflakeToBigint(tags.botId) : undefined);
+  // @ts-ignore allow this prop
+  if (!cache.requiredStructureProperties.roles.size || cache.requiredStructureProperties.roles.has("isNitroBoostRole"))
+    props.isNitroBoostRole = createNewProp("premiumSubscriber" in tags);
+  // @ts-ignore allow this prop
+  if (!cache.requiredStructureProperties.roles.size || cache.requiredStructureProperties.roles.has("integrationId"))
+    props.integrationId = createNewProp(tags.integrationId ? snowflakeToBigint(tags.integrationId) : undefined);
+  // @ts-ignore allow this prop
+  if (!cache.requiredStructureProperties.roles.size || cache.requiredStructureProperties.roles.has("bitfield"))
+    props.bitfield = createNewProp(bitfield);
 
-  return role;
+  return Object.create(baseRole, props) as DiscordenoRole;
 }
 
 export interface DiscordenoRole extends Omit<Role, "tags" | "id" | "permissions"> {


### PR DESCRIPTION
This pr adds a new feature to the library for advanced bot developers. 

The purpose of this feature is for optimizing memory in an easier way than having to customize structures and overriding them. For example, if you simply want to remove some properties you don't use, this would be the ideal way.

```ts
// This example is just to easily show you but you should ideally use an array and loop over the array
cache.requiredStructureProperties.channels.add("topic");
cache.requiredStructureProperties.channels.add("id");
```

This would now make it so that your channels will are ONLY storing the `topic` and `id` properties and nothing else.