### PR TITLE
feat: allow bigint or number to be passed in toggles classes too and not only the object

### DIFF
--- a/transformers/toggles/emoji.ts
+++ b/transformers/toggles/emoji.ts
@@ -1,4 +1,4 @@
-import { DiscordEmoji, DiscordRole } from "../../types/discord.ts";
+import { DiscordEmoji } from "../../types/discord.ts";
 import { ToggleBitfield } from "./ToggleBitfield.ts";
 
 export const EmojiToggle = {
@@ -13,13 +13,18 @@ export const EmojiToggle = {
 };
 
 export class EmojiToggles extends ToggleBitfield {
-  constructor(role: DiscordEmoji) {
+  constructor(roleOrTogglesInt: DiscordEmoji | number) {
     super();
 
-    if (role.require_colons) this.add(EmojiToggle.requireColons);
-    if (role.managed) this.add(EmojiToggle.managed);
-    if (role.animated) this.add(EmojiToggle.animated);
-    if (role.available) this.add(EmojiToggle.available);
+    if (typeof roleOrTogglesInt === "number") this.bitfield = roleOrTogglesInt;
+    else {
+      const role = roleOrTogglesInt;
+
+      if (role.require_colons) this.add(EmojiToggle.requireColons);
+      if (role.managed) this.add(EmojiToggle.managed);
+      if (role.animated) this.add(EmojiToggle.animated);
+      if (role.available) this.add(EmojiToggle.available);
+    }
   }
 
   /** Whether this emoji must be wrapped in colons */

--- a/transformers/toggles/guild.ts
+++ b/transformers/toggles/guild.ts
@@ -88,39 +88,44 @@ export const GuildToggle = {
 };
 
 export class GuildToggles extends ToggleBitfieldBigint {
-  constructor(guild: DiscordGuild) {
+  constructor(guildOrTogglesBigint: DiscordGuild | bigint) {
     super();
 
-    if (guild.owner) this.add(GuildToggle.owner);
-    if (guild.widget_enabled) this.add(GuildToggle.widgetEnabled);
-    if (guild.large) this.add(GuildToggle.large);
-    if (guild.unavailable) this.add(GuildToggle.unavailable);
-    if (guild.premium_progress_bar_enabled) this.add(GuildToggle.premiumProgressBarEnabled);
+    if (typeof guildOrTogglesBigint == "bigint") this.bitfield = guildOrTogglesBigint;
+    else {
+      const guild = guildOrTogglesBigint;
 
-    if (guild.features.includes(GuildFeatures.InviteSplash)) this.add(GuildToggle.inviteSplash);
-    if (guild.features.includes(GuildFeatures.VipRegions)) this.add(GuildToggle.vipRegions);
-    if (guild.features.includes(GuildFeatures.VanityUrl)) this.add(GuildToggle.vanityUrl);
-    if (guild.features.includes(GuildFeatures.Verified)) this.add(GuildToggle.verified);
-    if (guild.features.includes(GuildFeatures.Partnered)) this.add(GuildToggle.partnered);
-    if (guild.features.includes(GuildFeatures.Community)) this.add(GuildToggle.community);
-    if (guild.features.includes(GuildFeatures.AnimatedBanner)) this.add(GuildToggle.animatedBanner);
-    if (guild.features.includes(GuildFeatures.News)) this.add(GuildToggle.news);
-    if (guild.features.includes(GuildFeatures.Discoverable)) this.add(GuildToggle.discoverable);
-    if (guild.features.includes(GuildFeatures.Featurable)) this.add(GuildToggle.featurable);
-    if (guild.features.includes(GuildFeatures.AnimatedIcon)) this.add(GuildToggle.animatedIcon);
-    if (guild.features.includes(GuildFeatures.Banner)) this.add(GuildToggle.banner);
-    if (guild.features.includes(GuildFeatures.WelcomeScreenEnabled)) this.add(GuildToggle.welcomeScreenEnabled);
-    if (guild.features.includes(GuildFeatures.MemberVerificationGateEnabled)) {
-      this.add(GuildToggle.memberVerificationGateEnabled);
+      if (guild.owner) this.add(GuildToggle.owner);
+      if (guild.widget_enabled) this.add(GuildToggle.widgetEnabled);
+      if (guild.large) this.add(GuildToggle.large);
+      if (guild.unavailable) this.add(GuildToggle.unavailable);
+      if (guild.premium_progress_bar_enabled) this.add(GuildToggle.premiumProgressBarEnabled);
+
+      if (guild.features.includes(GuildFeatures.InviteSplash)) this.add(GuildToggle.inviteSplash);
+      if (guild.features.includes(GuildFeatures.VipRegions)) this.add(GuildToggle.vipRegions);
+      if (guild.features.includes(GuildFeatures.VanityUrl)) this.add(GuildToggle.vanityUrl);
+      if (guild.features.includes(GuildFeatures.Verified)) this.add(GuildToggle.verified);
+      if (guild.features.includes(GuildFeatures.Partnered)) this.add(GuildToggle.partnered);
+      if (guild.features.includes(GuildFeatures.Community)) this.add(GuildToggle.community);
+      if (guild.features.includes(GuildFeatures.AnimatedBanner)) this.add(GuildToggle.animatedBanner);
+      if (guild.features.includes(GuildFeatures.News)) this.add(GuildToggle.news);
+      if (guild.features.includes(GuildFeatures.Discoverable)) this.add(GuildToggle.discoverable);
+      if (guild.features.includes(GuildFeatures.Featurable)) this.add(GuildToggle.featurable);
+      if (guild.features.includes(GuildFeatures.AnimatedIcon)) this.add(GuildToggle.animatedIcon);
+      if (guild.features.includes(GuildFeatures.Banner)) this.add(GuildToggle.banner);
+      if (guild.features.includes(GuildFeatures.WelcomeScreenEnabled)) this.add(GuildToggle.welcomeScreenEnabled);
+      if (guild.features.includes(GuildFeatures.MemberVerificationGateEnabled)) {
+        this.add(GuildToggle.memberVerificationGateEnabled);
+      }
+      if (guild.features.includes(GuildFeatures.PreviewEnabled)) this.add(GuildToggle.previewEnabled);
+      if (guild.features.includes(GuildFeatures.TicketedEventsEnabled)) this.add(GuildToggle.ticketedEventsEnabled);
+      if (guild.features.includes(GuildFeatures.MonetizationEnabled)) this.add(GuildToggle.monetizationEnabled);
+      if (guild.features.includes(GuildFeatures.MoreStickers)) this.add(GuildToggle.moreStickers);
+      if (guild.features.includes(GuildFeatures.PrivateThreads)) this.add(GuildToggle.privateThreads);
+      if (guild.features.includes(GuildFeatures.RoleIcons)) this.add(GuildToggle.roleIcons);
+      if (guild.features.includes(GuildFeatures.AutoModeration)) this.add(GuildToggle.autoModeration);
+      if (guild.features.includes(GuildFeatures.InvitesDisabled)) this.add(GuildToggle.invitesDisabled);
     }
-    if (guild.features.includes(GuildFeatures.PreviewEnabled)) this.add(GuildToggle.previewEnabled);
-    if (guild.features.includes(GuildFeatures.TicketedEventsEnabled)) this.add(GuildToggle.ticketedEventsEnabled);
-    if (guild.features.includes(GuildFeatures.MonetizationEnabled)) this.add(GuildToggle.monetizationEnabled);
-    if (guild.features.includes(GuildFeatures.MoreStickers)) this.add(GuildToggle.moreStickers);
-    if (guild.features.includes(GuildFeatures.PrivateThreads)) this.add(GuildToggle.privateThreads);
-    if (guild.features.includes(GuildFeatures.RoleIcons)) this.add(GuildToggle.roleIcons);
-    if (guild.features.includes(GuildFeatures.AutoModeration)) this.add(GuildToggle.autoModeration);
-    if (guild.features.includes(GuildFeatures.InvitesDisabled)) this.add(GuildToggle.invitesDisabled);
   }
 
   get features() {

--- a/transformers/toggles/member.ts
+++ b/transformers/toggles/member.ts
@@ -1,4 +1,4 @@
-import { DiscordMember, DiscordUser } from "../../types/discord.ts";
+import { DiscordMember } from "../../types/discord.ts";
 import { ToggleBitfield } from "./ToggleBitfield.ts";
 
 export const MemberToggle = {
@@ -11,12 +11,17 @@ export const MemberToggle = {
 };
 
 export class MemberToggles extends ToggleBitfield {
-  constructor(member: Partial<DiscordMember>) {
+  constructor(memberOrTogglesInt: Partial<DiscordMember> | number) {
     super();
 
-    if (member.deaf) this.add(MemberToggle.deaf);
-    if (member.mute) this.add(MemberToggle.mute);
-    if (member.pending) this.add(MemberToggle.pending);
+    if (typeof memberOrTogglesInt === "number") this.bitfield = memberOrTogglesInt;
+    else {
+      const member = memberOrTogglesInt;
+
+      if (member.deaf) this.add(MemberToggle.deaf);
+      if (member.mute) this.add(MemberToggle.mute);
+      if (member.pending) this.add(MemberToggle.pending);
+    }
   }
 
   /** Whether the user belongs to an OAuth2 application */

--- a/transformers/toggles/role.ts
+++ b/transformers/toggles/role.ts
@@ -13,13 +13,18 @@ export const RoleToggle = {
 };
 
 export class RoleToggles extends ToggleBitfield {
-  constructor(role: DiscordRole) {
+  constructor(roleOrTogglesInt: DiscordRole | number) {
     super();
 
-    if (role.hoist) this.add(RoleToggle.hoist);
-    if (role.managed) this.add(RoleToggle.managed);
-    if (role.mentionable) this.add(RoleToggle.mentionable);
-    if (role.tags?.premium_subscriber === null) this.add(RoleToggle.premiumSubscriber);
+    if (typeof roleOrTogglesInt === "number") this.bitfield = roleOrTogglesInt;
+    else {
+      const role = roleOrTogglesInt;
+
+      if (role.hoist) this.add(RoleToggle.hoist);
+      if (role.managed) this.add(RoleToggle.managed);
+      if (role.mentionable) this.add(RoleToggle.mentionable);
+      if (role.tags?.premium_subscriber === null) this.add(RoleToggle.premiumSubscriber);
+    }
   }
 
   /** If this role is showed separately in the user listing */

--- a/transformers/toggles/user.ts
+++ b/transformers/toggles/user.ts
@@ -13,13 +13,18 @@ export const UserToggle = {
 };
 
 export class UserToggles extends ToggleBitfield {
-  constructor(user: DiscordUser) {
+  constructor(userOrTogglesInt: DiscordUser | number) {
     super();
 
-    if (user.bot) this.add(UserToggle.bot);
-    if (user.system) this.add(UserToggle.system);
-    if (user.mfa_enabled) this.add(UserToggle.mfaEnabled);
-    if (user.verified) this.add(UserToggle.verified);
+    if (typeof userOrTogglesInt === "number") this.bitfield = userOrTogglesInt;
+    else {
+      const user = userOrTogglesInt;
+
+      if (user.bot) this.add(UserToggle.bot);
+      if (user.system) this.add(UserToggle.system);
+      if (user.mfa_enabled) this.add(UserToggle.mfaEnabled);
+      if (user.verified) this.add(UserToggle.verified);
+    }
   }
 
   /** Whether the user belongs to an OAuth2 application */

--- a/transformers/toggles/voice.ts
+++ b/transformers/toggles/voice.ts
@@ -1,4 +1,4 @@
-import { DiscordUser, DiscordVoiceState } from "../../types/discord.ts";
+import { DiscordVoiceState } from "../../types/discord.ts";
 import { ToggleBitfield } from "./ToggleBitfield.ts";
 
 export const VoiceStateToggle = {
@@ -19,16 +19,21 @@ export const VoiceStateToggle = {
 };
 
 export class VoiceStateToggles extends ToggleBitfield {
-  constructor(voice: DiscordVoiceState) {
+  constructor(voiceOrTogglesInt: DiscordVoiceState | number) {
     super();
 
-    if (voice.deaf) this.add(VoiceStateToggle.deaf);
-    if (voice.mute) this.add(VoiceStateToggle.mute);
-    if (voice.self_deaf) this.add(VoiceStateToggle.selfDeaf);
-    if (voice.self_mute) this.add(VoiceStateToggle.selfMute);
-    if (voice.self_stream) this.add(VoiceStateToggle.selfStream);
-    if (voice.self_video) this.add(VoiceStateToggle.selfVideo);
-    if (voice.suppress) this.add(VoiceStateToggle.suppress);
+    if (typeof voiceOrTogglesInt === "number") this.bitfield = voiceOrTogglesInt;
+    else {
+      const voice = voiceOrTogglesInt;
+
+      if (voice.deaf) this.add(VoiceStateToggle.deaf);
+      if (voice.mute) this.add(VoiceStateToggle.mute);
+      if (voice.self_deaf) this.add(VoiceStateToggle.selfDeaf);
+      if (voice.self_mute) this.add(VoiceStateToggle.selfMute);
+      if (voice.self_stream) this.add(VoiceStateToggle.selfStream);
+      if (voice.self_video) this.add(VoiceStateToggle.selfVideo);
+      if (voice.suppress) this.add(VoiceStateToggle.suppress);
+    }
   }
 
   /** Whether this user is deafened by the server */


### PR DESCRIPTION
Currently there's a way to convert toggles to bigint (like `new GuildToggles(guild).bitfield`) but not a way to reverse it (converting bitfield to toggles), this PR adds support for that