### PR TITLE
docs(types): update `MessageComponentTypes` variant description

### DIFF
--- a/types/messages/components/messageComponentTypes.ts
+++ b/types/messages/components/messageComponentTypes.ts
@@ -1,11 +1,11 @@
 /** https://discord.com/developers/docs/interactions/message-components#component-types */
 export enum MessageComponentTypes {
-  /** A row of components at the bottom of a message */
+  /** A container for other components */
   ActionRow = 1,
-  /** A button! */
+  /** A button object */
   Button = 2,
-  /** A select menu. */
+  /** A select menu for picking from choices */
   SelectMenu = 3,
-  /** An Input Text. */
+  /** A text input object */
   InputText = 4,
 }


### PR DESCRIPTION
Closes: #2019 

Upstream: https://github.com/discord/discord-api-docs/commit/bc4cfa8fa1b85b80bde2e78179d0c7413c385157

Note: We already added Text Input to Component Types so I just update the jsdoc comments