### PR TITLE
feat(types)!: add `two_way_link` to `DiscordConnection`

### DIFF
--- a/types/discord.ts
+++ b/types/discord.ts
@@ -99,6 +99,8 @@ export interface DiscordConnection {
 
   /** An array of partial server integrations */
   integrations?: DiscordIntegration[];
+  /** Whether this connection has a corresponding third party OAuth2 token. */
+  two_way_link: boolean;
 }
 
 /** https://discord.com/developers/docs/resources/user#connection-object-services */


### PR DESCRIPTION
When the connection has a corresponding thrid party OAuth2 token `two_way_link` will be set to `true`.

Reference: https://github.com/discordeno/discordeno/issues/2479

Closes: #2479