### PR TITLE
ci: move integration test

### DIFF
--- a/.github/workflows/integrationTest.yml
+++ b/.github/workflows/integrationTest.yml
@@ -1,0 +1,47 @@
+name: Integration Test
+
+on:
+  push:
+    paths:
+      - ".github/workflows/integrationTest.yml"
+      - "gateway/**"
+      - "handlers/**"
+      - "helpers/**"
+      - "packages/**"
+      - "plugins/**"
+      - "rest/**"
+      - "template/**"
+      - "tests/**"
+      - "transformers/**"
+      - "types/**"
+      - "util/**"
+      - "bot.ts"
+      - "mod.ts"
+      - "dnt.ts"
+
+jobs:
+  integration-test:
+    name: Integration Test
+    runs-on: ubuntu-latest
+    concurrency: integration-test
+    steps:
+      - uses: actions/checkout@v3
+      - uses: denoland/setup-deno@main
+        with:
+          deno-version: v1.x
+      - name: Run integration
+        # if: ${{ github.actor == 'Skillz4Killz' || github.actor == 'itohatweb' }}
+        run: deno test --coverage=coverage -A tests/
+        env:
+          DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
+          UNIT_TEST_GUILD_ID: ${{ secrets.UNIT_TEST_GUILD_ID }}
+          TEST_ENV: INTEGRATION
+          PROXY_REST_SECRET: ${{ secrets.PROXY_REST_SECRET }}
+          PROXY_REST_URL: ${{ secrets.PROXY_REST_URL }}
+      - name: Create coverage report
+        run: deno coverage --exclude=tests ./coverage --lcov > coverage.lcov
+      - name: Collect and upload the coverage report
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.lcov
+          flags: integration

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,34 +62,6 @@ jobs:
       - name: Check Templates
         run: deno check template/beginner/mod.ts template/minimal/mod.ts
 
-  integration-test:
-    name: Integration Test
-    runs-on: ubuntu-latest
-    needs: path-filter
-    if: ${{ needs.path-filter.outputs.code-change == 'true' && github.ref == 'refs/heads/main' }}
-    concurrency: integration-test
-    steps:
-      - uses: actions/checkout@v3
-      - uses: denoland/setup-deno@main
-        with:
-          deno-version: v1.x
-      - name: Run integration
-        # if: ${{ github.actor == 'Skillz4Killz' || github.actor == 'itohatweb' }}
-        run: deno test --coverage=coverage -A tests/
-        env:
-          DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
-          UNIT_TEST_GUILD_ID: ${{ secrets.UNIT_TEST_GUILD_ID }}
-          TEST_ENV: INTEGRATION
-          PROXY_REST_SECRET: ${{ secrets.PROXY_REST_SECRET }}
-          PROXY_REST_URL: ${{ secrets.PROXY_REST_URL }}
-      - name: Create coverage report
-        run: deno coverage --exclude=tests ./coverage --lcov > coverage.lcov
-      - name: Collect and upload the coverage report
-        uses: codecov/codecov-action@v3
-        with:
-          file: ./coverage.lcov
-          flags: integration
-
   unit-test:
     name: Unit Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR moves the integration test to a separate workflow because codecov's carry forward doesn't seem to work for skip test in same workflow