### PR TITLE
fix: prevent deno deploy from crashing on stack capture #1088

### DIFF
--- a/src/rest/run_method.ts
+++ b/src/rest/run_method.ts
@@ -33,6 +33,7 @@ export async function runMethod<T = any>(
   });
 
   const errorStack = new Error("Location:");
+  // @ts-ignore Breaks deno deploy. Luca said add tsignore until it's fixed
   Error.captureStackTrace(errorStack);
 
   // For proxies we don't need to do any of the legwork so we just forward the request


### PR DESCRIPTION
Advised by luca to add a ts-ignore until they fix this in deno deploy.
Closes #1088 