### PR TITLE
feat(types): add `image_hash` audit log change key

### DIFF
--- a/transformers/auditlogEntry.ts
+++ b/transformers/auditlogEntry.ts
@@ -25,6 +25,7 @@ export function transformAuditlogEntry(bot: Bot, payload: DiscordAuditLogEntry) 
         case "rules_channel_id":
         case "public_updates_channel_id":
         case "icon_hash":
+        case "image_hash":
         case "splash_hash":
         case "owner_id":
         case "widget_channel_id":

--- a/types/discord.ts
+++ b/types/discord.ts
@@ -1417,6 +1417,7 @@ export type DiscordAuditLogChange =
       | "rules_channel_id"
       | "public_updates_channel_id"
       | "icon_hash"
+      | "image_hash"
       | "splash_hash"
       | "owner_id"
       | "region"


### PR DESCRIPTION
This adds the `image_hash` audit log change key which is being used when a guild scheduled event cover image gets updated.

Reference: https://github.com/discord/discord-api-docs/pull/4707

Closes: #2138