### PR TITLE
Fix member transformer, interface (continuation of Document Guild Member Timeout)

### DIFF
--- a/src/helpers/members/editMember.ts
+++ b/src/helpers/members/editMember.ts
@@ -14,6 +14,7 @@ export async function editMember(bot: Bot, guildId: bigint, memberId: bigint, op
       mute: options.mute,
       deaf: options.deaf,
       channel_id: options.channelId,
+      communication_disabled_until: options.communicationDisabledUntil,
     }
   );
 

--- a/src/transformers/member.ts
+++ b/src/transformers/member.ts
@@ -58,6 +58,7 @@ export function transformMember(
     cachedAt: Date.now(),
     avatar: payload.avatar ? bot.utils.iconHashToBigInt(payload.avatar) : undefined,
     permissions: payload.permissions ? bot.transformers.snowflake(payload.permissions) : undefined,
+    communicationDisabledUntil: payload.communication_disabled_until,
   };
 }
 
@@ -86,4 +87,6 @@ export interface DiscordenoMember {
   avatar?: bigint;
   /** The permissions this member has in the guild. Only present on interaction events. */
   permissions?: bigint;
+  /** when the user's timeout will expire and the user will be able to communicate in the guild again (up to 28 days in the future), set to null to remove timeout. Requires the `MODERATE_MEMBERS` permission */
+  communicationDisabledUntil?: number;
 }

--- a/src/transformers/message.ts
+++ b/src/transformers/message.ts
@@ -3,7 +3,7 @@ import { Message } from "../types/messages/message.ts";
 import { CHANNEL_MENTION_REGEX } from "../util/constants.ts";
 import { SnakeCasedPropertiesDeep } from "../types/util.ts";
 import { DiscordenoAttachment } from "./attachment.ts";
-import { MessageStickerFormatTypes } from "../types/messages/messageStickerFormatTypes.ts";
+import { StickerFormatTypes } from "../types/stickers/stickerFormatTypes.ts";
 import { DiscordenoMember, DiscordenoUser } from "./member.ts";
 import { DiscordenoEmbed } from "./embed.ts";
 import { MessageTypes } from "../types/messages/messageTypes.ts";
@@ -147,7 +147,7 @@ export interface DiscordenoMessage {
     /** Name of the sticker */
     name: string;
     /** Type of sticker format */
-    formatType: MessageStickerFormatTypes;
+    formatType: StickerFormatTypes;
   }[];
 
   /**

--- a/src/types/messages/message.ts
+++ b/src/types/messages/message.ts
@@ -10,10 +10,10 @@ import { Attachment } from "./attachment.ts";
 import { MessageComponents } from "./components/messageComponents.ts";
 import { MessageActivity } from "./messageActivity.ts";
 import { MessageReference } from "./messageReference.ts";
-import { MessageSticker } from "./messageSticker.ts";
+import { Sticker } from "../stickers/sticker.ts";
 import { MessageTypes } from "./messageTypes.ts";
 import { Reaction } from "./reaction.ts";
-import { MessageStickerItem } from "./messageStickerItem.ts";
+import { StickerItem } from "../stickers/stickerItem.ts";
 
 /** https://discord.com/developers/docs/resources/channel#message-object */
 export interface Message {
@@ -83,7 +83,7 @@ export interface Message {
    * The stickers sent with the message (bots currently can only receive messages with stickers, not send)
    * @deprecated
    */
-  stickers?: MessageSticker[];
+  stickers?: Sticker[];
   /**
    * The message associated with the `message_reference`
    * Note: This field is only returned for messages with a `type` of `19` (REPLY). If the message is a reply but the `referenced_message` field is not present, the backend did not attempt to fetch the message that was being replied to, so its state is unknown. If the field exists but is null, the referenced message was deleted.
@@ -96,5 +96,5 @@ export interface Message {
   /** The components related to this message */
   components?: MessageComponents;
   /** Sent if the message contains stickers */
-  stickerItems?: MessageStickerItem[];
+  stickerItems?: StickerItem[];
 }

--- a/src/types/messages/mod.ts
+++ b/src/types/messages/mod.ts
@@ -25,7 +25,5 @@ export * from "./messageReactionRemove.ts";
 export * from "./messageReactionRemoveAll.ts";
 export * from "./messageReactionRemoveEmoji.ts";
 export * from "./messageReference.ts";
-export * from "./messageSticker.ts";
-export * from "./messageStickerFormatTypes.ts";
 export * from "./messageTypes.ts";
 export * from "./reaction.ts";

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -17,6 +17,7 @@ export * from "./messages/mod.ts";
 export * from "./misc/mod.ts";
 export * from "./oauth2/mod.ts";
 export * from "./permissions/mod.ts";
+export * from "./stickers/mod.ts";
 export * from "./teams/mod.ts";
 export * from "./templates/mod.ts";
 export * from "./users/mod.ts";

--- a/src/types/stickers/mod.ts
+++ b/src/types/stickers/mod.ts
@@ -1,0 +1,5 @@
+export * from "./sticker.ts";
+export * from "./stickerFormatTypes.ts";
+export * from "./stickerItem.ts";
+export * from "./stickerPack.ts";
+export * from "./stickerTypes.ts";


### PR DESCRIPTION
Continuation of #1862 Document Guild Member Timeout

Fix member transformer in src/transformers/message.ts

Fix message interface in src/types/messages/message.ts

Export * from stickers.