### PR TITLE
fix: prevent crashing the rest process

### DIFF
--- a/template/bigbot/src/rest/mod.ts
+++ b/template/bigbot/src/rest/mod.ts
@@ -42,13 +42,7 @@ async function handleRequest(conn: Deno.Conn) {
       );
     }
 
-    // deno-lint-ignore no-explicit-any
-    let json: any;
-    if (requestEvent.request.body) {
-        json = (await requestEvent.request.json());
-    } else {
-        json = undefined
-    }
+    const json = requestEvent.request.body ? (await requestEvent.request.json()) : undefined;
 
     try {
       const result = await rest.runMethod(

--- a/template/bigbot/src/rest/mod.ts
+++ b/template/bigbot/src/rest/mod.ts
@@ -47,7 +47,7 @@ async function handleRequest(conn: Deno.Conn) {
     if (requestEvent.request.body) {
         json = (await requestEvent.request.json());
     } else {
-        json = ""
+        json = undefined
     }
 
     try {

--- a/template/bigbot/src/rest/mod.ts
+++ b/template/bigbot/src/rest/mod.ts
@@ -42,7 +42,13 @@ async function handleRequest(conn: Deno.Conn) {
       );
     }
 
-    const json = (await requestEvent.request.json());
+    // deno-lint-ignore no-explicit-any
+    let json: any;
+    if (requestEvent.request.body) {
+        json = (await requestEvent.request.json());
+    } else {
+        json = ""
+    }
 
     try {
       const result = await rest.runMethod(


### PR DESCRIPTION
There where instances where some requests crashed the rest process. I found that checking for a body pretty much fixed it. 
There is probably a better way to do this, please improve this if you have an idea :)