### PR TITLE
docs(types): add link for `InputTextComponent`

### DIFF
--- a/types/messages/components/inputTextComponent.ts
+++ b/types/messages/components/inputTextComponent.ts
@@ -1,7 +1,7 @@
 import { MessageComponentTypes } from "./messageComponentTypes.ts";
 import { TextStyles } from "./textStyles.ts";
 
-// TODO: docs link
+/** https://discord.com/developers/docs/interactions/message-components#text-inputs-text-input-structure */
 export interface InputTextComponent {
   /** InputText Component is of type 3 */
   type: MessageComponentTypes.InputText;


### PR DESCRIPTION
Closes: #2018 

Upstream: https://github.com/discord/discord-api-docs/commit/ba99e8c824a10c6398aaf918e78bc17607fb7cad

Note: Label is already NOT optional, so I just add the docs link
<img width="303" alt="image" src="https://user-images.githubusercontent.com/87189679/153884384-179ed9f2-7d26-4511-b89c-3b866aabdd27.png">
