### PR TITLE
Simplify fetchMembers

### DIFF
--- a/helpers/members/fetchMembers.ts
+++ b/helpers/members/fetchMembers.ts
@@ -1,5 +1,6 @@
 import type { Bot } from "../../bot.ts";
 import { GatewayIntents, GatewayOpcodes } from "../../types/shared.ts";
+import { calculateShardId } from "../../util/calculateShardId.ts";
 
 /**
  * Highly recommended to use this function to fetch members instead of getMember from REST.
@@ -9,7 +10,6 @@ import { GatewayIntents, GatewayOpcodes } from "../../types/shared.ts";
 export function fetchMembers(
   bot: Bot,
   guildId: bigint,
-  shardId: number,
   options?: Omit<RequestGuildMembers, "guildId">,
 ) {
   // You can request 1 member without the intent
@@ -21,6 +21,8 @@ export function fetchMembers(
   if (options?.userIds?.length) {
     options.limit = options.userIds.length;
   }
+
+  const shardId = calculateShardId(bot.gateway, guildId);
 
   return new Promise((resolve) => {
     const nonce = `${guildId}-${Date.now()}`;


### PR DESCRIPTION
**BREAKING**
removes the ShardId parameter and invokes a Util function to calculate the ShardId