### PR TITLE
Add descriptions for ApplicationCommandTypes

### DIFF
--- a/src/types/interactions/commands/applicationCommandTypes.ts
+++ b/src/types/interactions/commands/applicationCommandTypes.ts
@@ -1,5 +1,8 @@
 export enum ApplicationCommandTypes {
+  /** A text-based command that shows up when a user types `/` */
   ChatInput = 1,
+  /** A UI-based command that shows up when you right click or tap on a user */
   User,
+  /** A UI-based command that shows up when you right click or tap on a message */
   Message,
 }


### PR DESCRIPTION
As much as this seems like a tiny PR. It gets really confusing, as most of the time you should use `ChatInput` instead of `Message` but that is not directly explained.