### PR TITLE
fix(types): `ThreadMetadata#create_timestamp` is optional and nullable & `locked` is not optional

### DIFF
--- a/types/channels/threads/threadMetadata.ts
+++ b/types/channels/threads/threadMetadata.ts
@@ -7,9 +7,9 @@ export interface ThreadMetadata {
   /** Timestamp when the thread's archive status was last changed, used for calculating recent activity */
   archiveTimestamp: string;
   /** When a thread is locked, only users with `MANAGE_THREADS` can unarchive it */
-  locked?: boolean;
+  locked: boolean;
   /** whether non-moderators can add other non-moderators to a thread; only available on private threads */
   invitable?: boolean;
   /** Timestamp when the thread was created; only populated for threads created after 2022-01-09 */
-  createTimestamp: string;
+  createTimestamp?: string | null;
 }


### PR DESCRIPTION
Closes: #2003 

Upstream: <https://github.com/discord/discord-api-docs/commit/a783ca92c1150e1e2b7a510ce25fdb4de9ced1fd>

Note: Compatible with #2056

Reference for making locked NOT optional: <https://discord.com/developers/docs/resources/channel#thread-metadata-object-thread-metadata-structure>

<img width="210" alt="image" src="https://user-images.githubusercontent.com/87189679/153879639-652845cd-b46a-4e53-abc6-6bea30fb43a2.png">
