### PR TITLE
calculateBasePermissions may not correctly retrieve cached members

### DIFF
--- a/plugins/permissions/src/permissions.ts
+++ b/plugins/permissions/src/permissions.ts
@@ -18,7 +18,7 @@ export function calculateBasePermissions(
   memberOrId: bigint | Member,
 ) {
   const guild = typeof guildOrId === "bigint" ? bot.guilds.get(guildOrId) : guildOrId;
-  const member = typeof memberOrId === "bigint" ? bot.members.get(memberOrId) : memberOrId;
+  const member = typeof memberOrId === "bigint" ? bot.members.find(m => (m.id === memberOrId) && (m.guildId === guild?.id)) : memberOrId;
 
   if (!guild || !member) return 8n;
 

--- a/plugins/permissions/src/permissions.ts
+++ b/plugins/permissions/src/permissions.ts
@@ -18,7 +18,7 @@ export function calculateBasePermissions(
   memberOrId: bigint | Member,
 ) {
   const guild = typeof guildOrId === "bigint" ? bot.guilds.get(guildOrId) : guildOrId;
-  const member = typeof memberOrId === "bigint" ? bot.members.find(m => (m.id === memberOrId) && (m.guildId === guild?.id)) : memberOrId;
+  const member = typeof memberOrId === "bigint" ? bot.members.get(`${memberOrId}${guild?.id}`) : memberOrId;
 
   if (!guild || !member) return 8n;
 

--- a/plugins/permissions/src/permissions.ts
+++ b/plugins/permissions/src/permissions.ts
@@ -18,7 +18,7 @@ export function calculateBasePermissions(
   memberOrId: bigint | Member,
 ) {
   const guild = typeof guildOrId === "bigint" ? bot.guilds.get(guildOrId) : guildOrId;
-  const member = typeof memberOrId === "bigint" ? bot.members.get(`${memberOrId}${guild?.id}`) : memberOrId;
+  const member = typeof memberOrId === "bigint" ? bot.members.get(bot.transformers.snowflake(`${memberOrId}${guild?.id}`)) : memberOrId;
 
   if (!guild || !member) return 8n;
 


### PR DESCRIPTION
After testing the permissions plugin I stumbled upon what might be an oversight. `bot.members.get()` won't work sometimes as multiple members in this collection may have the same ID. This new code seems to work better from my testing with one of my bots, but I have not done rigorous testing.