### PR TITLE
plugins/validations: sendMessage at least one

### DIFF
--- a/helpers/messages/sendMessage.ts
+++ b/helpers/messages/sendMessage.ts
@@ -117,6 +117,7 @@ export async function sendMessage(bot: Bot, channelId: bigint, options: CreateMe
           },
         }
         : {}),
+      sticker_ids: options.stickerIds?.map((sticker) => sticker.toString()),
     },
   );
 
@@ -152,4 +153,6 @@ export interface CreateMessage {
   file?: FileContent | FileContent[];
   /** The components you would like to have sent in this message */
   components?: MessageComponents;
+  /** IDs of up to 3 stickers in the server to send in the message */
+  stickerIds?: [bigint] | [bigint, bigint] | [bigint, bigint, bigint];
 }

--- a/plugins/validations/src/messages/sendMessage.ts
+++ b/plugins/validations/src/messages/sendMessage.ts
@@ -1,5 +1,6 @@
 import { AllowedMentionsTypes, Bot } from "../../deps.ts";
 import { validateComponents } from "../components.ts";
+import { messages } from "./mod.ts";
 
 export function sendMessage(bot: Bot) {
   const sendMessage = bot.helpers.sendMessage;
@@ -53,6 +54,12 @@ export function sendMessage(bot: Bot) {
     }
 
     if (content.components) validateComponents(bot, content.components);
+
+    if (content.content || content.embeds || content.components || content.file || content.stickerIds) {
+      throw new Error(
+        "When sending a message, you must provide a value for at least one of content, embeds, stickerIds, components, or file.",
+      );
+    }
 
     return sendMessage(channelId, content);
   };


### PR DESCRIPTION
When creating a message, apps must provide a value for **at least one of** `content`, `embeds`, `sticker_ids`, `components`, or `files[n]`. https://discord.com/developers/docs/resources/channel#create-message-jsonform-params

Closes: #2454 
Upstream: https://github.com/discord/discord-api-docs/commit/e5bde9a18761e54c2cf4f1e090f6376b9d8e03f1