### PR TITLE
fixing REQUEST_TO_SPEAK to not toggle another perm

### DIFF
--- a/src/types/permissions/bitwise_permission_flags.ts
+++ b/src/types/permissions/bitwise_permission_flags.ts
@@ -65,7 +65,7 @@ export enum DiscordBitwisePermissionFlags {
   /** Allows members to use slash commands in text channels */
   USE_SLASH_COMMANDS = 0x80000000,
   /** Allows for requesting to speak in stage channels. */
-  REQUEST_TO_SPEAK = 0x100000001,
+  REQUEST_TO_SPEAK = 0x100000000,
   /** Allows for deleting and archiving threads, and viewing all private threads */
   MANAGE_THREADS = 0x0400000000,
   /** Allows for creating and participating in threads */


### PR DESCRIPTION
I guess they do say that "This permission is under active development and may be changed or removed." but still. I was wondering why `CREATE_INSTANT_INVITE` was just magically appearing in my permission list.

I have no idea why my server has `REQUEST_TO_SPEAK` in some roles, it just appeared one day.