### PR TITLE
docs(types): add `attachment` to `InteractionData` 

### DIFF
--- a/types/interactions/commands/applicationCommandInteractionData.ts
+++ b/types/interactions/commands/applicationCommandInteractionData.ts
@@ -1,6 +1,7 @@
 import { Channel, Message, MessageComponents, MessageComponentTypes, Role, User } from "../../mod.ts";
 import { InteractionGuildMember } from "../interactionGuildMember.ts";
 import { InteractionDataOption } from "./applicationCommandInteractionDataOption.ts";
+import { Attachment } from "../../messages/attachment.ts";
 
 export interface InteractionData {
   /** The type of component */
@@ -15,7 +16,7 @@ export interface InteractionData {
   id: string;
   /** The name of the invoked command */
   name: string;
-  /** Converted users + roles + channels */
+  /** converted users + roles + channels + attachments */
   resolved?: {
     /** The Ids and Message objects */
     messages?: Record<string, Message>;
@@ -27,6 +28,8 @@ export interface InteractionData {
     roles?: Record<string, Role>;
     /** The Ids and partial Channel objects */
     channels?: Record<string, Pick<Channel, "id" | "name" | "type" | "permissions">>;
+    /** the ids and attachment objects */
+    attachments: Record<string, Attachment>;
   };
   /** The params + values from the user */
   options?: InteractionDataOption[];

--- a/types/interactions/commands/applicationCommandInteractionData.ts
+++ b/types/interactions/commands/applicationCommandInteractionData.ts
@@ -16,7 +16,7 @@ export interface InteractionData {
   id: string;
   /** The name of the invoked command */
   name: string;
-  /** converted users + roles + channels + attachments */
+  /** Converted users + roles + channels + attachments */
   resolved?: {
     /** The Ids and Message objects */
     messages?: Record<string, Message>;
@@ -28,7 +28,7 @@ export interface InteractionData {
     roles?: Record<string, Role>;
     /** The Ids and partial Channel objects */
     channels?: Record<string, Pick<Channel, "id" | "name" | "type" | "permissions">>;
-    /** the ids and attachment objects */
+    /** The ids and attachment objects */
     attachments: Record<string, Attachment>;
   };
   /** The params + values from the user */


### PR DESCRIPTION
Closes: #2017

Upstream: <https://github.com/discord/discord-api-docs/commit/b268fe763a1e7707cac868aecc60957a8b8260aa>

Note: ApplicationCommandOption type already have ATTACHMENT, and transformInteractionDataResolved function already resolve ATTACHMENT