### PR TITLE
fix: ReferenceError: publishMessage is not defined

### DIFF
--- a/packages/embeds/mod.ts
+++ b/packages/embeds/mod.ts
@@ -1,5 +1,7 @@
-import { routes } from "../../util/routes.ts";
+// The order of the import is important
 import { DiscordEmbed, Embed, formatImageURL, iconBigintToHash, ImageFormat, ImageSize, User } from "./deps.ts";
+
+import { routes } from "../../util/routes.ts";
 
 export const embedLimits = {
   title: 256,


### PR DESCRIPTION
Close #2541 
Cause by using helpers before helpers initialize 
Only affected ESM, cjs not affected