### PR TITLE
fix(transformers): add min and max length to text input components

### DIFF
--- a/transformers/component.ts
+++ b/transformers/component.ts
@@ -72,6 +72,10 @@ export interface Component {
   minValues?: number;
   /** The maximum number of items that can be selected. Default 1. Between 1-25. */
   maxValues?: number;
+  /** The minimum input length for a text input. Between 0-4000 */
+  minLength?: number
+  /**The maximum input length for a text input. Between 1-4000 */
+  maxLength?: number;
   /** a list of child components */
   components?: Component[];
 }

--- a/transformers/component.ts
+++ b/transformers/component.ts
@@ -33,6 +33,8 @@ export function transformComponent(bot: Bot, payload: DiscordComponent): Compone
     placeholder: payload.placeholder,
     minValues: payload.min_values,
     maxValues: payload.max_values,
+    minLength: payload.min_length,
+    maxLength: payload.max_length,
     value: payload.value,
     components: payload.components?.map((component) => bot.transformers.component(bot, component)),
   };

--- a/transformers/component.ts
+++ b/transformers/component.ts
@@ -72,9 +72,9 @@ export interface Component {
   minValues?: number;
   /** The maximum number of items that can be selected. Default 1. Between 1-25. */
   maxValues?: number;
-  /** The minimum input length for a text input. Between 0-4000 */
+  /** The minimum input length for a text input. Between 0-4000. */
   minLength?: number
-  /**The maximum input length for a text input. Between 1-4000 */
+  /**The maximum input length for a text input. Between 1-4000. */
   maxLength?: number;
   /** a list of child components */
   components?: Component[];

--- a/transformers/component.ts
+++ b/transformers/component.ts
@@ -73,7 +73,7 @@ export interface Component {
   /** The maximum number of items that can be selected. Default 1. Between 1-25. */
   maxValues?: number;
   /** The minimum input length for a text input. Between 0-4000. */
-  minLength?: number
+  minLength?: number;
   /**The maximum input length for a text input. Between 1-4000. */
   maxLength?: number;
   /** a list of child components */

--- a/transformers/reverse/component.ts
+++ b/transformers/reverse/component.ts
@@ -33,6 +33,8 @@ export function transformComponentToDiscordComponent(bot: Bot, payload: Componen
     placeholder: payload.placeholder,
     min_values: payload.minValues,
     max_values: payload.maxValues,
+    min_length: payload.minLength,
+    max_length: payload.maxLength,
     value: payload.value,
     components: payload.components?.map((component) => bot.transformers.reverse.component(bot, component)),
   };

--- a/types/discord.ts
+++ b/types/discord.ts
@@ -2096,7 +2096,7 @@ export interface DiscordComponent {
   /** The maximum number of items that can be selected. Default 1. Between 1-25. */
   max_values?: number;
   /** The minimum input length for a text input. Between 0-4000. */
-  min_length?: number
+  min_length?: number;
   /**The maximum input length for a text input. Between 1-4000. */
   max_length?: number;
   /** a list of child components */

--- a/types/discord.ts
+++ b/types/discord.ts
@@ -40,7 +40,7 @@ import {
   VerificationLevels,
   VideoQualityModes,
   VisibilityTypes,
-  WebhookTypes
+  WebhookTypes,
 } from "./shared.ts";
 
 /** https://discord.com/developers/docs/resources/user#user-object */
@@ -2095,9 +2095,9 @@ export interface DiscordComponent {
   min_values?: number;
   /** The maximum number of items that can be selected. Default 1. Between 1-25. */
   max_values?: number;
-  /** The minimum input length for a text input. Between 0-4000 */
+  /** The minimum input length for a text input. Between 0-4000. */
   min_length?: number
-  /**The maximum input length for a text input. Between 1-4000 */
+  /**The maximum input length for a text input. Between 1-4000. */
   max_length?: number;
   /** a list of child components */
   components?: DiscordComponent[];

--- a/types/discord.ts
+++ b/types/discord.ts
@@ -40,7 +40,7 @@ import {
   VerificationLevels,
   VideoQualityModes,
   VisibilityTypes,
-  WebhookTypes,
+  WebhookTypes
 } from "./shared.ts";
 
 /** https://discord.com/developers/docs/resources/user#user-object */
@@ -2095,6 +2095,10 @@ export interface DiscordComponent {
   min_values?: number;
   /** The maximum number of items that can be selected. Default 1. Between 1-25. */
   max_values?: number;
+  /** The minimum input length for a text input. Between 0-4000 */
+  min_length?: number
+  /**The maximum input length for a text input. Between 1-4000 */
+  max_length?: number;
   /** a list of child components */
   components?: DiscordComponent[];
 }


### PR DESCRIPTION
The component transformer and the reverse transformer don't parse the min and max length of a text input component.
This PR fixed this problem.