### PR TITLE
fix(tests): delete invite 

### DIFF
--- a/tests/deps.ts
+++ b/tests/deps.ts
@@ -4,7 +4,8 @@ export {
   assertExists,
   assertNotEquals,
   assertThrows,
-  assertThrowsAsync
+  assertThrowsAsync,
+  assertRejects,
 } from "https://deno.land/std@0.115.1/testing/asserts.ts";
 export * from "https://deno.land/x/discordeno_cache_plugin@0.0.21/mod.ts";
 export * from "https://deno.land/x/discordeno_permissions_plugin@0.0.15/mod.ts";

--- a/tests/invite/deleteInvite.ts
+++ b/tests/invite/deleteInvite.ts
@@ -1,4 +1,4 @@
-import { assertExists } from "../deps.ts";
+import { assertExists, assertRejects } from "../deps.ts";
 import { bot, channel } from "../mod.ts";
 
 Deno.test({
@@ -14,9 +14,9 @@ Deno.test({
     // Assertions
     assertExists(invite);
 
-    const deletedInvite = await bot.helpers.deleteInvite(invite.code);
+    await bot.helpers.deleteInvite(invite.code);
 
     // Assertions
-    assertExists(deletedInvite);
+    assertRejects(() => bot.helpers.getInvite(invite.code));
   },
 });


### PR DESCRIPTION
fix delete invite test

`deleteInvite` function return `Promise<void>`, therefore the correct way to test is to check if `getInvite` function THROWS/REJECTS