### PR TITLE
Image Size 4096

### DIFF
--- a/helpers/members/avatarUrl.ts
+++ b/helpers/members/avatarUrl.ts
@@ -30,4 +30,4 @@ export function avatarURL(
 export type ImageFormat = "jpg" | "jpeg" | "png" | "webp" | "gif" | "json";
 
 /** https://discord.com/developers/docs/reference#image-formatting */
-export type ImageSize = 16 | 32 | 64 | 128 | 256 | 512 | 1024 | 2048;
+export type ImageSize = 16 | 32 | 64 | 128 | 256 | 512 | 1024 | 2048 | 4096;

--- a/transformers/component.ts
+++ b/transformers/component.ts
@@ -75,5 +75,3 @@ export interface Component {
   /** a list of child components */
   components?: Component[];
 }
-
-


### PR DESCRIPTION
https://discord.com/developers/docs/reference#image-formatting
Image size can be any power of two between 16 and 4096.