### PR TITLE
fix(types, helpers)!: EditMessage helper transformer & change `Embed` to `DiscordenoEmbed`

### DIFF
--- a/helpers/messages/editMessage.ts
+++ b/helpers/messages/editMessage.ts
@@ -16,7 +16,7 @@ export async function editMessage(bot: Bot, channelId: bigint, messageId: bigint
         type: embed.type,
         description: embed.description,
         url: embed.url,
-        timestamp: embed.timestamp,
+        timestamp: embed.timestamp ? new Date(embed.timestamp).toISOString() : undefined,
         color: embed.color,
         footer: embed.footer
           ? {

--- a/transformers/embed.ts
+++ b/transformers/embed.ts
@@ -42,12 +42,7 @@ export function transformEmbed(bot: Bot, payload: SnakeCasedPropertiesDeep<Embed
         width: payload.video.width,
       }
       : undefined,
-    provider: payload.provider
-      ? {
-        name: payload.provider.name,
-        url: payload.provider.url,
-      }
-      : undefined,
+    provider: payload.provider,
     author: payload.author
       ? {
         name: payload.author.name,
@@ -56,11 +51,7 @@ export function transformEmbed(bot: Bot, payload: SnakeCasedPropertiesDeep<Embed
         proxyIconUrl: payload.author.proxy_icon_url,
       }
       : undefined,
-    fields: payload.fields?.map((field) => ({
-      name: field.name,
-      value: field.value,
-      inline: field.inline,
-    })),
+    fields: payload.fields,
   };
 }
 

--- a/types/messages/editMessage.ts
+++ b/types/messages/editMessage.ts
@@ -1,5 +1,5 @@
 import { FileContent } from "../discordeno/fileContent.ts";
-import { Embed } from "../embeds/embed.ts";
+import { DiscordenoEmbed } from "../../transformers/embed.ts";
 import { AllowedMentions } from "./allowedMentions.ts";
 import { Attachment } from "./attachment.ts";
 import { MessageComponents } from "./components/messageComponents.ts";
@@ -9,7 +9,7 @@ export interface EditMessage {
   /** The new message contents (up to 2000 characters) */
   content?: string | null;
   /** Embedded `rich` content (up to 6000 characters) */
-  embeds?: Embed[] | null;
+  embeds?: DiscordenoEmbed[] | null;
   /** Edit the flags of the message (only `SUPRESS_EMBEDS` can currently be set/unset) */
   flags?: 4 | null;
   /** The contents of the file being sent/edited */


### PR DESCRIPTION
Note: I changed `transformer/embed.ts` because I looked at `helpers/messages/editMessage.ts` and see `provider: embed.provider` `fields: embed.fields` because both of them's properties are only one word therefore no camelCase to snake_case manual conversion needed