### PR TITLE
fix(types): `ScheduledEvent#creator_id` is nullable

### DIFF
--- a/types/guilds/scheduledEvents.ts
+++ b/types/guilds/scheduledEvents.ts
@@ -8,7 +8,7 @@ export interface ScheduledEvent {
   /** the channel id in which the scheduled event will be hosted if specified */
   channelId: string | null;
   /** the id of the user that created the scheduled event */
-  creatorId?: string;
+  creatorId?: string | null;
   /** the name of the scheduled event */
   name: string;
   /** the description of the scheduled event */


### PR DESCRIPTION
Closes: #2010 

Upstream: https://github.com/discord/discord-api-docs/commit/3ed90459752015a9fa43fb185a75d89431ec2112

Note: The change is making creator_id optional but for some reason we already make it optional but we forgot it's nullable so I make it nullable :)