### PR TITLE
perf(plugins/helpers,rest,site,template)!: uppercase rest methods

### DIFF
--- a/helpers/channels/createChannel.ts
+++ b/helpers/channels/createChannel.ts
@@ -10,7 +10,7 @@ export async function createChannel(bot: Bot, guildId: bigint, options?: CreateG
 
   const result = await bot.rest.runMethod<DiscordChannel>(
     bot.rest,
-    "post",
+    "POST",
     bot.constants.routes.GUILD_CHANNELS(guildId),
     options
       ? {

--- a/helpers/channels/createStageInstance.ts
+++ b/helpers/channels/createStageInstance.ts
@@ -5,7 +5,7 @@ import { DiscordStageInstance } from "../../types/discord.ts";
 export async function createStageInstance(bot: Bot, options: CreateStageInstance) {
   const result = await bot.rest.runMethod<DiscordStageInstance>(
     bot.rest,
-    "post",
+    "POST",
     bot.constants.routes.STAGE_INSTANCES(),
     {
       channel_id: options.channelId.toString(),

--- a/helpers/channels/deleteChannel.ts
+++ b/helpers/channels/deleteChannel.ts
@@ -5,7 +5,7 @@ import { DiscordChannel } from "../../types/discord.ts";
 export async function deleteChannel(bot: Bot, channelId: bigint, reason?: string) {
   await bot.rest.runMethod<DiscordChannel>(
     bot.rest,
-    "delete",
+    "DELETE",
     bot.constants.routes.CHANNEL(channelId),
     {
       reason,

--- a/helpers/channels/deleteChannelOverwrite.ts
+++ b/helpers/channels/deleteChannelOverwrite.ts
@@ -4,7 +4,7 @@ import type { Bot } from "../../bot.ts";
 export async function deleteChannelOverwrite(bot: Bot, channelId: bigint, overwriteId: bigint) {
   await bot.rest.runMethod<undefined>(
     bot.rest,
-    "delete",
+    "DELETE",
     bot.constants.routes.CHANNEL_OVERWRITE(channelId, overwriteId),
   );
 }

--- a/helpers/channels/deleteStageInstance.ts
+++ b/helpers/channels/deleteStageInstance.ts
@@ -2,5 +2,5 @@ import type { Bot } from "../../bot.ts";
 
 /** Deletes the Stage instance. Requires the user to be a moderator of the Stage channel. */
 export async function deleteStageInstance(bot: Bot, channelId: bigint) {
-  await bot.rest.runMethod(bot.rest, "delete", bot.constants.routes.STAGE_INSTANCE(channelId));
+  await bot.rest.runMethod(bot.rest, "DELETE", bot.constants.routes.STAGE_INSTANCE(channelId));
 }

--- a/helpers/channels/editChannel.ts
+++ b/helpers/channels/editChannel.ts
@@ -34,7 +34,7 @@ export async function editChannel(bot: Bot, channelId: bigint, options: ModifyCh
 
   const result = await bot.rest.runMethod<DiscordChannel>(
     bot.rest,
-    "patch",
+    "PATCH",
     bot.constants.routes.CHANNEL(channelId),
     {
       name: options.name,

--- a/helpers/channels/editChannelOverwrite.ts
+++ b/helpers/channels/editChannelOverwrite.ts
@@ -9,7 +9,7 @@ export async function editChannelOverwrite(
 ) {
   await bot.rest.runMethod<undefined>(
     bot.rest,
-    "put",
+    "PUT",
     bot.constants.routes.CHANNEL_OVERWRITE(channelId, overwrite.id),
     {
       allow: overwrite.allow ? bot.utils.calculateBits(overwrite.allow) : "0",

--- a/helpers/channels/followChannel.ts
+++ b/helpers/channels/followChannel.ts
@@ -5,7 +5,7 @@ import { DiscordFollowedChannel } from "../../types/discord.ts";
 export async function followChannel(bot: Bot, sourceChannelId: bigint, targetChannelId: bigint) {
   const data = await bot.rest.runMethod<DiscordFollowedChannel>(
     bot.rest,
-    "post",
+    "POST",
     bot.constants.routes.CHANNEL_FOLLOW(sourceChannelId),
     {
       webhook_channel_id: targetChannelId,

--- a/helpers/channels/forums/createForumPost.ts
+++ b/helpers/channels/forums/createForumPost.ts
@@ -11,7 +11,7 @@ export async function createForumPost(
 ) {
   const result = await bot.rest.runMethod<DiscordChannel>(
     bot.rest,
-    "post",
+    "POST",
     bot.constants.routes.FORUM_START(channelId),
     {
       name: options.name,

--- a/helpers/channels/getChannel.ts
+++ b/helpers/channels/getChannel.ts
@@ -5,7 +5,7 @@ import { DiscordChannel } from "../../types/discord.ts";
 export async function getChannel(bot: Bot, channelId: bigint) {
   const result = await bot.rest.runMethod<DiscordChannel>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.CHANNEL(channelId),
   );
 

--- a/helpers/channels/getChannelWebhooks.ts
+++ b/helpers/channels/getChannelWebhooks.ts
@@ -6,7 +6,7 @@ import { DiscordWebhook } from "../../types/discord.ts";
 export async function getChannelWebhooks(bot: Bot, channelId: bigint) {
   const result = await bot.rest.runMethod<DiscordWebhook[]>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.CHANNEL_WEBHOOKS(channelId),
   );
 

--- a/helpers/channels/getChannels.ts
+++ b/helpers/channels/getChannels.ts
@@ -6,7 +6,7 @@ import { DiscordChannel } from "../../types/discord.ts";
 export async function getChannels(bot: Bot, guildId: bigint) {
   const result = await bot.rest.runMethod<DiscordChannel[]>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.GUILD_CHANNELS(guildId),
   );
 

--- a/helpers/channels/getPins.ts
+++ b/helpers/channels/getPins.ts
@@ -5,7 +5,7 @@ import { DiscordMessage } from "../../types/discord.ts";
 export async function getPins(bot: Bot, channelId: bigint) {
   const result = await bot.rest.runMethod<DiscordMessage[]>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.CHANNEL_PINS(channelId),
   );
 

--- a/helpers/channels/getStageInstance.ts
+++ b/helpers/channels/getStageInstance.ts
@@ -5,7 +5,7 @@ import { DiscordStageInstance } from "../../types/discord.ts";
 export async function getStageInstance(bot: Bot, channelId: bigint) {
   const result = await bot.rest.runMethod<DiscordStageInstance>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.STAGE_INSTANCE(channelId),
   );
 

--- a/helpers/channels/startTyping.ts
+++ b/helpers/channels/startTyping.ts
@@ -6,5 +6,5 @@ import type { Bot } from "../../bot.ts";
  * this endpoint may be called to let the user know that the bot is processing their message.
  */
 export async function startTyping(bot: Bot, channelId: bigint) {
-  await bot.rest.runMethod<undefined>(bot.rest, "post", bot.constants.routes.CHANNEL_TYPING(channelId));
+  await bot.rest.runMethod<undefined>(bot.rest, "POST", bot.constants.routes.CHANNEL_TYPING(channelId));
 }

--- a/helpers/channels/swapChannels.ts
+++ b/helpers/channels/swapChannels.ts
@@ -8,7 +8,7 @@ export async function swapChannels(bot: Bot, guildId: bigint, channelPositions: 
 
   await bot.rest.runMethod<undefined>(
     bot.rest,
-    "patch",
+    "PATCH",
     bot.constants.routes.GUILD_CHANNELS(guildId),
     channelPositions.map((channelPosition) => {
       return {

--- a/helpers/channels/threads/addToThread.ts
+++ b/helpers/channels/threads/addToThread.ts
@@ -2,5 +2,5 @@ import type { Bot } from "../../../bot.ts";
 
 /** Adds a user to a thread. Requires the ability to send messages in the thread. Requires the thread is not archived. */
 export async function addToThread(bot: Bot, threadId: bigint, userId: bigint) {
-  await bot.rest.runMethod<undefined>(bot.rest, "put", bot.constants.routes.THREAD_USER(threadId, userId));
+  await bot.rest.runMethod<undefined>(bot.rest, "PUT", bot.constants.routes.THREAD_USER(threadId, userId));
 }

--- a/helpers/channels/threads/getActiveThreads.ts
+++ b/helpers/channels/threads/getActiveThreads.ts
@@ -6,7 +6,7 @@ import { Collection } from "../../../util/collection.ts";
 export async function getActiveThreads(bot: Bot, guildId: bigint) {
   const result = await bot.rest.runMethod<DiscordListActiveThreads>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.THREAD_ACTIVE(guildId),
   );
 

--- a/helpers/channels/threads/getArchivedThreads.ts
+++ b/helpers/channels/threads/getArchivedThreads.ts
@@ -18,7 +18,7 @@ export async function getArchivedThreads(
 
   const result = (await bot.rest.runMethod<DiscordListArchivedThreads>(
     bot.rest,
-    "get",
+    "GET",
     url,
   ));
 

--- a/helpers/channels/threads/getThreadMember.ts
+++ b/helpers/channels/threads/getThreadMember.ts
@@ -5,7 +5,7 @@ import { DiscordThreadMember } from "../../../types/discord.ts";
 export async function getThreadMember(bot: Bot, threadId: bigint, userId: bigint) {
   const result = await bot.rest.runMethod<DiscordThreadMember>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.THREAD_USER(threadId, userId),
   );
 

--- a/helpers/channels/threads/getThreadMembers.ts
+++ b/helpers/channels/threads/getThreadMembers.ts
@@ -6,7 +6,7 @@ import { Collection } from "../../../util/collection.ts";
 export async function getThreadMembers(bot: Bot, threadId: bigint) {
   const result = await bot.rest.runMethod<DiscordThreadMember[]>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.THREAD_MEMBERS(threadId),
   );
   // return result;

--- a/helpers/channels/threads/joinThread.ts
+++ b/helpers/channels/threads/joinThread.ts
@@ -2,5 +2,5 @@ import type { Bot } from "../../../bot.ts";
 
 /** Adds the bot to the thread. Cannot join an archived thread. */
 export async function joinThread(bot: Bot, threadId: bigint) {
-  await bot.rest.runMethod<undefined>(bot.rest, "put", bot.constants.routes.THREAD_ME(threadId));
+  await bot.rest.runMethod<undefined>(bot.rest, "PUT", bot.constants.routes.THREAD_ME(threadId));
 }

--- a/helpers/channels/threads/leaveThread.ts
+++ b/helpers/channels/threads/leaveThread.ts
@@ -2,5 +2,5 @@ import type { Bot } from "../../../bot.ts";
 
 /** Removes the bot from a thread. Requires the thread is not archived. */
 export async function leaveThread(bot: Bot, threadId: bigint) {
-  await bot.rest.runMethod<undefined>(bot.rest, "delete", bot.constants.routes.THREAD_ME(threadId));
+  await bot.rest.runMethod<undefined>(bot.rest, "DELETE", bot.constants.routes.THREAD_ME(threadId));
 }

--- a/helpers/channels/threads/removeThreadMember.ts
+++ b/helpers/channels/threads/removeThreadMember.ts
@@ -2,5 +2,5 @@ import type { Bot } from "../../../bot.ts";
 
 /** Removes a user from a thread. Requires the MANAGE_THREADS permission or that you are the creator of the thread. Also requires the thread is not archived. */
 export async function removeThreadMember(bot: Bot, threadId: bigint, userId: bigint) {
-  await bot.rest.runMethod<undefined>(bot.rest, "delete", bot.constants.routes.THREAD_USER(threadId, userId));
+  await bot.rest.runMethod<undefined>(bot.rest, "DELETE", bot.constants.routes.THREAD_USER(threadId, userId));
 }

--- a/helpers/channels/threads/startThreadWithMessage.ts
+++ b/helpers/channels/threads/startThreadWithMessage.ts
@@ -10,7 +10,7 @@ export async function startThreadWithMessage(
 ) {
   const result = await bot.rest.runMethod<DiscordChannel>(
     bot.rest,
-    "post",
+    "POST",
     bot.constants.routes.THREAD_START_PUBLIC(channelId, messageId),
     {
       name: options.name,

--- a/helpers/channels/threads/startThreadWithoutMessage.ts
+++ b/helpers/channels/threads/startThreadWithoutMessage.ts
@@ -6,7 +6,7 @@ import { ChannelTypes } from "../../../types/shared.ts";
 export async function startThreadWithoutMessage(bot: Bot, channelId: bigint, options: StartThreadWithoutMessage) {
   const result = await bot.rest.runMethod<DiscordChannel>(
     bot.rest,
-    "post",
+    "POST",
     bot.constants.routes.THREAD_START_PRIVATE(channelId),
     {
       name: options.name,

--- a/helpers/channels/updateStageInstance.ts
+++ b/helpers/channels/updateStageInstance.ts
@@ -10,7 +10,7 @@ export async function updateStageInstance(
 ) {
   const result = await bot.rest.runMethod<DiscordStageInstance>(
     bot.rest,
-    "patch",
+    "PATCH",
     bot.constants.routes.STAGE_INSTANCE(channelId),
     {
       topic: data.topic,

--- a/helpers/channels/updateVoiceState.ts
+++ b/helpers/channels/updateVoiceState.ts
@@ -11,7 +11,7 @@ import type { Bot } from "../../bot.ts";
  *  - When suppressed, the user will have their `request_to_speak_timestamp` removed.
  */
 export async function updateBotVoiceState(bot: Bot, guildId: bigint, options: UpdateSelfVoiceState) {
-  await bot.rest.runMethod(bot.rest, "patch", bot.constants.routes.UPDATE_VOICE_STATE(guildId), {
+  await bot.rest.runMethod(bot.rest, "PATCH", bot.constants.routes.UPDATE_VOICE_STATE(guildId), {
     channel_id: options.channelId,
     suppress: options.suppress,
     request_to_speak_timestamp: options.requestToSpeakTimestamp
@@ -34,7 +34,7 @@ export async function updateBotVoiceState(bot: Bot, guildId: bigint, options: Up
 export async function updateUserVoiceState(bot: Bot, guildId: bigint, options: UpdateOthersVoiceState) {
   await bot.rest.runMethod(
     bot.rest,
-    "patch",
+    "PATCH",
     bot.constants.routes.UPDATE_VOICE_STATE(guildId, options.userId),
     {
       channel_id: options.channelId,

--- a/helpers/discovery/addDiscoverySubcategory.ts
+++ b/helpers/discovery/addDiscoverySubcategory.ts
@@ -5,7 +5,7 @@ import { DiscordAddGuildDiscoverySubcategory } from "../../types/discord.ts";
 export async function addDiscoverySubcategory(bot: Bot, guildId: bigint, categoryId: number) {
   await bot.rest.runMethod<DiscordAddGuildDiscoverySubcategory>(
     bot.rest,
-    "post",
+    "POST",
     bot.constants.routes.DISCOVERY_SUBCATEGORY(guildId, categoryId),
   );
 }

--- a/helpers/discovery/editDiscovery.ts
+++ b/helpers/discovery/editDiscovery.ts
@@ -5,7 +5,7 @@ import { DiscordDiscoveryMetadata } from "../../types/discord.ts";
 export async function editDiscovery(bot: Bot, guildId: bigint, data: ModifyGuildDiscoveryMetadata) {
   const result = await bot.rest.runMethod<DiscordDiscoveryMetadata>(
     bot.rest,
-    "patch",
+    "PATCH",
     bot.constants.routes.DISCOVERY_METADATA(guildId),
     {
       primary_category_id: data.primaryCategoryId,

--- a/helpers/discovery/getDiscovery.ts
+++ b/helpers/discovery/getDiscovery.ts
@@ -5,7 +5,7 @@ import { DiscordDiscoveryMetadata } from "../../types/discord.ts";
 export async function getDiscovery(bot: Bot, guildId: bigint) {
   const result = await bot.rest.runMethod<DiscordDiscoveryMetadata>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.DISCOVERY_METADATA(guildId),
   );
 

--- a/helpers/discovery/getDiscoveryCategories.ts
+++ b/helpers/discovery/getDiscoveryCategories.ts
@@ -6,7 +6,7 @@ import { DiscordDiscoveryCategory } from "../../types/discord.ts";
 export async function getDiscoveryCategories(bot: Bot) {
   const result = await bot.rest.runMethod<DiscordDiscoveryCategory[]>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.DISCOVERY_CATEGORIES(),
   );
 

--- a/helpers/discovery/removeDiscoverySubcategory.ts
+++ b/helpers/discovery/removeDiscoverySubcategory.ts
@@ -4,7 +4,7 @@ import type { Bot } from "../../bot.ts";
 export async function removeDiscoverySubcategory(bot: Bot, guildId: bigint, categoryId: number) {
   await bot.rest.runMethod<undefined>(
     bot.rest,
-    "delete",
+    "DELETE",
     bot.constants.routes.DISCOVERY_SUBCATEGORY(guildId, categoryId),
   );
 }

--- a/helpers/discovery/validDiscoveryTerm.ts
+++ b/helpers/discovery/validDiscoveryTerm.ts
@@ -4,7 +4,7 @@ import { DiscordValidateDiscoverySearchTerm } from "../../types/discord.ts";
 export async function validDiscoveryTerm(bot: Bot, term: string) {
   const result = await bot.rest.runMethod<DiscordValidateDiscoverySearchTerm>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.DISCOVERY_VALID_TERM(term),
   );
 

--- a/helpers/emojis/createEmoji.ts
+++ b/helpers/emojis/createEmoji.ts
@@ -9,7 +9,7 @@ export async function createEmoji(bot: Bot, guildId: bigint, options: CreateGuil
 
   const emoji = await bot.rest.runMethod<DiscordEmoji>(
     bot.rest,
-    "post",
+    "POST",
     bot.constants.routes.GUILD_EMOJIS(guildId),
     {
       name: options.name,

--- a/helpers/emojis/deleteEmoji.ts
+++ b/helpers/emojis/deleteEmoji.ts
@@ -2,7 +2,7 @@ import type { Bot } from "../../bot.ts";
 
 /** Delete the given emoji. Requires the MANAGE_EMOJIS permission. Returns 204 No Content on success. */
 export async function deleteEmoji(bot: Bot, guildId: bigint, id: bigint, reason?: string) {
-  await bot.rest.runMethod<undefined>(bot.rest, "delete", bot.constants.routes.GUILD_EMOJI(guildId, id), {
+  await bot.rest.runMethod<undefined>(bot.rest, "DELETE", bot.constants.routes.GUILD_EMOJI(guildId, id), {
     reason,
   });
 }

--- a/helpers/emojis/editEmoji.ts
+++ b/helpers/emojis/editEmoji.ts
@@ -5,7 +5,7 @@ import { DiscordEmoji } from "../../types/discord.ts";
 export async function editEmoji(bot: Bot, guildId: bigint, id: bigint, options: ModifyGuildEmoji) {
   const result = await bot.rest.runMethod<DiscordEmoji>(
     bot.rest,
-    "patch",
+    "PATCH",
     bot.constants.routes.GUILD_EMOJI(guildId, id),
     {
       name: options.name,

--- a/helpers/emojis/getEmoji.ts
+++ b/helpers/emojis/getEmoji.ts
@@ -7,7 +7,7 @@ import { DiscordEmoji } from "../../types/discord.ts";
 export async function getEmoji(bot: Bot, guildId: bigint, emojiId: bigint) {
   const result = await bot.rest.runMethod<DiscordEmoji>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.GUILD_EMOJI(guildId, emojiId),
   );
 

--- a/helpers/emojis/getEmojis.ts
+++ b/helpers/emojis/getEmojis.ts
@@ -8,7 +8,7 @@ import { Collection } from "../../util/collection.ts";
 export async function getEmojis(bot: Bot, guildId: bigint) {
   const result = await bot.rest.runMethod<DiscordEmoji[]>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.GUILD_EMOJIS(guildId),
   );
 

--- a/helpers/guilds/createGuild.ts
+++ b/helpers/guilds/createGuild.ts
@@ -11,7 +11,7 @@ import {
 
 /** Create a new guild. Returns a guild object on success. Fires a Guild Create Gateway event. This endpoint can be used only by bots in less than 10 guilds. */
 export async function createGuild(bot: Bot, options: CreateGuild) {
-  const result = await bot.rest.runMethod<DiscordGuild>(bot.rest, "post", bot.constants.routes.GUILDS(), {
+  const result = await bot.rest.runMethod<DiscordGuild>(bot.rest, "POST", bot.constants.routes.GUILDS(), {
     name: options.name,
     afk_channel_id: options.afkChannelId,
     afk_timeout: options.afkTimeout,

--- a/helpers/guilds/deleteGuild.ts
+++ b/helpers/guilds/deleteGuild.ts
@@ -2,5 +2,5 @@ import type { Bot } from "../../bot.ts";
 
 /** Delete a guild permanently. User must be owner. Returns 204 No Content on success. Fires a Guild Delete Gateway event. */
 export async function deleteGuild(bot: Bot, guildId: bigint) {
-  await bot.rest.runMethod<undefined>(bot.rest, "delete", bot.constants.routes.GUILD(guildId));
+  await bot.rest.runMethod<undefined>(bot.rest, "DELETE", bot.constants.routes.GUILD(guildId));
 }

--- a/helpers/guilds/editGuild.ts
+++ b/helpers/guilds/editGuild.ts
@@ -24,7 +24,7 @@ export async function editGuild(bot: Bot, guildId: bigint, options: ModifyGuild,
 
   const result = await bot.rest.runMethod<DiscordGuild>(
     bot.rest,
-    "patch",
+    "PATCH",
     bot.constants.routes.GUILD(guildId),
     options,
   );

--- a/helpers/guilds/editWelcomeScreen.ts
+++ b/helpers/guilds/editWelcomeScreen.ts
@@ -4,7 +4,7 @@ import { DiscordWelcomeScreen } from "../../types/discord.ts";
 export async function editWelcomeScreen(bot: Bot, guildId: bigint, options: ModifyGuildWelcomeScreen) {
   const result = await bot.rest.runMethod<DiscordWelcomeScreen>(
     bot.rest,
-    "patch",
+    "PATCH",
     bot.constants.routes.GUILD_WELCOME_SCREEN(guildId),
     {
       enabled: options.enabled,

--- a/helpers/guilds/editWidget.ts
+++ b/helpers/guilds/editWidget.ts
@@ -5,7 +5,7 @@ import { DiscordGuildWidgetSettings } from "../../types/discord.ts";
 export async function editWidget(bot: Bot, guildId: bigint, enabled: boolean, channelId?: string | null) {
   const result = await bot.rest.runMethod<DiscordGuildWidgetSettings>(
     bot.rest,
-    "patch",
+    "PATCH",
     bot.constants.routes.GUILD_WIDGET(guildId),
     {
       enabled,

--- a/helpers/guilds/getAuditLogs.ts
+++ b/helpers/guilds/getAuditLogs.ts
@@ -8,7 +8,7 @@ export async function getAuditLogs(bot: Bot, guildId: bigint, options?: GetGuild
 
   const auditlog = await bot.rest.runMethod<DiscordAuditLog>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.GUILD_AUDIT_LOGS(guildId, options),
   );
 

--- a/helpers/guilds/getAvailableVoiceRegions.ts
+++ b/helpers/guilds/getAvailableVoiceRegions.ts
@@ -6,7 +6,7 @@ import { Collection } from "../../util/collection.ts";
 export async function getAvailableVoiceRegions(bot: Bot) {
   const result = await bot.rest.runMethod<DiscordVoiceRegion[]>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.VOICE_REGIONS(),
   );
 

--- a/helpers/guilds/getBan.ts
+++ b/helpers/guilds/getBan.ts
@@ -5,7 +5,7 @@ import { DiscordBan } from "../../types/discord.ts";
 export async function getBan(bot: Bot, guildId: bigint, memberId: bigint) {
   const result = await bot.rest.runMethod<DiscordBan>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.GUILD_BAN(guildId, memberId),
   );
 

--- a/helpers/guilds/getBans.ts
+++ b/helpers/guilds/getBans.ts
@@ -7,7 +7,7 @@ import { User } from "../../transformers/member.ts";
 export async function getBans(bot: Bot, guildId: bigint, options?: GetBans) {
   const results = await bot.rest.runMethod<DiscordBan[]>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.GUILD_BANS(guildId, options),
   );
 

--- a/helpers/guilds/getGuild.ts
+++ b/helpers/guilds/getGuild.ts
@@ -14,7 +14,7 @@ export async function getGuild(
 ) {
   const result = await bot.rest.runMethod<DiscordGuild>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.GUILD(guildId, options.counts),
   );
 

--- a/helpers/guilds/getGuildPreview.ts
+++ b/helpers/guilds/getGuildPreview.ts
@@ -5,7 +5,7 @@ import { DiscordGuildPreview } from "../../types/discord.ts";
 export async function getGuildPreview(bot: Bot, guildId: bigint) {
   const result = await bot.rest.runMethod<DiscordGuildPreview>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.GUILD_PREVIEW(guildId),
   );
 

--- a/helpers/guilds/getPruneCount.ts
+++ b/helpers/guilds/getPruneCount.ts
@@ -7,7 +7,7 @@ export async function getPruneCount(bot: Bot, guildId: bigint, options?: GetGuil
 
   const result = await bot.rest.runMethod(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.GUILD_PRUNE(guildId),
   );
 

--- a/helpers/guilds/getVanityUrl.ts
+++ b/helpers/guilds/getVanityUrl.ts
@@ -5,7 +5,7 @@ import { DiscordInviteMetadata } from "../../types/discord.ts";
 export async function getVanityUrl(bot: Bot, guildId: bigint) {
   const result = await bot.rest.runMethod<Partial<DiscordInviteMetadata>>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.GUILD_VANITY_URL(guildId),
   );
 

--- a/helpers/guilds/getVoiceRegions.ts
+++ b/helpers/guilds/getVoiceRegions.ts
@@ -6,7 +6,7 @@ import { DiscordVoiceRegion } from "../../types/discord.ts";
 export async function getVoiceRegions(bot: Bot, guildId: bigint) {
   const result = await bot.rest.runMethod<DiscordVoiceRegion[]>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.GUILD_REGIONS(guildId),
   );
 

--- a/helpers/guilds/getWelcomeScreen.ts
+++ b/helpers/guilds/getWelcomeScreen.ts
@@ -5,7 +5,7 @@ import { DiscordWelcomeScreen } from "../../types/discord.ts";
 export async function getWelcomeScreen(bot: Bot, guildId: bigint) {
   const result = await bot.rest.runMethod<DiscordWelcomeScreen>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.GUILD_WELCOME_SCREEN(guildId),
   );
 

--- a/helpers/guilds/getWidget.ts
+++ b/helpers/guilds/getWidget.ts
@@ -5,7 +5,7 @@ import { DiscordGuildWidget } from "../../types/discord.ts";
 export async function getWidget(bot: Bot, guildId: bigint) {
   const result = await bot.rest.runMethod<DiscordGuildWidget>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.GUILD_WIDGET_JSON(guildId),
   );
 

--- a/helpers/guilds/getWidgetSettings.ts
+++ b/helpers/guilds/getWidgetSettings.ts
@@ -5,7 +5,7 @@ import { DiscordGuildWidgetSettings } from "../../types/discord.ts";
 export async function getWidgetSettings(bot: Bot, guildId: bigint) {
   const result = await bot.rest.runMethod<DiscordGuildWidgetSettings>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.GUILD_WIDGET(guildId),
   );
 

--- a/helpers/guilds/leaveGuild.ts
+++ b/helpers/guilds/leaveGuild.ts
@@ -2,5 +2,5 @@ import type { Bot } from "../../bot.ts";
 
 /** Leave a guild */
 export async function leaveGuild(bot: Bot, guildId: bigint) {
-  await bot.rest.runMethod<undefined>(bot.rest, "delete", bot.constants.routes.GUILD_LEAVE(guildId));
+  await bot.rest.runMethod<undefined>(bot.rest, "DELETE", bot.constants.routes.GUILD_LEAVE(guildId));
 }

--- a/helpers/guilds/scheduledEvents/createScheduledEvent.ts
+++ b/helpers/guilds/scheduledEvents/createScheduledEvent.ts
@@ -28,7 +28,7 @@ export async function createScheduledEvent(bot: Bot, guildId: bigint, options: C
 
   const event = await bot.rest.runMethod<DiscordScheduledEvent>(
     bot.rest,
-    "post",
+    "POST",
     bot.constants.routes.GUILD_SCHEDULED_EVENTS(guildId),
     {
       channel_id: options.channelId?.toString(),

--- a/helpers/guilds/scheduledEvents/deleteScheduledEvent.ts
+++ b/helpers/guilds/scheduledEvents/deleteScheduledEvent.ts
@@ -4,7 +4,7 @@ import { Bot } from "../../../bot.ts";
 export async function deleteScheduledEvent(bot: Bot, guildId: bigint, eventId: bigint) {
   await bot.rest.runMethod<undefined>(
     bot.rest,
-    "delete",
+    "DELETE",
     bot.constants.routes.GUILD_SCHEDULED_EVENT(guildId, eventId),
   );
 }

--- a/helpers/guilds/scheduledEvents/editScheduledEvent.ts
+++ b/helpers/guilds/scheduledEvents/editScheduledEvent.ts
@@ -24,7 +24,7 @@ export async function editScheduledEvent(
 
   const event = await bot.rest.runMethod<DiscordScheduledEvent>(
     bot.rest,
-    "patch",
+    "PATCH",
     bot.constants.routes.GUILD_SCHEDULED_EVENT(guildId, eventId),
     {
       channel_id: options.channelId === null ? null : options.channelId?.toString(),

--- a/helpers/guilds/scheduledEvents/getScheduledEvent.ts
+++ b/helpers/guilds/scheduledEvents/getScheduledEvent.ts
@@ -10,7 +10,7 @@ export async function getScheduledEvent(
 ) {
   const event = await bot.rest.runMethod<DiscordScheduledEvent>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.GUILD_SCHEDULED_EVENT(guildId, eventId, options?.withUserCount),
   );
 

--- a/helpers/guilds/scheduledEvents/getScheduledEventUsers.ts
+++ b/helpers/guilds/scheduledEvents/getScheduledEventUsers.ts
@@ -36,7 +36,7 @@ export async function getScheduledEventUsers(
 
   const result = await bot.rest.runMethod<{ user: DiscordUser; member?: DiscordMember }[]>(
     bot.rest,
-    "get",
+    "GET",
     url,
   );
 

--- a/helpers/guilds/scheduledEvents/getScheduledEvents.ts
+++ b/helpers/guilds/scheduledEvents/getScheduledEvents.ts
@@ -7,7 +7,7 @@ import { Collection } from "../../../util/collection.ts";
 export async function getScheduledEvents(bot: Bot, guildId: bigint, options?: GetScheduledEvents) {
   const events = await bot.rest.runMethod<DiscordScheduledEvent[]>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.GUILD_SCHEDULED_EVENTS(guildId, options?.withUserCount),
   );
 

--- a/helpers/integrations/deleteIntegration.ts
+++ b/helpers/integrations/deleteIntegration.ts
@@ -2,5 +2,5 @@ import type { Bot } from "../../bot.ts";
 
 /** Delete the attached integration object for the guild with this id. Requires MANAGE_GUILD permission. */
 export async function deleteIntegration(bot: Bot, guildId: bigint, id: bigint) {
-  await bot.rest.runMethod<undefined>(bot.rest, "delete", bot.constants.routes.GUILD_INTEGRATION(guildId, id));
+  await bot.rest.runMethod<undefined>(bot.rest, "DELETE", bot.constants.routes.GUILD_INTEGRATION(guildId, id));
 }

--- a/helpers/integrations/getIntegrations.ts
+++ b/helpers/integrations/getIntegrations.ts
@@ -6,7 +6,7 @@ import { DiscordIntegration } from "../../types/discord.ts";
 export async function getIntegrations(bot: Bot, guildId: bigint) {
   const result = await bot.rest.runMethod<DiscordIntegration[]>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.GUILD_INTEGRATIONS(guildId),
   );
 

--- a/helpers/interactions/commands/createApplicationCommand.ts
+++ b/helpers/interactions/commands/createApplicationCommand.ts
@@ -21,7 +21,7 @@ export async function createApplicationCommand(
 ) {
   const result = await bot.rest.runMethod<DiscordApplicationCommand>(
     bot.rest,
-    "post",
+    "POST",
     guildId
       ? bot.constants.routes.COMMANDS_GUILD(bot.applicationId, guildId)
       : bot.constants.routes.COMMANDS(bot.applicationId),

--- a/helpers/interactions/commands/deleteApplicationCommand.ts
+++ b/helpers/interactions/commands/deleteApplicationCommand.ts
@@ -4,7 +4,7 @@ import type { Bot } from "../../../bot.ts";
 export async function deleteApplicationCommand(bot: Bot, id: bigint, guildId?: bigint) {
   await bot.rest.runMethod<undefined>(
     bot.rest,
-    "delete",
+    "DELETE",
     guildId
       ? bot.constants.routes.COMMANDS_GUILD_ID(bot.applicationId, guildId, id)
       : bot.constants.routes.COMMANDS_ID(bot.applicationId, id),

--- a/helpers/interactions/commands/deleteInteractionResponse.ts
+++ b/helpers/interactions/commands/deleteInteractionResponse.ts
@@ -4,7 +4,7 @@ import type { Bot } from "../../../bot.ts";
 export async function deleteInteractionResponse(bot: Bot, token: string, messageId?: bigint) {
   await bot.rest.runMethod<undefined>(
     bot.rest,
-    "delete",
+    "DELETE",
     messageId
       ? bot.constants.routes.INTERACTION_ID_TOKEN_MESSAGE_ID(bot.applicationId, token, messageId)
       : bot.constants.routes.INTERACTION_ORIGINAL_ID_TOKEN(bot.applicationId, token),

--- a/helpers/interactions/commands/editApplicationCommandPermissions.ts
+++ b/helpers/interactions/commands/editApplicationCommandPermissions.ts
@@ -13,7 +13,7 @@ export async function editApplicationCommandPermissions(
 ) {
   const result = await bot.rest.runMethod<DiscordGuildApplicationCommandPermissions>(
     bot.rest,
-    "put",
+    "PUT",
     bot.constants.routes.COMMANDS_PERMISSION(bot.applicationId, guildId, commandId),
     {
       permissions: options,

--- a/helpers/interactions/commands/editInteractionResponse.ts
+++ b/helpers/interactions/commands/editInteractionResponse.ts
@@ -13,7 +13,7 @@ export async function editInteractionResponse(
 ) {
   const result = await bot.rest.runMethod(
     bot.rest,
-    "patch",
+    "PATCH",
     options.messageId
       ? bot.constants.routes.WEBHOOK_MESSAGE(bot.applicationId, token, options.messageId)
       : bot.constants.routes.INTERACTION_ORIGINAL_ID_TOKEN(bot.applicationId, token),

--- a/helpers/interactions/commands/getApplicationCommand.ts
+++ b/helpers/interactions/commands/getApplicationCommand.ts
@@ -5,7 +5,7 @@ import { DiscordApplicationCommand } from "../../../types/discord.ts";
 export async function getApplicationCommand(bot: Bot, commandId: bigint, options?: GetApplicationCommand) {
   const result = await bot.rest.runMethod<DiscordApplicationCommand>(
     bot.rest,
-    "get",
+    "GET",
     options?.guildId
       ? bot.constants.routes.COMMANDS_GUILD_ID(
         bot.applicationId,

--- a/helpers/interactions/commands/getApplicationCommandPermission.ts
+++ b/helpers/interactions/commands/getApplicationCommandPermission.ts
@@ -5,7 +5,7 @@ import { DiscordGuildApplicationCommandPermissions } from "../../../types/discor
 export async function getApplicationCommandPermission(bot: Bot, guildId: bigint, commandId: bigint) {
   const result = await bot.rest.runMethod<DiscordGuildApplicationCommandPermissions>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.COMMANDS_PERMISSION(bot.applicationId, guildId, commandId),
   );
 

--- a/helpers/interactions/commands/getApplicationCommandPermissions.ts
+++ b/helpers/interactions/commands/getApplicationCommandPermissions.ts
@@ -6,7 +6,7 @@ import { Collection } from "../../../util/collection.ts";
 export async function getApplicationCommandPermissions(bot: Bot, guildId: bigint) {
   const result = await bot.rest.runMethod<DiscordGuildApplicationCommandPermissions[]>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.COMMANDS_PERMISSIONS(bot.applicationId, guildId),
   );
 

--- a/helpers/interactions/commands/getApplicationCommands.ts
+++ b/helpers/interactions/commands/getApplicationCommands.ts
@@ -6,7 +6,7 @@ import { DiscordApplicationCommand } from "../../../types/discord.ts";
 export async function getApplicationCommands(bot: Bot, guildId?: bigint) {
   const result = await bot.rest.runMethod<DiscordApplicationCommand[]>(
     bot.rest,
-    "get",
+    "GET",
     guildId
       ? bot.constants.routes.COMMANDS_GUILD(bot.applicationId, guildId)
       : bot.constants.routes.COMMANDS(bot.applicationId),

--- a/helpers/interactions/commands/upsertApplicationCommand.ts
+++ b/helpers/interactions/commands/upsertApplicationCommand.ts
@@ -19,7 +19,7 @@ export async function upsertApplicationCommand(
 ) {
   const result = await bot.rest.runMethod<DiscordApplicationCommand>(
     bot.rest,
-    "patch",
+    "PATCH",
     guildId
       ? bot.constants.routes.COMMANDS_GUILD_ID(bot.applicationId, guildId, commandId)
       : bot.constants.routes.COMMANDS_ID(bot.applicationId, commandId),

--- a/helpers/interactions/commands/upsertApplicationCommands.ts
+++ b/helpers/interactions/commands/upsertApplicationCommands.ts
@@ -21,7 +21,7 @@ export async function upsertApplicationCommands(
 ) {
   const result = await bot.rest.runMethod<DiscordApplicationCommand[]>(
     bot.rest,
-    "put",
+    "PUT",
     guildId
       ? bot.constants.routes.COMMANDS_GUILD(bot.applicationId, guildId)
       : bot.constants.routes.COMMANDS(bot.applicationId),

--- a/helpers/interactions/followups/deleteFollowupMessage.ts
+++ b/helpers/interactions/followups/deleteFollowupMessage.ts
@@ -4,7 +4,7 @@ import { Bot } from "../../../bot.ts";
 export async function deleteFollowupMessage(bot: Bot, interactionToken: string, messageId: bigint) {
   await bot.rest.runMethod<undefined>(
     bot.rest,
-    "delete",
+    "DELETE",
     bot.constants.routes.WEBHOOK_MESSAGE(bot.applicationId, interactionToken, messageId),
   );
 }

--- a/helpers/interactions/followups/editFollowupMessage.ts
+++ b/helpers/interactions/followups/editFollowupMessage.ts
@@ -12,7 +12,7 @@ export async function editFollowupMessage(
 ) {
   const result = await bot.rest.runMethod<DiscordMessage>(
     bot.rest,
-    "patch",
+    "PATCH",
     bot.constants.routes.WEBHOOK_MESSAGE(bot.applicationId, interactionToken, messageId),
     {
       content: options.content,

--- a/helpers/interactions/followups/getFollowupMessage.ts
+++ b/helpers/interactions/followups/getFollowupMessage.ts
@@ -5,7 +5,7 @@ import { DiscordMessage } from "../../../types/discord.ts";
 export async function getFollowupMessage(bot: Bot, interactionToken: string, messageId: bigint) {
   const result = await bot.rest.runMethod<DiscordMessage>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.WEBHOOK_MESSAGE(bot.applicationId, interactionToken, messageId),
   );
 

--- a/helpers/interactions/getOriginalInteractionResponse.ts
+++ b/helpers/interactions/getOriginalInteractionResponse.ts
@@ -5,7 +5,7 @@ import { DiscordMessage } from "../../types/discord.ts";
 export async function getOriginalInteractionResponse(bot: Bot, token: string) {
   const result = await bot.rest.runMethod<DiscordMessage>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.INTERACTION_ORIGINAL_ID_TOKEN(bot.applicationId, token),
   );
 

--- a/helpers/interactions/sendInteractionResponse.ts
+++ b/helpers/interactions/sendInteractionResponse.ts
@@ -99,7 +99,7 @@ export async function sendInteractionResponse(
   if (bot.cache.unrepliedInteractions.delete(id)) {
     return await bot.rest.runMethod<undefined>(
       bot.rest,
-      "post",
+      "POST",
       bot.constants.routes.INTERACTION_ID_TOKEN(id, token),
       {
         type: options.type,
@@ -112,7 +112,7 @@ export async function sendInteractionResponse(
   // If its already been executed, we need to send a followup response
   const result = await bot.rest.runMethod<DiscordMessage>(
     bot.rest,
-    "post",
+    "POST",
     bot.constants.routes.WEBHOOK(bot.applicationId, token),
     { ...data, file: options.data.file },
   );

--- a/helpers/invites/createInvite.ts
+++ b/helpers/invites/createInvite.ts
@@ -6,7 +6,7 @@ import { InviteTargetTypes } from "../../types/shared.ts";
 export async function createInvite(bot: Bot, channelId: bigint, options: CreateChannelInvite = {}) {
   const result = await bot.rest.runMethod<DiscordInvite>(
     bot.rest,
-    "post",
+    "POST",
     bot.constants.routes.CHANNEL_INVITES(channelId),
     {
       max_age: options.maxAge,

--- a/helpers/invites/deleteInvite.ts
+++ b/helpers/invites/deleteInvite.ts
@@ -3,5 +3,5 @@ import { DiscordInviteMetadata } from "../../types/discord.ts";
 
 /** Deletes an invite for the given code. Requires `MANAGE_CHANNELS` or `MANAGE_GUILD` permission */
 export async function deleteInvite(bot: Bot, inviteCode: string) {
-  await bot.rest.runMethod<DiscordInviteMetadata>(bot.rest, "delete", bot.constants.routes.INVITE(inviteCode));
+  await bot.rest.runMethod<DiscordInviteMetadata>(bot.rest, "DELETE", bot.constants.routes.INVITE(inviteCode));
 }

--- a/helpers/invites/getChannelInvites.ts
+++ b/helpers/invites/getChannelInvites.ts
@@ -6,7 +6,7 @@ import { DiscordInviteMetadata } from "../../types/discord.ts";
 export async function getChannelInvites(bot: Bot, channelId: bigint) {
   const result = await bot.rest.runMethod<DiscordInviteMetadata[]>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.CHANNEL_INVITES(channelId),
   );
 

--- a/helpers/invites/getInvite.ts
+++ b/helpers/invites/getInvite.ts
@@ -5,7 +5,7 @@ import { DiscordInviteMetadata } from "../../types/discord.ts";
 export async function getInvite(bot: Bot, inviteCode: string, options?: GetInvite) {
   const result = await bot.rest.runMethod<DiscordInviteMetadata>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.INVITE(inviteCode, options),
   );
 

--- a/helpers/invites/getInvites.ts
+++ b/helpers/invites/getInvites.ts
@@ -6,7 +6,7 @@ import { DiscordInviteMetadata } from "../../types/discord.ts";
 export async function getInvites(bot: Bot, guildId: bigint) {
   const result = await bot.rest.runMethod<DiscordInviteMetadata[]>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.GUILD_INVITES(guildId),
   );
 

--- a/helpers/members/banMember.ts
+++ b/helpers/members/banMember.ts
@@ -4,7 +4,7 @@ import type { Bot } from "../../bot.ts";
 export async function banMember(bot: Bot, guildId: bigint, id: bigint, options?: CreateGuildBan) {
   await bot.rest.runMethod<undefined>(
     bot.rest,
-    "put",
+    "PUT",
     bot.constants.routes.GUILD_BAN(guildId, id),
     options
       ? {

--- a/helpers/members/editBotNickname.ts
+++ b/helpers/members/editBotNickname.ts
@@ -4,7 +4,7 @@ import type { Bot } from "../../bot.ts";
 export async function editBotNickname(bot: Bot, guildId: bigint, options: { nick: string | null; reason?: string }) {
   const response = await bot.rest.runMethod<{ nick: string }>(
     bot.rest,
-    "patch",
+    "PATCH",
     bot.constants.routes.USER_NICK(guildId),
     options,
   );

--- a/helpers/members/editMember.ts
+++ b/helpers/members/editMember.ts
@@ -5,7 +5,7 @@ import { DiscordMemberWithUser } from "../../types/discord.ts";
 export async function editMember(bot: Bot, guildId: bigint, memberId: bigint, options: ModifyGuildMember) {
   const result = await bot.rest.runMethod<DiscordMemberWithUser>(
     bot.rest,
-    "patch",
+    "PATCH",
     bot.constants.routes.GUILD_MEMBER(guildId, memberId),
     {
       nick: options.nick,

--- a/helpers/members/getDmChannel.ts
+++ b/helpers/members/getDmChannel.ts
@@ -5,7 +5,7 @@ import { DiscordChannel } from "../../types/discord.ts";
 export async function getDmChannel(bot: Bot, userId: bigint) {
   if (userId === bot.id) throw new Error(bot.constants.Errors.YOU_CAN_NOT_DM_THE_BOT_ITSELF);
 
-  const dmChannelData = await bot.rest.runMethod<DiscordChannel>(bot.rest, "post", bot.constants.routes.USER_DM(), {
+  const dmChannelData = await bot.rest.runMethod<DiscordChannel>(bot.rest, "POST", bot.constants.routes.USER_DM(), {
     recipient_id: userId.toString(),
   });
 

--- a/helpers/members/getMember.ts
+++ b/helpers/members/getMember.ts
@@ -5,7 +5,7 @@ import { DiscordMemberWithUser } from "../../types/discord.ts";
 export async function getMember(bot: Bot, guildId: bigint, id: bigint) {
   const data = await bot.rest.runMethod<DiscordMemberWithUser>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.GUILD_MEMBER(guildId, id),
   );
 

--- a/helpers/members/getMembers.ts
+++ b/helpers/members/getMembers.ts
@@ -11,7 +11,7 @@ import { Collection } from "../../util/collection.ts";
 export async function getMembers(bot: Bot, guildId: bigint, options: ListGuildMembers) {
   const result = await bot.rest.runMethod<DiscordMemberWithUser[]>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.GUILD_MEMBERS(guildId, options),
   );
 

--- a/helpers/members/kickMember.ts
+++ b/helpers/members/kickMember.ts
@@ -2,7 +2,7 @@ import { Bot } from "../../bot.ts";
 
 /** Kick a member from the server */
 export async function kickMember(bot: Bot, guildId: bigint, memberId: bigint, reason?: string) {
-  await bot.rest.runMethod<undefined>(bot.rest, "delete", bot.constants.routes.GUILD_MEMBER(guildId, memberId), {
+  await bot.rest.runMethod<undefined>(bot.rest, "DELETE", bot.constants.routes.GUILD_MEMBER(guildId, memberId), {
     reason,
   });
 }

--- a/helpers/members/pruneMembers.ts
+++ b/helpers/members/pruneMembers.ts
@@ -11,7 +11,7 @@ export async function pruneMembers(bot: Bot, guildId: bigint, options: BeginGuil
 
   const result = await bot.rest.runMethod<{ pruned: number }>(
     bot.rest,
-    "post",
+    "POST",
     bot.constants.routes.GUILD_PRUNE(guildId),
     {
       days: options.days,

--- a/helpers/members/searchMembers.ts
+++ b/helpers/members/searchMembers.ts
@@ -22,7 +22,7 @@ export async function searchMembers(
 
   const result = await bot.rest.runMethod<DiscordMemberWithUser[]>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.GUILD_MEMBERS_SEARCH(guildId, query, options),
   );
 

--- a/helpers/members/unbanMember.ts
+++ b/helpers/members/unbanMember.ts
@@ -2,5 +2,5 @@ import type { Bot } from "../../bot.ts";
 
 /** Remove the ban for a user. Requires BAN_MEMBERS permission */
 export async function unbanMember(bot: Bot, guildId: bigint, id: bigint) {
-  await bot.rest.runMethod<undefined>(bot.rest, "delete", bot.constants.routes.GUILD_BAN(guildId, id));
+  await bot.rest.runMethod<undefined>(bot.rest, "DELETE", bot.constants.routes.GUILD_BAN(guildId, id));
 }

--- a/helpers/messages/addReaction.ts
+++ b/helpers/messages/addReaction.ts
@@ -10,7 +10,7 @@ export async function addReaction(bot: Bot, channelId: bigint, messageId: bigint
 
   await bot.rest.runMethod<undefined>(
     bot.rest,
-    "put",
+    "PUT",
     bot.constants.routes.CHANNEL_MESSAGE_REACTION_ME(channelId, messageId, reaction),
     {},
   );

--- a/helpers/messages/deleteMessage.ts
+++ b/helpers/messages/deleteMessage.ts
@@ -12,7 +12,7 @@ export async function deleteMessage(
 
   await bot.rest.runMethod<undefined>(
     bot.rest,
-    "delete",
+    "DELETE",
     bot.constants.routes.CHANNEL_MESSAGE(channelId, messageId),
     { reason },
   );

--- a/helpers/messages/deleteMessages.ts
+++ b/helpers/messages/deleteMessages.ts
@@ -10,7 +10,7 @@ export async function deleteMessages(bot: Bot, channelId: bigint, ids: bigint[],
     console.warn(`This endpoint only accepts a maximum of 100 messages. Deleting the first 100 message ids provided.`);
   }
 
-  await bot.rest.runMethod<undefined>(bot.rest, "post", bot.constants.routes.CHANNEL_BULK_DELETE(channelId), {
+  await bot.rest.runMethod<undefined>(bot.rest, "POST", bot.constants.routes.CHANNEL_BULK_DELETE(channelId), {
     messages: ids.splice(0, 100).map((id) => id.toString()),
     reason,
   });

--- a/helpers/messages/editMessage.ts
+++ b/helpers/messages/editMessage.ts
@@ -9,7 +9,7 @@ import { MessageComponentTypes } from "../../types/shared.ts";
 export async function editMessage(bot: Bot, channelId: bigint, messageId: bigint, content: EditMessage) {
   const result = await bot.rest.runMethod<DiscordMessage>(
     bot.rest,
-    "patch",
+    "PATCH",
     bot.constants.routes.CHANNEL_MESSAGE(channelId, messageId),
     {
       content: content.content,

--- a/helpers/messages/getMessage.ts
+++ b/helpers/messages/getMessage.ts
@@ -5,7 +5,7 @@ import { DiscordMessage } from "../../types/discord.ts";
 export async function getMessage(bot: Bot, channelId: bigint, id: bigint) {
   const result = await bot.rest.runMethod<DiscordMessage>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.CHANNEL_MESSAGE(channelId, id),
   );
 

--- a/helpers/messages/getMessages.ts
+++ b/helpers/messages/getMessages.ts
@@ -13,7 +13,7 @@ export async function getMessages(
 
   const result = await bot.rest.runMethod<DiscordMessage[]>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.CHANNEL_MESSAGES(channelId, options),
   );
 

--- a/helpers/messages/getReactions.ts
+++ b/helpers/messages/getReactions.ts
@@ -18,7 +18,7 @@ export async function getReactions(
 
   const users = await bot.rest.runMethod<DiscordUser[]>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.CHANNEL_MESSAGE_REACTION(channelId, messageId, encodeURIComponent(reaction), options),
   );
 

--- a/helpers/messages/pinMessage.ts
+++ b/helpers/messages/pinMessage.ts
@@ -2,5 +2,5 @@ import type { Bot } from "../../bot.ts";
 
 /** Pin a message in a channel. Requires MANAGE_MESSAGES. Max pins allowed in a channel = 50. */
 export async function pinMessage(bot: Bot, channelId: bigint, messageId: bigint) {
-  await bot.rest.runMethod<undefined>(bot.rest, "put", bot.constants.routes.CHANNEL_PIN(channelId, messageId));
+  await bot.rest.runMethod<undefined>(bot.rest, "PUT", bot.constants.routes.CHANNEL_PIN(channelId, messageId));
 }

--- a/helpers/messages/publishMessage.ts
+++ b/helpers/messages/publishMessage.ts
@@ -5,7 +5,7 @@ import { DiscordMessage } from "../../types/discord.ts";
 export async function publishMessage(bot: Bot, channelId: bigint, messageId: bigint) {
   const data = await bot.rest.runMethod<DiscordMessage>(
     bot.rest,
-    "post",
+    "POST",
     bot.constants.routes.CHANNEL_MESSAGE_CROSSPOST(channelId, messageId),
   );
 

--- a/helpers/messages/removeAllReactions.ts
+++ b/helpers/messages/removeAllReactions.ts
@@ -4,7 +4,7 @@ import type { Bot } from "../../bot.ts";
 export async function removeAllReactions(bot: Bot, channelId: bigint, messageId: bigint) {
   await bot.rest.runMethod<undefined>(
     bot.rest,
-    "delete",
+    "DELETE",
     bot.constants.routes.CHANNEL_MESSAGE_REACTIONS(channelId, messageId),
   );
 }

--- a/helpers/messages/removeReaction.ts
+++ b/helpers/messages/removeReaction.ts
@@ -16,7 +16,7 @@ export async function removeReaction(
 
   await bot.rest.runMethod<undefined>(
     bot.rest,
-    "delete",
+    "DELETE",
     options?.userId
       ? bot.constants.routes.CHANNEL_MESSAGE_REACTION_USER(
         channelId,

--- a/helpers/messages/removeReactionEmoji.ts
+++ b/helpers/messages/removeReactionEmoji.ts
@@ -10,7 +10,7 @@ export async function removeReactionEmoji(bot: Bot, channelId: bigint, messageId
 
   await bot.rest.runMethod<undefined>(
     bot.rest,
-    "delete",
+    "DELETE",
     bot.constants.routes.CHANNEL_MESSAGE_REACTION(channelId, messageId, reaction),
   );
 }

--- a/helpers/messages/sendMessage.ts
+++ b/helpers/messages/sendMessage.ts
@@ -8,7 +8,7 @@ import { Embed } from "../../transformers/embed.ts";
 export async function sendMessage(bot: Bot, channelId: bigint, content: CreateMessage) {
   const result = await bot.rest.runMethod<DiscordMessage>(
     bot.rest,
-    "post",
+    "POST",
     bot.constants.routes.CHANNEL_MESSAGES(channelId),
     {
       content: content.content,

--- a/helpers/messages/unpinMessage.ts
+++ b/helpers/messages/unpinMessage.ts
@@ -2,5 +2,5 @@
 import type { Bot } from "../../bot.ts";
 
 export async function unpinMessage(bot: Bot, channelId: bigint, messageId: bigint) {
-  await bot.rest.runMethod<undefined>(bot.rest, "delete", bot.constants.routes.CHANNEL_PIN(channelId, messageId));
+  await bot.rest.runMethod<undefined>(bot.rest, "DELETE", bot.constants.routes.CHANNEL_PIN(channelId, messageId));
 }

--- a/helpers/misc/editBotProfile.ts
+++ b/helpers/misc/editBotProfile.ts
@@ -7,7 +7,7 @@ import { DiscordUser } from "../../types/discord.ts";
 export async function editBotProfile(bot: Bot, options: { username?: string; botAvatarURL?: string | null }) {
   const avatar = options?.botAvatarURL ? await bot.utils.urlToBase64(options?.botAvatarURL) : options?.botAvatarURL;
 
-  const result = await bot.rest.runMethod<DiscordUser>(bot.rest, "patch", bot.constants.routes.USER_BOT(), {
+  const result = await bot.rest.runMethod<DiscordUser>(bot.rest, "PATCH", bot.constants.routes.USER_BOT(), {
     username: options.username?.trim(),
     avatar,
   });

--- a/helpers/misc/getGatewayBot.ts
+++ b/helpers/misc/getGatewayBot.ts
@@ -3,7 +3,7 @@ import { DiscordGetGatewayBot } from "../../types/discord.ts";
 
 /** Get the bots Gateway metadata that can help during the operation of large or sharded bots. */
 export async function getGatewayBot(bot: Bot) {
-  const result = await bot.rest.runMethod<DiscordGetGatewayBot>(bot.rest, "get", bot.constants.routes.GATEWAY_BOT());
+  const result = await bot.rest.runMethod<DiscordGetGatewayBot>(bot.rest, "GET", bot.constants.routes.GATEWAY_BOT());
 
   return bot.transformers.gatewayBot(result);
 }

--- a/helpers/misc/getUser.ts
+++ b/helpers/misc/getUser.ts
@@ -3,7 +3,7 @@ import { DiscordUser } from "../../types/discord.ts";
 
 /** This function will return the raw user payload in the rare cases you need to fetch a user directly from the API. */
 export async function getUser(bot: Bot, userId: bigint) {
-  const result = await bot.rest.runMethod<DiscordUser>(bot.rest, "get", bot.constants.routes.USER(userId));
+  const result = await bot.rest.runMethod<DiscordUser>(bot.rest, "GET", bot.constants.routes.USER(userId));
 
   return bot.transformers.user(bot, result);
 }

--- a/helpers/misc/nitroStickerPacks.ts
+++ b/helpers/misc/nitroStickerPacks.ts
@@ -5,7 +5,7 @@ import { DiscordStickerPack } from "../../types/discord.ts";
 export async function nitroStickerPacks(bot: Bot) {
   const packs = await bot.rest.runMethod<DiscordStickerPack[]>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.NITRO_STICKER_PACKS(),
   );
 

--- a/helpers/oauth/getApplicationInfo.ts
+++ b/helpers/oauth/getApplicationInfo.ts
@@ -5,7 +5,7 @@ import { DiscordApplication } from "../../types/discord.ts";
 export async function getApplicationInfo(bot: Bot) {
   const result = await bot.rest.runMethod<DiscordApplication>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.OAUTH2_APPLICATION(),
   );
 

--- a/helpers/roles/addRole.ts
+++ b/helpers/roles/addRole.ts
@@ -4,7 +4,7 @@ import type { Bot } from "../../bot.ts";
 export async function addRole(bot: Bot, guildId: bigint, memberId: bigint, roleId: bigint, reason?: string) {
   await bot.rest.runMethod<undefined>(
     bot.rest,
-    "put",
+    "PUT",
     bot.constants.routes.GUILD_MEMBER_ROLE(guildId, memberId, roleId),
     { reason },
   );

--- a/helpers/roles/createRole.ts
+++ b/helpers/roles/createRole.ts
@@ -4,7 +4,7 @@ import { PermissionStrings } from "../../types/shared.ts";
 
 /** Create a new role for the guild. Requires the MANAGE_ROLES permission. */
 export async function createRole(bot: Bot, guildId: bigint, options: CreateGuildRole, reason?: string) {
-  const result = await bot.rest.runMethod<DiscordRole>(bot.rest, "post", bot.constants.routes.GUILD_ROLES(guildId), {
+  const result = await bot.rest.runMethod<DiscordRole>(bot.rest, "POST", bot.constants.routes.GUILD_ROLES(guildId), {
     name: options.name,
     color: options.color,
     hoist: options.hoist,

--- a/helpers/roles/deleteRole.ts
+++ b/helpers/roles/deleteRole.ts
@@ -2,5 +2,5 @@ import type { Bot } from "../../bot.ts";
 
 /** Delete a guild role. Requires the MANAGE_ROLES permission. */
 export async function deleteRole(bot: Bot, guildId: bigint, id: bigint) {
-  await bot.rest.runMethod<undefined>(bot.rest, "delete", bot.constants.routes.GUILD_ROLE(guildId, id));
+  await bot.rest.runMethod<undefined>(bot.rest, "DELETE", bot.constants.routes.GUILD_ROLE(guildId, id));
 }

--- a/helpers/roles/editRole.ts
+++ b/helpers/roles/editRole.ts
@@ -6,7 +6,7 @@ import { PermissionStrings } from "../../types/shared.ts";
 export async function editRole(bot: Bot, guildId: bigint, id: bigint, options: EditGuildRole) {
   const result = await bot.rest.runMethod<DiscordRole>(
     bot.rest,
-    "patch",
+    "PATCH",
     bot.constants.routes.GUILD_ROLE(guildId, id),
     {
       name: options.name,

--- a/helpers/roles/getRoles.ts
+++ b/helpers/roles/getRoles.ts
@@ -7,7 +7,7 @@ import { DiscordRole } from "../../types/discord.ts";
  * ⚠️ **If you need this, you are probably doing something wrong. This is not intended for use. Your roles will be cached in your guild.**
  */
 export async function getRoles(bot: Bot, guildId: bigint) {
-  const result = await bot.rest.runMethod<DiscordRole[]>(bot.rest, "get", bot.constants.routes.GUILD_ROLES(guildId));
+  const result = await bot.rest.runMethod<DiscordRole[]>(bot.rest, "GET", bot.constants.routes.GUILD_ROLES(guildId));
 
   const roleStructures = result.map((role) => bot.transformers.role(bot, { role, guildId }));
 

--- a/helpers/roles/modifyRolePositions.ts
+++ b/helpers/roles/modifyRolePositions.ts
@@ -6,7 +6,7 @@ import { Collection } from "../../util/collection.ts";
 export async function modifyRolePositions(bot: Bot, guildId: bigint, options: ModifyRolePositions[]) {
   const roles = await bot.rest.runMethod<DiscordRole[]>(
     bot.rest,
-    "patch",
+    "PATCH",
     bot.constants.routes.GUILD_ROLES(guildId),
     options,
   );

--- a/helpers/roles/removeRole.ts
+++ b/helpers/roles/removeRole.ts
@@ -4,7 +4,7 @@ import type { Bot } from "../../bot.ts";
 export async function removeRole(bot: Bot, guildId: bigint, memberId: bigint, roleId: bigint, reason?: string) {
   await bot.rest.runMethod<undefined>(
     bot.rest,
-    "delete",
+    "DELETE",
     bot.constants.routes.GUILD_MEMBER_ROLE(guildId, memberId, roleId),
     { reason },
   );

--- a/helpers/templates/createGuildFromTemplate.ts
+++ b/helpers/templates/createGuildFromTemplate.ts
@@ -12,7 +12,7 @@ export async function createGuildFromTemplate(bot: Bot, templateCode: string, da
 
   const createdGuild = await bot.rest.runMethod<DiscordGuild>(
     bot.rest,
-    "post",
+    "POST",
     bot.constants.routes.TEMPLATE(templateCode),
     data,
   );

--- a/helpers/templates/createGuildTemplate.ts
+++ b/helpers/templates/createGuildTemplate.ts
@@ -13,7 +13,7 @@ export async function createGuildTemplate(bot: Bot, guildId: bigint, data: Creat
 
   return await bot.rest.runMethod<DiscordTemplate>(
     bot.rest,
-    "post",
+    "POST",
     bot.constants.routes.GUILD_TEMPLATES(guildId),
     data,
   );

--- a/helpers/templates/deleteGuildTemplate.ts
+++ b/helpers/templates/deleteGuildTemplate.ts
@@ -8,7 +8,7 @@ import { DiscordTemplate } from "../../types/discord.ts";
 export async function deleteGuildTemplate(bot: Bot, guildId: bigint, templateCode: string) {
   await bot.rest.runMethod<DiscordTemplate>(
     bot.rest,
-    "delete",
+    "DELETE",
     bot.constants.routes.GUILD_TEMPLATE(guildId, templateCode),
   );
 }

--- a/helpers/templates/editGuildTemplate.ts
+++ b/helpers/templates/editGuildTemplate.ts
@@ -16,7 +16,7 @@ export async function editGuildTemplate(bot: Bot, guildId: bigint, templateCode:
 
   return await bot.rest.runMethod<DiscordTemplate>(
     bot.rest,
-    "patch",
+    "PATCH",
     bot.constants.routes.GUILD_TEMPLATE(guildId, templateCode),
     {
       name: data.name,

--- a/helpers/templates/getGuildTemplates.ts
+++ b/helpers/templates/getGuildTemplates.ts
@@ -6,7 +6,7 @@ import { DiscordTemplate } from "../../types/discord.ts";
 export async function getGuildTemplates(bot: Bot, guildId: bigint) {
   const templates = await bot.rest.runMethod<DiscordTemplate[]>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.GUILD_TEMPLATES(guildId),
   );
 

--- a/helpers/templates/getTemplate.ts
+++ b/helpers/templates/getTemplate.ts
@@ -5,7 +5,7 @@ import { DiscordTemplate } from "../../types/discord.ts";
 export async function getTemplate(bot: Bot, templateCode: string) {
   const result = await bot.rest.runMethod<DiscordTemplate>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.TEMPLATE(templateCode),
   );
 

--- a/helpers/templates/syncGuildTemplate.ts
+++ b/helpers/templates/syncGuildTemplate.ts
@@ -8,7 +8,7 @@ import { DiscordTemplate } from "../../types/discord.ts";
 export async function syncGuildTemplate(bot: Bot, guildId: bigint, templateCode: string) {
   return await bot.rest.runMethod<DiscordTemplate>(
     bot.rest,
-    "put",
+    "PUT",
     bot.constants.routes.GUILD_TEMPLATE(guildId, templateCode),
   );
 }

--- a/helpers/webhooks/createWebhook.ts
+++ b/helpers/webhooks/createWebhook.ts
@@ -9,7 +9,7 @@ import { DiscordWebhook } from "../../types/discord.ts";
 export async function createWebhook(bot: Bot, channelId: bigint, options: CreateWebhook) {
   const result = await bot.rest.runMethod<DiscordWebhook>(
     bot.rest,
-    "post",
+    "POST",
     bot.constants.routes.CHANNEL_WEBHOOKS(channelId),
     {
       name: options.name,

--- a/helpers/webhooks/deleteWebhook.ts
+++ b/helpers/webhooks/deleteWebhook.ts
@@ -2,5 +2,5 @@ import type { Bot } from "../../bot.ts";
 
 /** Delete a webhook permanently. Requires the `MANAGE_WEBHOOKS` permission. Returns a undefined on success */
 export async function deleteWebhook(bot: Bot, webhookId: bigint, reason?: string) {
-  await bot.rest.runMethod<undefined>(bot.rest, "delete", bot.constants.routes.WEBHOOK_ID(webhookId), { reason });
+  await bot.rest.runMethod<undefined>(bot.rest, "DELETE", bot.constants.routes.WEBHOOK_ID(webhookId), { reason });
 }

--- a/helpers/webhooks/deleteWebhookMessage.ts
+++ b/helpers/webhooks/deleteWebhookMessage.ts
@@ -14,7 +14,7 @@ export async function deleteWebhookMessage(
 ) {
   await bot.rest.runMethod<undefined>(
     bot.rest,
-    "delete",
+    "DELETE",
     bot.constants.routes.WEBHOOK_MESSAGE(webhookId, webhookToken, messageId, options),
   );
 }

--- a/helpers/webhooks/deleteWebhookWithToken.ts
+++ b/helpers/webhooks/deleteWebhookWithToken.ts
@@ -2,5 +2,5 @@ import type { Bot } from "../../bot.ts";
 
 /** Delete a webhook permanently. Returns a undefined on success */
 export async function deleteWebhookWithToken(bot: Bot, webhookId: bigint, webhookToken: string) {
-  await bot.rest.runMethod<undefined>(bot.rest, "delete", bot.constants.routes.WEBHOOK(webhookId, webhookToken));
+  await bot.rest.runMethod<undefined>(bot.rest, "DELETE", bot.constants.routes.WEBHOOK(webhookId, webhookToken));
 }

--- a/helpers/webhooks/editWebhook.ts
+++ b/helpers/webhooks/editWebhook.ts
@@ -5,7 +5,7 @@ import { DiscordWebhook } from "../../types/discord.ts";
 export async function editWebhook(bot: Bot, webhookId: bigint, options: ModifyWebhook) {
   const result = await bot.rest.runMethod<DiscordWebhook>(
     bot.rest,
-    "patch",
+    "PATCH",
     bot.constants.routes.WEBHOOK_ID(webhookId),
     {
       name: options.name,

--- a/helpers/webhooks/editWebhookMessage.ts
+++ b/helpers/webhooks/editWebhookMessage.ts
@@ -13,7 +13,7 @@ export async function editWebhookMessage(
 ) {
   const result = await bot.rest.runMethod<DiscordMessage>(
     bot.rest,
-    "patch",
+    "PATCH",
     options.messageId
       ? bot.constants.routes.WEBHOOK_MESSAGE(webhookId, webhookToken, options.messageId, options)
       : bot.constants.routes.WEBHOOK_MESSAGE_ORIGINAL(webhookId, webhookToken, options),

--- a/helpers/webhooks/editWebhookWithToken.ts
+++ b/helpers/webhooks/editWebhookWithToken.ts
@@ -11,7 +11,7 @@ export async function editWebhookWithToken(
 ) {
   const result = await bot.rest.runMethod<DiscordWebhook>(
     bot.rest,
-    "patch",
+    "PATCH",
     bot.constants.routes.WEBHOOK(webhookId, webhookToken),
     {
       name: options.name,

--- a/helpers/webhooks/getWebhook.ts
+++ b/helpers/webhooks/getWebhook.ts
@@ -5,7 +5,7 @@ import { DiscordWebhook } from "../../types/discord.ts";
 export async function getWebhook(bot: Bot, webhookId: bigint) {
   const result = await bot.rest.runMethod<DiscordWebhook>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.WEBHOOK_ID(webhookId),
   );
 

--- a/helpers/webhooks/getWebhookMessage.ts
+++ b/helpers/webhooks/getWebhookMessage.ts
@@ -15,7 +15,7 @@ export async function getWebhookMessage(
 ) {
   const result = await bot.rest.runMethod<DiscordMessage>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.WEBHOOK_MESSAGE(webhookId, webhookToken, messageId, options),
   );
 

--- a/helpers/webhooks/getWebhookWithToken.ts
+++ b/helpers/webhooks/getWebhookWithToken.ts
@@ -5,7 +5,7 @@ import { DiscordWebhook } from "../../types/discord.ts";
 export async function getWebhookWithToken(bot: Bot, webhookId: bigint, token: string) {
   const result = await bot.rest.runMethod<DiscordWebhook>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.WEBHOOK(webhookId, token),
   );
 

--- a/helpers/webhooks/getWebhooks.ts
+++ b/helpers/webhooks/getWebhooks.ts
@@ -6,7 +6,7 @@ import { Collection } from "../../util/collection.ts";
 export async function getWebhooks(bot: Bot, guildId: bigint) {
   const result = await bot.rest.runMethod<DiscordWebhook[]>(
     bot.rest,
-    "get",
+    "GET",
     bot.constants.routes.GUILD_WEBHOOKS(guildId),
   );
 

--- a/helpers/webhooks/sendWebhook.ts
+++ b/helpers/webhooks/sendWebhook.ts
@@ -16,7 +16,7 @@ export async function sendWebhook(bot: Bot, webhookId: bigint, webhookToken: str
 
   const result = await bot.rest.runMethod<DiscordMessage>(
     bot.rest,
-    "post",
+    "POST",
     bot.constants.routes.WEBHOOK(webhookId, webhookToken, options),
     {
       wait: options.wait,

--- a/plugins/helpers/src/getMembersPaginated.ts
+++ b/plugins/helpers/src/getMembersPaginated.ts
@@ -32,7 +32,7 @@ export async function getMembersPaginated(
 
     const result = await bot.rest.runMethod<DiscordMemberWithUser[]>(
       bot.rest,
-      "get",
+      "GET",
       bot.constants.routes.GUILD_MEMBERS(guildId, {
         limit: membersLeft > 1000 ? 1000 : membersLeft,
         after: options.after,

--- a/plugins/helpers/src/suppressEmbeds.ts
+++ b/plugins/helpers/src/suppressEmbeds.ts
@@ -8,7 +8,7 @@ export async function suppressEmbeds(
 ) {
   const result = await bot.rest.runMethod<DiscordMessage>(
     bot.rest,
-    "patch",
+    "PATCH",
     bot.constants.routes.CHANNEL_MESSAGE(channelId, messageId),
     { flags: 4 },
   );

--- a/plugins/helpers/src/threads.ts
+++ b/plugins/helpers/src/threads.ts
@@ -24,7 +24,7 @@ export async function unlockThread(bot: Bot, threadId: bigint) {
 export async function editThread(bot: Bot, threadId: bigint, options: ModifyThread, reason?: string) {
   const result = await bot.rest.runMethod<DiscordChannel>(
     bot.rest,
-    "patch",
+    "PATCH",
     bot.constants.routes.CHANNEL(threadId),
     {
       name: options.name,

--- a/rest/createRequestBody.ts
+++ b/rest/createRequestBody.ts
@@ -18,7 +18,7 @@ export function createRequestBody(rest: RestManager, queuedRequest: { request: R
   }
 
   // GET METHODS SHOULD NOT HAVE A BODY
-  if (queuedRequest.request.method.toUpperCase() === "GET") {
+  if (queuedRequest.request.method === "GET") {
     queuedRequest.payload.body = undefined;
   }
 
@@ -53,6 +53,6 @@ export function createRequestBody(rest: RestManager, queuedRequest: { request: R
   return {
     headers,
     body: (queuedRequest.payload.body?.file ?? JSON.stringify(queuedRequest.payload.body)) as FormData | string,
-    method: queuedRequest.request.method.toUpperCase(),
+    method: queuedRequest.request.method,
   };
 }

--- a/rest/processQueue.ts
+++ b/rest/processQueue.ts
@@ -12,7 +12,7 @@ export function processQueue(rest: RestManager, id: string) {
     // IF THIS DOESN'T HAVE ANY ITEMS JUST CANCEL, THE CLEANER WILL REMOVE IT.
     if (!queuedRequest) break;
 
-    const basicURL = rest.simplifyUrl(queuedRequest.request.url, queuedRequest.request.method.toUpperCase());
+    const basicURL = rest.simplifyUrl(queuedRequest.request.url, queuedRequest.request.method);
 
     // IF THIS URL IS STILL RATE LIMITED, TRY AGAIN
     const urlResetIn = rest.checkRateLimits(rest, basicURL);

--- a/rest/runMethod.ts
+++ b/rest/runMethod.ts
@@ -4,7 +4,7 @@ import { RestRequestRejection, RestRequestResponse } from "./rest.ts";
 
 export async function runMethod<T = any>(
   rest: RestManager,
-  method: "get" | "post" | "put" | "delete" | "patch",
+  method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH",
   route: string,
   body?: unknown,
   options?: {
@@ -35,7 +35,7 @@ export async function runMethod<T = any>(
         Authorization: rest.secretKey,
         "Content-Type": "application/json",
       },
-      method: method.toUpperCase(),
+      method,
     }).catch((error) => {
       errorStack.message = (error as Error)?.message;
       console.error(error);

--- a/rest/runProxyMethod.ts
+++ b/rest/runProxyMethod.ts
@@ -7,7 +7,7 @@ export type ProxyMethodResponse<T> = Omit<RestRequestResponse | RestRequestRejec
 // this file could also be moved to a plugin.
 export async function runProxyMethod<T = any>(
   rest: RestManager,
-  method: "get" | "post" | "put" | "delete" | "patch",
+  method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH",
   url: string,
   body?: unknown,
   retryCount = 0,

--- a/site/docs/big-bot-guide/gateway.md
+++ b/site/docs/big-bot-guide/gateway.md
@@ -91,7 +91,7 @@ const rest = createRestManager({
 });
 
 // CALL THE REST PROCESS TO GET GATEWAY DATA
-const result = await rest.runMethod(rest, "get", endpoints.GATEWAY_BOT).then((res) => ({
+const result = await rest.runMethod(rest, "GET", endpoints.GATEWAY_BOT).then((res) => ({
   url: res.url,
   shards: res.shards,
   sessionStartLimit: {
@@ -302,7 +302,7 @@ async function handleInteractionQueueing(gateway: GatewayManager, data: GatewayP
   if ([InteractionTypes.ModalSubmit, InteractionTypes.ApplicationCommandAutocomplete].includes(interaction.type)) {
     return await rest.runMethod(
       rest,
-      "post",
+      "POST",
       endpoints.INTERACTION_ID_TOKEN(BigInt(interaction.id), interaction.token),
       {
         type: InteractionResponseTypes.ChannelMessageWithSource,
@@ -314,7 +314,7 @@ async function handleInteractionQueueing(gateway: GatewayManager, data: GatewayP
     );
   }
 
-  await rest.runMethod(rest, "post", endpoints.INTERACTION_ID_TOKEN(BigInt(interaction.id), interaction.token), {
+  await rest.runMethod(rest, "POST", endpoints.INTERACTION_ID_TOKEN(BigInt(interaction.id), interaction.token), {
     // MESSAGE COMPONENTS NEED SPECIAL DEFER
     type: InteractionTypes.MessageComponent === interaction.type
       ? InteractionResponseTypes.DeferredUpdateMessage
@@ -474,7 +474,7 @@ async function handleInteractionQueueing(gateway: GatewayManager, data: GatewayP
   if ([InteractionTypes.ModalSubmit, InteractionTypes.ApplicationCommandAutocomplete].includes(interaction.type)) {
     return await rest.runMethod(
       rest,
-      "post",
+      "POST",
       endpoints.INTERACTION_ID_TOKEN(BigInt(interaction.id), interaction.token),
       {
         type: InteractionResponseTypes.ChannelMessageWithSource,
@@ -486,7 +486,7 @@ async function handleInteractionQueueing(gateway: GatewayManager, data: GatewayP
     );
   }
 
-  await rest.runMethod(rest, "post", endpoints.INTERACTION_ID_TOKEN(BigInt(interaction.id), interaction.token), {
+  await rest.runMethod(rest, "POST", endpoints.INTERACTION_ID_TOKEN(BigInt(interaction.id), interaction.token), {
     // MESSAGE COMPONENTS NEED SPECIAL DEFER
     type: InteractionTypes.MessageComponent === interaction.type
       ? InteractionResponseTypes.DeferredUpdateMessage

--- a/template/bigbot/src/gateway/mod.ts
+++ b/template/bigbot/src/gateway/mod.ts
@@ -21,7 +21,7 @@ const workers = new Collection<number, Worker>();
 
 async function startGateway() {
   // CALL THE REST PROCESS TO GET GATEWAY DATA
-  const result = await rest.runMethod(rest, "get", endpoints.GATEWAY_BOT()).then((res) => ({
+  const result = await rest.runMethod(rest, "GET", endpoints.GATEWAY_BOT()).then((res) => ({
     url: res.url,
     shards: res.shards,
     sessionStartLimit: {
@@ -125,7 +125,7 @@ startGateway();
 setInterval(async () => {
   console.log("GW DEBUG", "[Resharding] Checking if resharding is needed.");
 
-  const results = await rest.runMethod(rest, "get", endpoints.GATEWAY_BOT()).then((res) => ({
+  const results = await rest.runMethod(rest, "GET", endpoints.GATEWAY_BOT()).then((res) => ({
     url: res.url,
     shards: res.shards,
     sessionStartLimit: {

--- a/template/bigbot/src/gateway/mod.ts
+++ b/template/bigbot/src/gateway/mod.ts
@@ -21,7 +21,7 @@ const workers = new Collection<number, Worker>();
 
 async function startGateway() {
   // CALL THE REST PROCESS TO GET GATEWAY DATA
-  const result = await rest.runMethod(rest, "GET", endpoints.GATEWAY_BOT()).then((res) => ({
+  const result = await rest.runMethod(rest, "get", endpoints.GATEWAY_BOT()).then((res) => ({
     url: res.url,
     shards: res.shards,
     sessionStartLimit: {
@@ -125,7 +125,7 @@ startGateway();
 setInterval(async () => {
   console.log("GW DEBUG", "[Resharding] Checking if resharding is needed.");
 
-  const results = await rest.runMethod(rest, "GET", endpoints.GATEWAY_BOT()).then((res) => ({
+  const results = await rest.runMethod(rest, "get", endpoints.GATEWAY_BOT()).then((res) => ({
     url: res.url,
     shards: res.shards,
     sessionStartLimit: {

--- a/template/bigbot/src/rest/mod.ts
+++ b/template/bigbot/src/rest/mod.ts
@@ -80,4 +80,4 @@ async function handleRequest(conn: Deno.Conn) {
   }
 }
 
-type RequestMethod = "POST" | "PUT" | "DELETE" | "PATCH";
+type RequestMethod = "post" | "put" | "delete" | "patch";

--- a/template/bigbot/src/rest/mod.ts
+++ b/template/bigbot/src/rest/mod.ts
@@ -80,4 +80,4 @@ async function handleRequest(conn: Deno.Conn) {
   }
 }
 
-type RequestMethod = "post" | "put" | "delete" | "patch";
+type RequestMethod = "POST" | "PUT" | "DELETE" | "PATCH";


### PR DESCRIPTION
There is no need for us to pass the methods in lower case and then use the `toUpperCase()` method everywhere. Therefore this PR changes every lowercase method to be uppercase (eg. `"get"` => `"GET"`).