### PR TITLE
refactor(.github,README,gateway,plugins/fileloader,tests,types)!: make intent calculation manual

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,9 +22,7 @@ const bot = createBot({
   events: {
     // ADD EVENTS NEEDED TO SHOW THE BUG HERE
   },
-  intents: [
-    // ADD INTENTS NEEDED HERE FOR YOUR TEST
-  ],
+  intents: 0, // ADD INTENTS NEEDED HERE FOR YOUR TEST IF NECESSARY
 });
 
 await startBot(bot);

--- a/README.md
+++ b/README.md
@@ -100,12 +100,12 @@ Have your cache setup in any way you like. Redis, PGSQL or any cache layer you w
 Here is a minimal example to get started with:
 
 ```typescript
-import { createBot, startBot } from "https://deno.land/x/discordeno@13.0.0-rc18/mod.ts";
+import { createBot, Intents, startBot } from "https://deno.land/x/discordeno@13.0.0-rc18/mod.ts";
 import { enableCachePlugin, enableCacheSweepers } from "https://deno.land/x/discordeno_cache_plugin@0.0.18/mod.ts";
 
 const baseBot = createBot({
   token: Deno.env.get("DISCORD_TOKEN"),
-  intents: ["Guilds", "GuildMessages"],
+  intents: Intents.Guilds | Intents.GuildMessages,
   botId: Deno.env.get("BOT_ID"),
   events: {
     ready() {

--- a/bot.ts
+++ b/bot.ts
@@ -145,10 +145,7 @@ export function createBot(options: CreateBotOptions): Bot {
     applicationId: options.applicationId || options.botId,
     token: removeTokenPrefix(options.token),
     events: createEventHandlers(options.events ?? {}),
-    intents: (options.intents ?? []).reduce(
-      (bits, next) => (bits |= GatewayIntents[next]),
-      0,
-    ),
+    intents: options.intents,
     botGatewayData: options.botGatewayData,
     activeGuildIds: new Set<bigint>(),
     constants: createBotConstants(),
@@ -318,7 +315,7 @@ export interface CreateBotOptions {
   applicationId?: bigint;
   secretKey?: string;
   events?: Partial<EventHandlers>;
-  intents?: (keyof typeof GatewayIntents)[];
+  intents?: GatewayIntents;
   botGatewayData?: GetGatewayBot;
   rest?: Omit<CreateRestManagerOptions, "token">;
   handleDiscordPayload?: GatewayManager["handleDiscordPayload"];

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -57,7 +57,7 @@ startGateway({
   /** Whether or not to use compression for gateway payloads. */
   compress: true,
   /** The intents you would like to enable. */
-  intents: ["GUILDS", "GUILD_MESSAGES"],
+  intents: Intents.Guilds | Intents.GuildMessages,
   /** The max amount of shards used for identifying. This can be useful for zero-downtime updates or resharding. */
   maxShards: 885,
   /** The first shard Id for this group of shards. */

--- a/gateway/gatewayManager.ts
+++ b/gateway/gatewayManager.ts
@@ -59,10 +59,7 @@ export function createGatewayManager(
     $os: options.$os ?? "linux",
     $browser: options.$browser ?? "Discordeno",
     $device: options.$device ?? "Discordeno",
-    intents:
-      (Array.isArray(options.intents)
-        ? options.intents.reduce((bits, next) => (bits |= GatewayIntents[next]), 0)
-        : options.intents) ?? 0,
+    intents: options.intents ?? 0,
     shard: options.shard ?? [0, options.shardsRecommended ?? 1],
     presence: options.presence,
     urlWSS: options.urlWSS ?? "wss://gateway.discord.gg/?v=9&encoding=json",
@@ -131,7 +128,7 @@ export interface GatewayManager {
   $os: string;
   $browser: string;
   $device: string;
-  intents: number | (keyof typeof GatewayIntents)[];
+  intents: GatewayIntents;
   shard: [number, number];
   presence?: Omit<StatusUpdate, "afk" | "since">;
 

--- a/plugins/fileloader/README.md
+++ b/plugins/fileloader/README.md
@@ -5,7 +5,7 @@ This plugin leverages the ability to write files, and then import them.
 ## Code Example
 
 ```typescript
-import { createBot, enableFileLoaderPlugin, startBot } from "./deps.ts"; // Import discordeno and this plugin.
+import { createBot, enableFileLoaderPlugin, Intents, startBot } from "./deps.ts"; // Import discordeno and this plugin.
 
 console.log("Starting Up the Bot, this might take awhile...");
 
@@ -13,7 +13,7 @@ const bot = enableFileLoaderPlugin(
   createBot({
     token: "", // Your bot's token
     botId: 0n, // Your bot's "Application Id",
-    intents: [],
+    intents: Intents.Guilds,
     events: {
       ready() {
         console.log("Bot Ready");

--- a/site/docs/big-bot-guide/events.md
+++ b/site/docs/big-bot-guide/events.md
@@ -25,14 +25,14 @@ Create a file path like `src/bot/mod.ts`.
 
 ```ts
 import { DISCORD_TOKEN } from "../../configs.ts";
-import { Collection, createBot } from "../../deps.ts";
+import { Collection, createBot, Intents } from "../../deps.ts";
 import { psql } from "./cache/mod.ts";
 
 export const bot = createBot({
   token: DISCORD_TOKEN,
   botId: 270010330782892032n,
   // applicationId: 270010330782892032,
-  intents: ["Guilds", "GuildMessages"],
+  intents: Intents.Guilds | Intents.GuildMessages,
   events: {
     messageCreate: function (bot, message) {
       console.log("message arrived");
@@ -126,7 +126,8 @@ Alright that was a lot of code. Now let's break it down little by little.
   developers have mentioned that this behavior is not documented and not supposed to be relied on to remain stable. Due
   to these reasons, we chose to just require the bot id be passed here.
 - `applicationId` is an optional choice if your bot is old and has a unique id different from it's bot id.
-- `intents`: Provide the intents you like using strings or a number. String form supports autocomplete and type safety.
+- `intents`: Provide the intents you like using a bitwise OR operation (eg. `Intents.Guilds | Intents.GuildsMessages`).
+  String form supports autocomplete and type safety.
 - `events`: These are your event handler functions. When a MESSAGE_CREATE event arrives from Discord it will be
   processed here. We will set up the routing to run these functions later in the guide but for now you can see how to
   set it up. Note, you can create these functions in separate files and just import them here as you wish.

--- a/site/docs/big-bot-guide/gateway.md
+++ b/site/docs/big-bot-guide/gateway.md
@@ -111,7 +111,7 @@ With this info, we can now create our gateway manager.
 const gateway = createGatewayManager({
   secretKey: EVENT_HANDLER_SECRET_KEY,
   token: DISCORD_TOKEN,
-  intents: ["GuildMessages", "Guilds"],
+  intents: Intents.Guilds | Intents.GuildMessages,
   shardsRecommended: result.shards,
   sessionStartLimitTotal: result.sessionStartLimit.total,
   sessionStartLimitRemaining: result.sessionStartLimit.remaining,

--- a/site/docs/general/getting-started.md
+++ b/site/docs/general/getting-started.md
@@ -45,11 +45,11 @@ Starting with Discordeno is very simple, you can start from scratch without any 
 of code into a new TypeScript file:
 
 ```ts
-import { startBot } from "https://deno.land/x/discordeno/mod.ts";
+import { Intents, startBot } from "https://deno.land/x/discordeno/mod.ts";
 
 startBot({
   token: "BOT TOKEN",
-  intents: ["GUILDS", "GUILD_MESSAGES"],
+  intents: Intents.Guilds | Intents.GuildMessages,
   eventHandlers: {
     ready() {
       console.log("Successfully connected to gateway");

--- a/site/docs/general/migrating.md
+++ b/site/docs/general/migrating.md
@@ -161,7 +161,7 @@ startBot({
   token: configs.token,
   // Pick the intents you wish to have for your bot.
   // For instance, to work with guild message reactions, you will have to pass the Intents.GUILD_MESSAGE_REACTIONS intent to the array.
-  intents: [Intents.GUILDS, Intents.GUILD_MESSAGES],
+  intents: Intents.Guilds | Intents.GuildMessages,
   // These are all your event handler functions. Imported from the events folder
   eventHandlers: botCache.eventHandlers,
 });

--- a/tests/mod.ts
+++ b/tests/mod.ts
@@ -26,6 +26,7 @@ import { categoryChildrenTest } from "./helpers/channels/categoryChannels.ts";
 import { deleteChannelOverwriteTests } from "./helpers/channels/deleteChannelOverwrite.ts";
 import { editChannelTests } from "./helpers/channels/editChannel.ts";
 import { CACHED_COMMUNITY_GUILD_ID, sanitizeMode } from "./constants.ts";
+import { Intents } from "../types/shared.ts";
 
 console.log("[Tests] Starting test preparation");
 dotenv({ export: true, path: `${Deno.cwd()}/.env` });
@@ -45,17 +46,15 @@ const baseBot = createBot({
     },
     // debug: console.log,
   }),
-  intents: [
-    "Guilds",
-    "GuildEmojis",
-    "GuildMessages",
-    "GuildMessageReactions",
-    "GuildBans",
-    "GuildMembers",
-    "GuildScheduledEvents",
-    "GuildVoiceStates",
-    "GuildPresences",
-  ],
+  intents: Intents.Guilds |
+    Intents.GuildEmojis |
+    Intents.GuildMessages |
+    Intents.GuildMessageReactions |
+    Intents.GuildBans |
+    Intents.GuildMembers |
+    Intents.GuildScheduledEvents |
+    Intents.GuildVoiceStates |
+    Intents.GuildPresences,
 });
 
 export const bot = enableCachePlugin(baseBot);

--- a/testss/mod.ts
+++ b/testss/mod.ts
@@ -10,7 +10,7 @@ export function loadBot() {
   const botId = BigInt(atob(token.split(".")[0]));
   const bot = createBot({
     events: {},
-    intents: [],
+    intents: 0,
     botId,
     token,
   });

--- a/types/shared.ts
+++ b/types/shared.ts
@@ -1151,6 +1151,12 @@ export enum GatewayIntents {
   GuildScheduledEvents = (1 << 16),
 }
 
+// ALIASES JUST FOR BETTER UX IN THIS CASE
+
+/** https://discord.com/developers/docs/topics/gateway#list-of-intents */
+export const Intents = GatewayIntents;
+export type Intents = GatewayIntents;
+
 /** https://discord.com/developers/docs/interactions/slash-commands#interaction-response-interactionresponsetype */
 export enum InteractionResponseTypes {
   /** ACK a `Ping` */


### PR DESCRIPTION
This changes the calculation of intents to be manual to the dev.
This is to improve overall consistency of our code base, also it is not a big drawback for users since intents are usually done once and then never (seldom) touched again.