### PR TITLE
fix send a message with a webhook test

### DIFF
--- a/tests/webhooks/sendWebhook.ts
+++ b/tests/webhooks/sendWebhook.ts
@@ -9,6 +9,7 @@ Deno.test("[webhooks] Send a message with a webhook", async (t) => {
   assertExists(webhook.token);
   const message = await bot.helpers.sendWebhook(webhook.id, webhook.token, {
     content: "discordeno is best lib",
+    wait: true,
   });
 
   assertExists(message);


### PR DESCRIPTION
Waits for server confirmation of message send before response, and returns the created message body (defaults to false; when false a message that is not saved does not return an error)