### PR TITLE
fix(permissions): `editMessage` content length check

### DIFF
--- a/plugins/permissions/src/messages/create.ts
+++ b/plugins/permissions/src/messages/create.ts
@@ -163,7 +163,7 @@ export function editMessage(bot: BotWithCache) {
 
     if (
       content.content &&
-      bot.utils.validateLength(content.content, { max: 2000 })
+      !bot.utils.validateLength(content.content, { max: 2000 })
     ) {
       throw new Error(
         "A message content can not contain more than 2000 characters.",


### PR DESCRIPTION
Fix permissions plugin, that throws an error about message content length when it's valid instead of when it's invalid.