### PR TITLE
update DiscordApplicationCommand

### DIFF
--- a/testss/emojis/getEmoji.test.ts
+++ b/testss/emojis/getEmoji.test.ts
@@ -17,7 +17,7 @@ Deno.test({
 
     const exists = await bot.helpers.getEmoji(CACHED_COMMUNITY_GUILD_ID, emoji.id);
     assertExists(exists.id);
-    assertEquals(emoji.id, exists.id)
+    assertEquals(emoji.id, exists.id);
 
     await bot.helpers.deleteEmoji(CACHED_COMMUNITY_GUILD_ID, emoji.id);
   },

--- a/types/discord.ts
+++ b/types/discord.ts
@@ -1715,9 +1715,9 @@ export interface DiscordApplicationCommand {
   /** Parameters for the command, max of 25 */
   options?: DiscordApplicationCommandOption[];
   /** Set of permissions represented as a bit set */
-  default_member_permissions?: string | null;
+  default_member_permissions: string | null;
   /** Indicates whether the command is available in DMs with the app, only for globally-scoped commands. By default, commands are visible. */
-  dm_permission?: boolean | null;
+  dm_permission?: boolean;
   /** Auto incrementing version identifier updated during substantial record changes */
   version: string;
 }


### PR DESCRIPTION
Closes: #2254 
Upstream: https://github.com/discord/discord-api-docs/commit/ad81ed31372245d2b4f7006924bd8dd68130a87f

`dm_permission` no longer nullable
`default_member_permissions` no longer optional