### PR TITLE
fix(rest): only send Content-Type header to proxy if body content is sent

### DIFF
--- a/rest/runMethod.ts
+++ b/rest/runMethod.ts
@@ -50,7 +50,7 @@ export async function runMethod<T = any>(
       body: body ? JSON.stringify(body) : undefined,
       headers: {
         Authorization: rest.secretKey,
-        "Content-Type": "application/json",
+        "Content-Type": body ? "application/json" : undefined,
       },
       method,
     });


### PR DESCRIPTION
Hi, 
I had some problems with a (nestjs-)fastify proxy that wasn't fine with sending no body but a content-type header.

This should fix the issue and shouldn't affect other bots.