### PR TITLE
added type undefined to interface BotConfig.token

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -63,7 +63,7 @@ export function setApplicationId(id: string) {
 }
 
 export interface BotConfig {
-  token: string;
+  token: string | undefined;
   compress?: boolean;
   intents: (DiscordGatewayIntents | keyof typeof DiscordGatewayIntents)[];
   eventHandlers?: EventHandlers;


### PR DESCRIPTION
when we use an environment variable using `Deno.env.get("VAR") ` it shows a type error which says that `type undefined is not assignable to type 'string'`