### PR TITLE
fix: wrong USER_GUILDS url

### DIFF
--- a/util/constants.ts
+++ b/util/constants.ts
@@ -470,7 +470,7 @@ export const routes = {
     return `/users/@me`;
   },
   USER_GUILDS: () => {
-    return `/@me/guilds`;
+    return `/users/@me/guilds`;
   },
   // TODO: move this away
   USER_AVATAR: (userId: bigint, icon: string) => {


### PR DESCRIPTION
This PR fixes an endpoint with a wrong URL
https://discord.com/developers/docs/resources/user#get-current-user-guilds