### PR TITLE
Make Interactions Have Bigints

### DIFF
--- a/src/handlers/interactions/INTERACTION_CREATE.ts
+++ b/src/handlers/interactions/INTERACTION_CREATE.ts
@@ -10,6 +10,7 @@ import { snowflakeToBigint } from "../../util/bigint.ts";
 export async function handleInteractionCreate(data: DiscordGatewayPayload) {
   const basePayload = data.d as Interaction;
 
+  // Change strings to bigints
   const payload = {
     ...basePayload,
     id: snowflakeToBigint(basePayload.id),


### PR DESCRIPTION
Currently our InteractionCreate events send Interaction using strings and users have to convert to bigints to use our helper functions, this pr should fix that by making them into bigints internally before running the interaction events