### PR TITLE
Fixes getReactions again.

### DIFF
--- a/helpers/messages/reactions/getReactions.ts
+++ b/helpers/messages/reactions/getReactions.ts
@@ -28,7 +28,7 @@ export async function getReactions(
   const results = await bot.rest.runMethod<DiscordUser[]>(
     bot.rest,
     "GET",
-    bot.constants.routes.CHANNEL_MESSAGE_REACTION(channelId, messageId, encodeURIComponent(reaction), options),
+    bot.constants.routes.CHANNEL_MESSAGE_REACTION(channelId, messageId, reaction, options),
   );
 
   return new Collection(

--- a/util/constants.ts
+++ b/util/constants.ts
@@ -6,7 +6,7 @@ export const API_VERSION = 10;
 
 // TODO: update this version
 /** https://github.com/discordeno/discordeno/releases */
-export const DISCORDENO_VERSION = "14.0.0";
+export const DISCORDENO_VERSION = "14.0.1";
 
 /** https://discord.com/developers/docs/reference#user-agent */
 export const USER_AGENT = `DiscordBot (https://github.com/discordeno/discordeno, v${DISCORDENO_VERSION})`;


### PR DESCRIPTION
Looks like the fix in [my previous PR](https://github.com/discordeno/discordeno/pull/2438) got lost in a reorganization done right before the v14 release.  This PR puts the fix back.