### PR TITLE
fix(types): handle `communicationDisabledUntil` correctly

### DIFF
--- a/src/transformers/message.ts
+++ b/src/transformers/message.ts
@@ -47,36 +47,35 @@ export function transformMessage(bot: Bot, payload: SnakeCasedPropertiesDeep<Mes
     flags: payload.flags,
     interaction: payload.interaction
       ? {
-          id: bot.transformers.snowflake(payload.interaction.id),
-          type: payload.interaction.type,
-          name: payload.interaction.name,
-          user: bot.transformers.user(bot, payload.interaction.user),
-          member: payload.interaction.member
-            ? {
-                id: userId,
-                guildId,
-                nick: payload.interaction.member.nick ?? undefined,
-                roles: payload.interaction.member.roles?.map((id) => BigInt(id)),
-                joinedAt: payload.interaction.member.joined_at
-                  ? Date.parse(payload.interaction.member.joined_at)
-                  : undefined,
-                premiumSince: payload.interaction.member.premium_since
-                  ? Date.parse(payload.interaction.member.premium_since)
-                  : undefined,
-                deaf: payload.interaction.member.deaf,
-                mute: payload.interaction.member.mute,
-                pending: payload.interaction.member.pending,
-                cachedAt: Date.now(),
-                avatar: payload.interaction.member.avatar
-                  ? bot.utils.iconHashToBigInt(payload.interaction.member.avatar)
-                  : undefined,
-                permissions: payload.interaction.member.permissions
-                  ? bot.transformers.snowflake(payload.interaction.member.permissions)
-                  : undefined,
-                communicationDisabledUntil: payload.interaction.member.communication_disabled_until,
-              }
+        id: bot.transformers.snowflake(payload.interaction.id),
+        type: payload.interaction.type,
+        name: payload.interaction.name,
+        user: bot.transformers.user(bot, payload.interaction.user),
+        member: payload.interaction.member
+          ? {
+            id: userId,
+            guildId,
+            nick: payload.interaction.member.nick ?? undefined,
+            roles: payload.interaction.member.roles?.map((id) => BigInt(id)),
+            joinedAt: payload.interaction.member.joined_at
+              ? Date.parse(payload.interaction.member.joined_at)
+              : undefined,
+            premiumSince: payload.interaction.member.premium_since
+              ? Date.parse(payload.interaction.member.premium_since) : undefined,
+            deaf: payload.interaction.member.deaf,
+            mute: payload.interaction.member.mute,
+            pending: payload.interaction.member.pending,
+            cachedAt: Date.now(),
+            avatar: payload.interaction.member.avatar ? bot.utils.iconHashToBigInt(payload.interaction.member.avatar)
             : undefined,
-        }
+            permissions: payload.interaction.member.permissions
+              ? bot.transformers.snowflake(payload.interaction.member.permissions) : undefined,
+            communicationDisabledUntil: payload.interaction.member.communication_disabled_until
+              ? Date.parse(payload.interaction.member.communication_disabled_until)
+              : undefined,
+          }
+          : undefined,
+      }
       : undefined,
     thread: payload.thread ? bot.transformers.channel(bot, { channel: payload.thread, guildId }) : undefined,
     components: payload.components?.map((component) => bot.transformers.component(bot, component)),
@@ -101,9 +100,8 @@ export function transformMessage(bot: Bot, payload: SnakeCasedPropertiesDeep<Mes
         channelId: payload.message_reference.channel_id
           ? bot.transformers.snowflake(payload.message_reference.channel_id)
           : undefined,
-        guildId: payload.message_reference.guild_id
-          ? bot.transformers.snowflake(payload.message_reference.guild_id)
-          : undefined,
+        guildId: payload.message_reference.guild_id ? bot.transformers.snowflake(payload.message_reference.guild_id)
+        : undefined,
       }
       : undefined,
     mentionedUserIds: payload.mentions ? payload.mentions.map((m) => bot.transformers.snowflake(m.id)) : [],

--- a/src/types/members/guildMemberUpdate.ts
+++ b/src/types/members/guildMemberUpdate.ts
@@ -23,5 +23,5 @@ export interface GuildMemberUpdate {
   /** Whether the user has not yet passed the guild's Membership Screening requirements */
   pending?: boolean;
   /** when the user's [timeout](https://support.discord.com/hc/en-us/articles/4413305239191-Time-Out-FAQ) will expire and the user will be able to communicate in the guild again, null or a time in the past if the user is not timed out */
-  communicationDisabledUntil?: number;
+  communicationDisabledUntil?: string;
 }


### PR DESCRIPTION
- Changed the type of `GuildMemberUpdate#communicationDisabledUntil` to number (this is a temporary fix it will be changed soonTM)
- Now parsing the `communicationDisabledUntil` in the message transformer