### PR TITLE
fix(gateway): rate-limit handling

### DIFF
--- a/gateway/handleOnMessage.ts
+++ b/gateway/handleOnMessage.ts
@@ -47,6 +47,8 @@ export async function handleOnMessage(gateway: GatewayManager, message: any, sha
       break;
     case GatewayOpcodes.Hello:
       gateway.heartbeat(gateway, shardId, (messageData.d as DiscordHello).heartbeat_interval);
+      // UPDATES THE SAFE AMOUNT OF SHARDS BASED ON THE INTERVAL
+      if (shard) shard.safeRequestsPerShard = gateway.safeRequestsPerShard(gateway, shard);
       break;
     case GatewayOpcodes.HeartbeatACK:
       if (gateway.shards.has(shardId)) {

--- a/gateway/identify.ts
+++ b/gateway/identify.ts
@@ -36,6 +36,8 @@ export function identify(gateway: GatewayManager, shardId: number, maxShards: nu
     processingQueue: false,
     queueStartedAt: Date.now(),
     queueCounter: 0,
+    // BY DEFAULT SET TO 120. EDIT IN HELLO
+    safeRequestsPerShard: 120,
   });
 
   socket.onopen = () => {

--- a/gateway/mod.ts
+++ b/gateway/mod.ts
@@ -10,5 +10,6 @@ export * from "./spawnShards.ts";
 export * from "./sendShardMessage.ts";
 export * from "./startGatewayOptions.ts";
 export * from "./tellWorkerToIdentify.ts";
-export * from "./ws.ts";
+export * from "./shard.ts";
 export * from "./gateway_manager.ts";
+export * from './safeRequestsPerShard.ts'

--- a/gateway/mod.ts
+++ b/gateway/mod.ts
@@ -12,4 +12,4 @@ export * from "./startGatewayOptions.ts";
 export * from "./tellWorkerToIdentify.ts";
 export * from "./shard.ts";
 export * from "./gateway_manager.ts";
-export * from './safeRequestsPerShard.ts'
+export * from "./safeRequestsPerShard.ts";

--- a/gateway/resume.ts
+++ b/gateway/resume.ts
@@ -43,6 +43,7 @@ export function resume(gateway: GatewayManager, shardId: number) {
     processingQueue: false,
     queueStartedAt: Date.now(),
     queueCounter: 0,
+    safeRequestsPerShard: oldShard.safeRequestsPerShard || 120,
   });
 
   // Resume on open

--- a/gateway/safeRequestsPerShard.ts
+++ b/gateway/safeRequestsPerShard.ts
@@ -1,0 +1,9 @@
+import { GatewayManager } from "./gateway_manager.ts";
+import { DiscordenoShard } from "./shard.ts";
+
+export function safeRequestsPerShard(gateway: GatewayManager, shard: DiscordenoShard) {
+  // * 2 adds extra safety layer for discords OP 1 requests that we need to respond to
+  const safeRequests = gateway.maxRequestsPerInterval -
+    Math.ceil(gateway.queueResetInterval / shard.heartbeat.interval) * 2;
+  return safeRequests > 0 ? safeRequests : 0;
+}

--- a/gateway/sendShardMessage.ts
+++ b/gateway/sendShardMessage.ts
@@ -1,5 +1,5 @@
 import { GatewayManager } from "./gateway_manager.ts";
-import { DiscordenoShard, WebSocketRequest } from "./ws.ts";
+import { DiscordenoShard, WebSocketRequest } from "./shard.ts";
 
 export function sendShardMessage(
   gateway: GatewayManager,

--- a/gateway/shard.ts
+++ b/gateway/shard.ts
@@ -40,13 +40,11 @@ export interface DiscordenoShard {
   queueStartedAt: number;
   /** The request counter of the queue. */
   queueCounter: number;
+  /** The safe number of requests that can be made while preserving some for required things like heartbeating. */
+  safeRequestsPerShard: number;
 }
 
 export interface WebSocketRequest {
   op: GatewayOpcodes;
   d: unknown;
-  // guildId: bigint;
-  // shardId: number;
-  // nonce?: bigint;
-  // options?: Record<string, unknown>;
 }


### PR DESCRIPTION
This PR will close #1886 

It improves on some minor but crucial aspects of rate limiting in the gateway side.

- Instead of hardcoding 120/m we now make it dynamic so that bots can override in case discord will bump their max amount or such.
- Instead of hardcoding the reserved requests for heartbeating we now dynamically calculate this based on the interval discord will provide. This protects against any possible change discord may decide to change the heartbeat interval.
- Optimized the delay. Before when you hit the max, we just hardcoded a 1 min wait to reset the timer since discord didn't provide a good value to know. Now we will reset based on the amount of time left since the first request was sent.
- Changed gateway/ws.ts to gateway/shard.ts. The filename was just weird.