### PR TITLE
Fixes getReations by removing the double URI encode

### DIFF
--- a/helpers/messages/getReactions.ts
+++ b/helpers/messages/getReactions.ts
@@ -20,7 +20,7 @@ export async function getReactions(
   const results = await bot.rest.runMethod<DiscordUser[]>(
     bot.rest,
     "GET",
-    bot.constants.routes.CHANNEL_MESSAGE_REACTION(channelId, messageId, encodeURIComponent(reaction), options),
+    bot.constants.routes.CHANNEL_MESSAGE_REACTION(channelId, messageId, reaction, options),
   );
 
   return new Collection(


### PR DESCRIPTION
[util/routes.ts](https://github.com/discordeno/discordeno/blob/aca0e3cf1b74db1b39ff30897ae18ab198aab18b/util/routes.ts#L74) already takes care of URI encoding the emoji in the request.  This PR removes the extra URI encode to let the getReactions function work.

This fix was discussed on discord [here](https://discord.com/channels/785384884197392384/1016114488958791751/1016114491953532968).