### PR TITLE
fix(cname): website domain not getting set

### DIFF
--- a/site/static/CNAME
+++ b/site/static/CNAME
@@ -1,0 +1,1 @@
+discordeno.mod.land


### PR DESCRIPTION
Currently always when deploying the website the `CNAME` file gets deleted, therefore the website won't be accessible from `discordeno.mod.land` after every deploy. 