### PR TITLE
types: add SortOrderTypes and default_sort_order to DiscordChannel, helpers: add defaultSortOrder to createChannel and editChannel options

### DIFF
--- a/helpers/channels/createChannel.ts
+++ b/helpers/channels/createChannel.ts
@@ -3,7 +3,7 @@ import { WithReason } from "../../mod.ts";
 import { Channel } from "../../transformers/channel.ts";
 import { DiscordChannel } from "../../types/discord.ts";
 import { OverwriteReadable } from "../../types/discordeno.ts";
-import { BigString, ChannelTypes } from "../../types/shared.ts";
+import { BigString, ChannelTypes, SortOrderTypes } from "../../types/shared.ts";
 
 /**
  * Creates a channel within a guild.
@@ -49,6 +49,7 @@ export async function createChannel(bot: Bot, guildId: BigString, options: Creat
           deny: overwrite.deny ? bot.utils.calculateBits(overwrite.deny) : null,
         })),
         type: options?.type || ChannelTypes.GuildText,
+        default_sort_order: options.defaultSortOrder,
         reason: options.reason,
         default_auto_archive_duration: options?.defaultAutoArchiveDuration,
       }
@@ -81,4 +82,6 @@ export interface CreateGuildChannel extends WithReason {
   nsfw?: boolean;
   /** Default duration (in minutes) that clients (not the API) use for newly created threads in this channel, to determine when to automatically archive the thread after the last activity */
   defaultAutoArchiveDuration?: number;
+  /** the default sort order type used to order posts in forum channels */
+  defaultSortOrder?: SortOrderTypes | null;
 }

--- a/helpers/channels/editChannel.ts
+++ b/helpers/channels/editChannel.ts
@@ -3,7 +3,7 @@ import { WithReason } from "../../mod.ts";
 import { Channel } from "../../transformers/channel.ts";
 import { DiscordChannel } from "../../types/discord.ts";
 import { OverwriteReadable } from "../../types/discordeno.ts";
-import { BigString, ChannelTypes, VideoQualityModes } from "../../types/shared.ts";
+import { BigString, ChannelTypes, SortOrderTypes, VideoQualityModes } from "../../types/shared.ts";
 
 /**
  * Edits a channel's settings.
@@ -103,6 +103,7 @@ export async function editChannel(bot: Bot, channelId: BigString, options: Modif
           emoji_name: options.defaultReactionEmoji.emojiName,
         }
         : undefined,
+      default_sort_order: options.defaultSortOrder,
       reason: options.reason,
     },
   );
@@ -223,4 +224,6 @@ export interface ModifyChannel extends WithReason {
   };
   /** the initial rate_limit_per_user to set on newly created threads in a channel. this field is copied to the thread at creation time and does not live update. */
   defaultThreadRateLimitPerUser?: number;
+  /** the default sort order type used to order posts in forum channels */
+  defaultSortOrder?: SortOrderTypes | null;
 }

--- a/types/discord.ts
+++ b/types/discord.ts
@@ -785,6 +785,8 @@ export interface DiscordChannel {
   default_reaction_emoji?: DiscordDefaultReactionEmoji | null;
   /** the initial rate_limit_per_user to set on newly created threads in a channel. this field is copied to the thread at creation time and does not live update. */
   default_thread_rate_limit_per_user: number;
+  /** the default sort order type used to order posts in GUILD_FORUM channels. Defaults to null, which indicates a preferred sort order hasn't been set by a channel admin */
+  default_sort_order?: number | null;
 }
 
 /** https://discord.com/developers/docs/topics/gateway#presence-update */

--- a/types/discord.ts
+++ b/types/discord.ts
@@ -786,7 +786,7 @@ export interface DiscordChannel {
   /** the initial rate_limit_per_user to set on newly created threads in a channel. this field is copied to the thread at creation time and does not live update. */
   default_thread_rate_limit_per_user: number;
   /** the default sort order type used to order posts in GUILD_FORUM channels. Defaults to null, which indicates a preferred sort order hasn't been set by a channel admin */
-  default_sort_order?: number | null;
+  default_sort_order?: SortOrderTypes | null;
 }
 
 /** https://discord.com/developers/docs/topics/gateway#presence-update */

--- a/types/shared.ts
+++ b/types/shared.ts
@@ -1241,6 +1241,13 @@ export enum InteractionResponseTypes {
   Modal = 9,
 }
 
+export enum SortOrderTypes {
+  /** Sort forum posts by activity */
+  LatestActivity,
+  /** Sort forum posts by creation time (from most recent to oldest) */
+  CreationDate,
+}
+
 export enum Errors {
   // Bot Role errors
   BOTS_HIGHEST_ROLE_TOO_LOW = "BOTS_HIGHEST_ROLE_TOO_LOW",


### PR DESCRIPTION
types: add SortOrderTypes and default_sort_order to DiscordChannel
helpers: add defaultSortOrder to createChannel and editChannel options
closes: #2518 
upstream: https://github.com/discord/discord-api-docs/commit/d81f425adff2fa0a330f648aece421d085479932
docs:
[create channel](https://discord.com/developers/docs/resources/guild#create-guild-channel-json-params)
[edit channel](https://discord.com/developers/docs/resources/channel#modify-channel-json-params-guild-channel)
[discord channel](https://discord.com/developers/docs/resources/channel#channel-object-channel-structure)
[sort order types](https://discord.com/developers/docs/resources/channel#channel-object-sort-order-types)