### PR TITLE
Proxy delete channel tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         run: deno cache template/beginner/mod.ts template/bigbot/src/bot/mod.ts template/bigbot/src/gateway/mod.ts template/bigbot/src/rest/mod.ts template/minimal/mod.ts
       - name: Run test script for maintainers
         if: ${{ github.actor == 'Skillz4Killz' || github.actor == 'itohatweb' }}
-        run: deno test --unstable --coverage=coverage -A tests/mod.ts
+        run: deno test --unstable --coverage=coverage -A testss/
       - name: Create coverage report
         if: github.ref == 'refs/heads/main'
         run: deno coverage --exclude=tests ./coverage --lcov > coverage.lcov
@@ -43,3 +43,5 @@ jobs:
           file: ./coverage.lcov
     env:
       DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
+      PROXY_REST_SECRET: ${{ secrets.PROXY_REST_SECRET }}
+      PROXY_REST_URL: ${{ secrets.PROXY_REST_URL }}

--- a/helpers/channels/getChannel.ts
+++ b/helpers/channels/getChannel.ts
@@ -9,8 +9,11 @@ export async function getChannel(bot: Bot, channelId: bigint) {
     bot.constants.endpoints.CHANNEL_BASE(channelId),
   );
 
-  return bot.transformers.channel(bot, {
-    channel: result,
-    guildId: result.guild_id ? bot.transformers.snowflake(result.guild_id) : undefined,
-  });
+  // IF A CHANNEL DOESN'T EXIST, DISCORD RETURNS `{}`
+  return result.id
+    ? bot.transformers.channel(bot, {
+      channel: result,
+      guildId: result.guild_id ? bot.transformers.snowflake(result.guild_id) : undefined,
+    })
+    : undefined;
 }

--- a/site/docs/general/migrating.md
+++ b/site/docs/general/migrating.md
@@ -62,9 +62,8 @@ fs.readdir("./src/events/", (err, files) => {
     const eventFunction = require(`./src/events/${file}`);
     if (eventFunction.disabled) return;
     const event = eventFunction.event || file.split(".")[0];
-    const emitter = (typeof eventFunction.emitter === "string"
-      ? client[eventFunction.emitter]
-      : eventFunction.emitter) || client;
+    const emitter =
+      (typeof eventFunction.emitter === "string" ? client[eventFunction.emitter] : eventFunction.emitter) || client;
     const { once } = eventFunction;
     try {
       emitter[

--- a/template/bigbot/src/bot/types/command.ts
+++ b/template/bigbot/src/bot/types/command.ts
@@ -188,11 +188,11 @@ export type ConvertArgumentDefinitionsToArgs<
   UnionToIntersection<
     {
       [P in keyof T]: T[P] extends StringOptionalArgumentDefinition<infer N> // STRING
-      ? {
-        [_ in getName<N>]?: T[P]["choices"] extends readonly { name: string; value: string }[] ? // @ts-ignore ts being dumb
-        T[P]["choices"][number]["value"]
-          : string;
-      }
+        ? {
+          [_ in getName<N>]?: T[P]["choices"] extends readonly { name: string; value: string }[] ? // @ts-ignore ts being dumb
+          T[P]["choices"][number]["value"]
+            : string;
+        }
         : T[P] extends StringArgumentDefinition<infer N> ? {
           [_ in getName<N>]: T[P]["choices"] extends readonly { name: string; value: string }[] ? // @ts-ignore ts being dumb
           T[P]["choices"][number]["value"]

--- a/testss/channels/deleteWithReason.test.ts
+++ b/testss/channels/deleteWithReason.test.ts
@@ -1,0 +1,23 @@
+import { assertEquals, assertExists } from "../deps.ts";
+import { loadBot } from "../mod.ts";
+import { CACHED_COMMUNITY_GUILD_ID, delayUntil } from "../utils.ts";
+
+Deno.test({
+  name: "[channel] delete a channel with a reason",
+  async fn(t) {
+    const bot = loadBot();
+    const channel = await bot.helpers.createChannel(CACHED_COMMUNITY_GUILD_ID, {
+      name: "delete-channel",
+    });
+
+    // Make sure the channel was created
+    assertExists(channel.id);
+
+    // Delete the channel now with a reason
+    await bot.helpers.deleteChannel(channel.id, "with a reason");
+
+    // Check if channel still exists
+    const exists = await bot.helpers.getChannel(channel.id);
+    assertEquals(exists, undefined);
+  },
+});

--- a/testss/channels/deleteWithoutReason.test.ts
+++ b/testss/channels/deleteWithoutReason.test.ts
@@ -1,0 +1,24 @@
+import { assertEquals, assertExists, assertThrows, assertThrowsAsync } from "../deps.ts";
+import { loadBot } from "../mod.ts";
+import { CACHED_COMMUNITY_GUILD_ID } from "../utils.ts";
+
+Deno.test({
+  name: "[channel] delete a channel without a reason",
+  async fn(t) {
+    const bot = loadBot();
+    // Create a channel to delete
+    const channel = await bot.helpers.createChannel(CACHED_COMMUNITY_GUILD_ID, {
+      name: "delete-channel",
+    });
+
+    // Make sure the channel was created
+    assertExists(channel.id);
+
+    // Delete the channel now without a reason
+    await bot.helpers.deleteChannel(channel.id);
+
+    // Check if channel still exists
+    const exists = await bot.helpers.getChannel(channel.id);
+    assertEquals(exists, undefined);
+  },
+});

--- a/testss/deps.ts
+++ b/testss/deps.ts
@@ -1,0 +1,2 @@
+export { config as dotenv } from "https://deno.land/x/dotenv@v3.2.0/mod.ts";
+export * from "https://deno.land/std@0.115.1/testing/asserts.ts";

--- a/testss/deps.ts
+++ b/testss/deps.ts
@@ -1,2 +1,2 @@
 export { config as dotenv } from "https://deno.land/x/dotenv@v3.2.0/mod.ts";
-export * from "https://deno.land/std@0.115.1/testing/asserts.ts";
+export * from "https://deno.land/std@0.137.0/testing/asserts.ts";

--- a/testss/mod.ts
+++ b/testss/mod.ts
@@ -1,0 +1,26 @@
+import { createBot, createRestManager, runMethod } from "../mod.ts";
+import enableCachePlugin from "../plugins/cache/mod.ts";
+import { dotenv } from "./deps.ts";
+
+dotenv({ export: true, path: `${Deno.cwd()}/.env` });
+
+export function loadBot() {
+  const token = Deno.env.get("DISCORD_TOKEN");
+  if (!token) throw new Error("Token was not provided.");
+
+  const botId = BigInt(atob(token.split(".")[0]));
+  const bot = enableCachePlugin(createBot({
+    events: {},
+    intents: [],
+    botId,
+    token,
+  }));
+
+  bot.rest = createRestManager({
+    token,
+    customUrl: Deno.env.get("PROXY_REST_URL"),
+    secretKey: Deno.env.get("PROXY_REST_SECRET"),
+  });
+
+  return bot;
+}

--- a/testss/utils.ts
+++ b/testss/utils.ts
@@ -1,0 +1,21 @@
+export const CACHED_COMMUNITY_GUILD_ID = 907350958810480671n;
+
+export function delayUntil(
+  maxMs: number,
+  isReady: () => boolean | undefined | Promise<boolean | undefined>,
+  timeoutTime = 100,
+): Promise<void> {
+  const maxTime = Date.now() + maxMs;
+
+  async function hackyFix(resolve: () => void) {
+    if ((await isReady()) || Date.now() >= maxTime) {
+      resolve();
+    } else {
+      setTimeout(() => {
+        hackyFix(resolve);
+      }, timeoutTime);
+    }
+  }
+
+  return new Promise((resolve) => hackyFix(resolve));
+}

--- a/transformers/channel.ts
+++ b/transformers/channel.ts
@@ -45,8 +45,9 @@ export function transformChannel(bot: Bot, payload: { channel: DiscordChannel } 
       ? bot.transformers.snowflake(payload.channel.last_message_id)
       : undefined,
     ownerId: payload.channel.owner_id ? bot.transformers.snowflake(payload.channel.owner_id) : undefined,
-    applicationId: payload.channel.application_id ? bot.transformers.snowflake(payload.channel.application_id)
-    : undefined,
+    applicationId: payload.channel.application_id
+      ? bot.transformers.snowflake(payload.channel.application_id)
+      : undefined,
     parentId: payload.channel.parent_id ? bot.transformers.snowflake(payload.channel.parent_id) : undefined,
     memberCount: payload.channel.member_count,
     messageCount: payload.channel.message_count,

--- a/transformers/guild.ts
+++ b/transformers/guild.ts
@@ -88,13 +88,16 @@ export function transformGuild(bot: Bot, payload: { guild: DiscordGuild } & { sh
     ownerId: payload.guild.owner_id ? bot.transformers.snowflake(payload.guild.owner_id) : 0n,
     permissions: payload.guild.permissions ? bot.transformers.snowflake(payload.guild.permissions) : 0n,
     afkChannelId: payload.guild.afk_channel_id ? bot.transformers.snowflake(payload.guild.afk_channel_id) : undefined,
-    widgetChannelId: payload.guild.widget_channel_id ? bot.transformers.snowflake(payload.guild.widget_channel_id)
-    : undefined,
+    widgetChannelId: payload.guild.widget_channel_id
+      ? bot.transformers.snowflake(payload.guild.widget_channel_id)
+      : undefined,
     applicationId: payload.guild.application_id ? bot.transformers.snowflake(payload.guild.application_id) : undefined,
-    systemChannelId: payload.guild.system_channel_id ? bot.transformers.snowflake(payload.guild.system_channel_id)
-    : undefined,
-    rulesChannelId: payload.guild.rules_channel_id ? bot.transformers.snowflake(payload.guild.rules_channel_id)
-    : undefined,
+    systemChannelId: payload.guild.system_channel_id
+      ? bot.transformers.snowflake(payload.guild.system_channel_id)
+      : undefined,
+    rulesChannelId: payload.guild.rules_channel_id
+      ? bot.transformers.snowflake(payload.guild.rules_channel_id)
+      : undefined,
     publicUpdatesChannelId: payload.guild.public_updates_channel_id
       ? bot.transformers.snowflake(payload.guild.public_updates_channel_id)
       : undefined,

--- a/transformers/message.ts
+++ b/transformers/message.ts
@@ -48,12 +48,15 @@ export function transformMessage(bot: Bot, payload: DiscordMessage) {
               ? Date.parse(payload.interaction.member.joined_at)
               : undefined,
             premiumSince: payload.interaction.member.premium_since
-              ? Date.parse(payload.interaction.member.premium_since) : undefined,
+              ? Date.parse(payload.interaction.member.premium_since)
+              : undefined,
             toggles: new MemberToggles(payload.interaction.member),
-            avatar: payload.interaction.member.avatar ? bot.utils.iconHashToBigInt(payload.interaction.member.avatar)
-            : undefined,
+            avatar: payload.interaction.member.avatar
+              ? bot.utils.iconHashToBigInt(payload.interaction.member.avatar)
+              : undefined,
             permissions: payload.interaction.member.permissions
-              ? bot.transformers.snowflake(payload.interaction.member.permissions) : undefined,
+              ? bot.transformers.snowflake(payload.interaction.member.permissions)
+              : undefined,
             communicationDisabledUntil: payload.interaction.member.communication_disabled_until
               ? Date.parse(payload.interaction.member.communication_disabled_until)
               : undefined,
@@ -84,8 +87,9 @@ export function transformMessage(bot: Bot, payload: DiscordMessage) {
         channelId: payload.message_reference.channel_id
           ? bot.transformers.snowflake(payload.message_reference.channel_id)
           : undefined,
-        guildId: payload.message_reference.guild_id ? bot.transformers.snowflake(payload.message_reference.guild_id)
-        : undefined,
+        guildId: payload.message_reference.guild_id
+          ? bot.transformers.snowflake(payload.message_reference.guild_id)
+          : undefined,
       }
       : undefined,
     mentionedUserIds: payload.mentions ? payload.mentions.map((m) => bot.transformers.snowflake(m.id)) : [],


### PR DESCRIPTION
This PR introduces a new style of doing unit tests. Since our library is oriented towards big bot developers, our unit tests should also be oriented towards using proxies. This PR introduces a proxy REST and adds the first test to showcase that this design works.

The general idea of the new design is to eliminate the need of having startBot() and leaking ops in tests. This will allow us to run all our tests in parallel as well as check any leaks. Each test will be entirely standalone and run in entirely separate contexts.

**Main Concerns:**

- Since this no longer uses the internal REST code, we need to remember to update the PROXY when REST code undergoes major changes.
- Currently this PR does not introduce the Gateway PROXY. I am still unsure how to implement that at this time.

**Pending Discussions:**

Everything is still open to discussion and changing at this time. This is mainly just to see if the idea works, which it does,. For example, the file structure and file names are open to changes.

---

HUGE THANKS TO @TriForMine 