### PR TITLE
discord-api-docs: Document message flag FAILED_TO_MENTION_SOME_ROLES_IN_THREAD

### DIFF
--- a/src/types/messages/messageFlags.ts
+++ b/src/types/messages/messageFlags.ts
@@ -16,4 +16,6 @@ export enum MessageFlags {
   Empheral = 1 << 6,
   /** This message is an Interaction Response and the bot is "thinking" */
   Loading = 1 << 7,
+  /** This message failed to mention some roles and add their members to the thread */
+  FailedToMentionSomeRolesInThread = 1 << 8,
 }


### PR DESCRIPTION
discord/discord-api-docs@2d13f67
Closes: #1918