### PR TITLE
discord-api-docs: Document error code 30046 (old message edit rate limit)

### DIFF
--- a/src/types/codes/jsonErrorCodes.ts
+++ b/src/types/codes/jsonErrorCodes.ts
@@ -75,6 +75,7 @@ export enum JsonErrorCodes {
   MaximumNumberOfStickersReached = 30039,
   MaximumNumberOfPruneRequestsHasBeenReachedTryAgainLater,
   MaximumNumberOfGuildWidgetSettingsUpdatesHasBeenReachedTryAgainLater = 30042,
+  MaximumNumberOfEditsToMessagesOlderThan1HourReachedTryAgainLater = 30046,
   UnauthorizedProvideAValidTokenAndTryAgain = 40001,
   YouNeedToVerifyYourAccountInOrderToPerformThisAction,
   YouAreOpeningDirectMessagesTooFast,


### PR DESCRIPTION
discord/discord-api-docs@a4be17f
Closes: #1915 