### PR TITLE
fix(transformers): transform required field for InputText

### DIFF
--- a/transformers/component.ts
+++ b/transformers/component.ts
@@ -45,6 +45,8 @@ export interface Component {
   type: MessageComponentTypes;
   /** a developer-defined identifier for the component, max 100 characters */
   customId?: string;
+  /** whether this component is required to be filled, default true */
+  required?: boolean;
   /** whether the component is disabled, default false */
   disabled?: boolean;
   /** For different styles/colors of the buttons */

--- a/transformers/reverse/component.ts
+++ b/transformers/reverse/component.ts
@@ -7,6 +7,7 @@ export function transformComponentToDiscordComponent(bot: Bot, payload: Componen
     type: payload.type,
     custom_id: payload.customId,
     disabled: payload.disabled,
+    required: payload.required,
     style: payload.style,
     label: payload.label,
     emoji: payload.emoji

--- a/types/discord.ts
+++ b/types/discord.ts
@@ -1248,6 +1248,8 @@ export interface DiscordInputTextComponent {
   type: MessageComponentTypes.InputText;
   /** The style of the InputText */
   style: TextStyles;
+  /** whether this component is required to be filled, default true */
+  required?: boolean;
   /** The customId of the InputText */
   custom_id: string;
   /** The label of the InputText (max 45 characters)*/


### PR DESCRIPTION
the `required` field didn't get transformed to DiscordComponent