### PR TITLE
discord-api-docs: document the required permission for retrieving the welcome screen when disabled

### DIFF
--- a/src/helpers/guilds/getWelcomeScreen.ts
+++ b/src/helpers/guilds/getWelcomeScreen.ts
@@ -1,6 +1,7 @@
 import type { WelcomeScreen } from "../../types/guilds/welcomeScreen.ts";
 import type { Bot } from "../../bot.ts";
 
+/** Returns the Welcome Screen object for the guild. Requires the `MANAGE_GUILD` permission. */
 export async function getWelcomeScreen(bot: Bot, guildId: bigint) {
   const result = await bot.rest.runMethod<WelcomeScreen>(
     bot.rest,


### PR DESCRIPTION
discord/discord-api-docs@00a0ae2
Closes: #1905 