### PR TITLE
fix(helpers): when creating/modifying a channel `permission_overwrites` can omit the `allow` and `deny`

### DIFF
--- a/helpers/channels/createChannel.ts
+++ b/helpers/channels/createChannel.ts
@@ -22,11 +22,11 @@ export async function createChannel(bot: Bot, guildId: bigint, options?: CreateG
         position: options.position,
         parent_id: options.parentId?.toString(),
         nsfw: options.nsfw,
-        permission_overwrites: options?.permissionOverwrites?.map((perm) => ({
-          id: perm.id.toString(),
-          type: perm.type,
-          allow: perm.allow ? bot.utils.calculateBits(perm.allow) : "0",
-          deny: perm.deny ? bot.utils.calculateBits(perm.deny) : "0",
+        permission_overwrites: options?.permissionOverwrites?.map((overwrite) => ({
+          id: overwrite.id.toString(),
+          type: overwrite.type,
+          allow: overwrite.allow ? bot.utils.calculateBits(overwrite.allow) : null,
+          deny: overwrite.deny ? bot.utils.calculateBits(overwrite.deny) : null,
         })),
         type: options?.type || ChannelTypes.GuildText,
         reason,

--- a/helpers/channels/editChannel.ts
+++ b/helpers/channels/editChannel.ts
@@ -46,13 +46,12 @@ export async function editChannel(bot: Bot, channelId: bigint, options: ModifyCh
     locked: options.locked,
     invitable: options.invitable,
     permission_overwrites: options.permissionOverwrites
-      ? options.permissionOverwrites?.map((overwrite) => {
-        return {
-          ...overwrite,
-          allow: overwrite.allow ? bot.utils.calculateBits(overwrite.allow) : "0",
-          deny: overwrite.deny ? bot.utils.calculateBits(overwrite.deny) : "0",
-        };
-      })
+      ? options.permissionOverwrites?.map((overwrite) => ({
+        id: overwrite.id.toString(),
+        type: overwrite.type,
+        allow: overwrite.allow ? bot.utils.calculateBits(overwrite.allow) : null,
+        deny: overwrite.deny ? bot.utils.calculateBits(overwrite.deny) : null,
+      }))
       : undefined,
     reason,
   });


### PR DESCRIPTION
Closes: #1971 

Upstream: https://github.com/discord/discord-api-docs/commit/7c0249a3c41b7596f7a7a4c6d2b3b7e4a6ac307c

Note: feel free to discuss if you prefer `null` or `undefined` or `"0"`

> * In each overwrite object, the allow and deny keys can be omitted or set to null, which both default to "0".