### PR TITLE
Handing unauthorized on runMethod

### DIFF
--- a/src/rest/runMethod.ts
+++ b/src/rest/runMethod.ts
@@ -35,6 +35,12 @@ export async function runMethod<T = any>(
       throw errorStack;
     });
 
+    if (!result.ok) {
+      errorStack.message = result.statusText as Error['message'];
+      console.error(`Invalid authorization key.`);
+      throw errorStack;
+    }
+
     return result.status !== 204 ? await result.json() : undefined;
   }
 


### PR DESCRIPTION
Fix for one of the #1889 issues:
- Error handling inside rest.runMethod's method API call