### PR TITLE
helpers: Add missing properties for create guild channel

### DIFF
--- a/helpers/channels/createChannel.ts
+++ b/helpers/channels/createChannel.ts
@@ -102,7 +102,7 @@ export interface CreateGuildChannel extends WithReason {
   /** Emoji to show in the add reaction button on a thread in a forum channel */
   defaultReactionEmoji?: {
     /** The id of a guild's custom emoji. Exactly one of `emojiId` and `emojiName` must be set. */
-    emojiId?: bigint | null;
+    emojiId?: BigString | null;
     /** The unicode character of the emoji. Exactly one of `emojiId` and `emojiName` must be set. */
     emojiName?: string | null;
   };

--- a/helpers/channels/createChannel.ts
+++ b/helpers/channels/createChannel.ts
@@ -109,7 +109,7 @@ export interface CreateGuildChannel extends WithReason {
   /** Set of tags that can be used in a forum channel */
   availableTags?: {
     /** The id of the tag */
-    id: bigint;
+    id: BigString;
     /** The name of the tag (0-20 characters) */
     name: string;
     /** whether this tag can only be added to or removed from threads by a member with the MANAGE_THREADS permission */

--- a/helpers/channels/createChannel.ts
+++ b/helpers/channels/createChannel.ts
@@ -115,7 +115,7 @@ export interface CreateGuildChannel extends WithReason {
     /** whether this tag can only be added to or removed from threads by a member with the MANAGE_THREADS permission */
     moderated: boolean;
     /** The id of a guild's custom emoji */
-    emojiId: bigint;
+    emojiId: BigString;
     /** The unicode character of the emoji */
     emojiName?: string;
   }[];

--- a/helpers/channels/createChannel.ts
+++ b/helpers/channels/createChannel.ts
@@ -51,6 +51,24 @@ export async function createChannel(bot: Bot, guildId: BigString, options: Creat
         type: options?.type || ChannelTypes.GuildText,
         reason: options.reason,
         default_auto_archive_duration: options?.defaultAutoArchiveDuration,
+        default_reaction_emoji: options.defaultReactionEmoji
+          ? {
+            emoji_id: options.defaultReactionEmoji.emojiId
+              ? bot.transformers.reverse.snowflake(options.defaultReactionEmoji.emojiId)
+              : options.defaultReactionEmoji.emojiId,
+            emoji_name: options.defaultReactionEmoji.emojiName,
+          }
+          : undefined,
+
+        available_tags: options.availableTags
+          ? options.availableTags.map((availableTag) => ({
+            id: bot.transformers.reverse.snowflake(availableTag.id),
+            name: availableTag.name,
+            moderated: availableTag.moderated,
+            emoji_name: availableTag.emojiName,
+            emoji_id: availableTag.emojiId ? bot.transformers.reverse.snowflake(availableTag.emojiId) : undefined,
+          }))
+          : undefined,
       }
       : {},
   );
@@ -81,4 +99,24 @@ export interface CreateGuildChannel extends WithReason {
   nsfw?: boolean;
   /** Default duration (in minutes) that clients (not the API) use for newly created threads in this channel, to determine when to automatically archive the thread after the last activity */
   defaultAutoArchiveDuration?: number;
+  /** Emoji to show in the add reaction button on a thread in a forum channel */
+  defaultReactionEmoji?: {
+    /** The id of a guild's custom emoji. Exactly one of `emojiId` and `emojiName` must be set. */
+    emojiId?: bigint | null;
+    /** The unicode character of the emoji. Exactly one of `emojiId` and `emojiName` must be set. */
+    emojiName?: string | null;
+  };
+  /** Set of tags that can be used in a forum channel */
+  availableTags?: {
+    /** The id of the tag */
+    id: bigint;
+    /** The name of the tag (0-20 characters) */
+    name: string;
+    /** whether this tag can only be added to or removed from threads by a member with the MANAGE_THREADS permission */
+    moderated: boolean;
+    /** The id of a guild's custom emoji */
+    emojiId: bigint;
+    /** The unicode character of the emoji */
+    emojiName?: string;
+  }[];
 }


### PR DESCRIPTION
Closes: #2513 
Upstream: https://github.com/discord/discord-api-docs/commit/c2f74223c6f00d48a678bcd75892ff43ea5a2ddc
Docs: 
[Create Guild Channel](https://discord.com/developers/docs/resources/guild#create-guild-channel-json-params)
[Default Reaction](https://discord.com/developers/docs/resources/channel#default-reaction-object-default-reaction-structure)
[Forum Tag](https://discord.com/developers/docs/resources/channel#forum-tag-object-forum-tag-structure)