### PR TITLE
fix(types): `invitable` & `createTimestamp` are in `ThreadMetadata` and not in `Channel`

### DIFF
--- a/transformers/channel.ts
+++ b/transformers/channel.ts
@@ -71,8 +71,10 @@ export function transformChannel(
     botIsMember: Boolean(payload.channel.member),
     archived: payload.channel.thread_metadata?.archived,
     locked: payload.channel.thread_metadata?.locked,
-    invitable: payload.channel.invitable,
-    createTimestamp: payload.channel.create_timestamp ? Date.parse(payload.channel.create_timestamp) : undefined,
+    invitable: payload.channel.thread_metadata?.invitable,
+    createTimestamp: payload.channel.thread_metadata?.create_timestamp
+      ? Date.parse(payload.channel.thread_metadata.create_timestamp)
+      : undefined,
   };
 }
 

--- a/types/channels/channel.ts
+++ b/types/channels/channel.ts
@@ -58,8 +58,4 @@ export interface Channel {
   defaultAutoArchiveDuration?: number;
   /** computed permissions for the invoking user in the channel, including overwrites, only included when part of the resolved data received on a application command interaction */
   permissions?: string;
-  /** whether non-moderators can add other non-moderators to a thread; only available on private threads */
-  invitable?: boolean;
-  /** timestamp when the thread was created; only populated for threads created after 2022-01-09 */
-  createTimestamp?: string;
 }


### PR DESCRIPTION
Note: `invitable` and `createTimestamp` should be and already in `ThreadMeatadata`, and shouldn't be in `Channel`