### PR TITLE
add application_commands to audit log structure

### DIFF
--- a/helpers/guilds/getAuditLogs.ts
+++ b/helpers/guilds/getAuditLogs.ts
@@ -1,4 +1,5 @@
 import type { Bot } from "../../bot.ts";
+import { ApplicationCommand } from "../../transformers/applicationCommand.ts";
 import { AuditLogEntry } from "../../transformers/auditLogEntry.ts";
 import { AutoModerationRule } from "../../transformers/automodRule.ts";
 import { Channel } from "../../transformers/channel.ts";
@@ -17,6 +18,7 @@ export type AuditLog = {
   threads: Channel[];
   users: User[];
   webhooks: Webhook[];
+  applicationCommands: ApplicationCommand[];
 };
 
 /** Returns the audit logs for the guild. Requires VIEW_AUDIT_LOGS permission */
@@ -68,6 +70,9 @@ export async function getAuditLogs(bot: Bot, guildId: bigint, options?: GetGuild
     threads: result.threads.map((thread) => bot.transformers.channel(bot, { channel: thread, guildId })),
     users: result.users.map((user) => bot.transformers.user(bot, user)),
     webhooks: result.webhooks.map((hook) => bot.transformers.webhook(bot, hook)),
+    applicationCommands: result.application_commands.map((applicationCommand) =>
+      bot.transformers.applicationCommand(bot, applicationCommand)
+    ),
   };
 }
 

--- a/types/discord.ts
+++ b/types/discord.ts
@@ -17,7 +17,6 @@ import {
   GuildNsfwLevel,
   IntegrationExpireBehaviors,
   InteractionTypes,
-  Locales,
   Localization,
   MessageActivityTypes,
   MessageComponentTypes,
@@ -1404,6 +1403,8 @@ export interface DiscordAuditLog {
   guild_scheduled_events?: DiscordScheduledEvent[];
   /** List of auto moderation rules referenced in the audit log */
   auto_moderation_rules?: DiscordAutoModerationRule[];
+  /** List of application commands referenced in the audit log */
+  application_commands: DiscordApplicationCommand[];
 }
 
 export interface DiscordAutoModerationRule {


### PR DESCRIPTION
closes #2407 
upstream https://github.com/discord/discord-api-docs/commit/b3a575c8613b848ee4f5f91c1c297dd45ef5fca2