### PR TITLE
Fix message.member being present but message.member not being present

### DIFF
--- a/transformers/member.ts
+++ b/transformers/member.ts
@@ -9,9 +9,7 @@ export function transformUser(bot: Bot, payload: DiscordUser) {
     id: bot.transformers.snowflake(payload.id || ""),
     username: payload.username,
     discriminator: payload.discriminator,
-    avatar: payload.avatar
-      ? bot.utils.iconHashToBigInt(payload.avatar)
-      : undefined,
+    avatar: payload.avatar ? bot.utils.iconHashToBigInt(payload.avatar) : undefined,
     locale: payload.locale,
     email: payload.email ?? undefined,
     flags: payload.flags,
@@ -41,15 +39,9 @@ export function transformMember(
     nick: payload.nick ?? undefined,
     roles: payload.roles.map((id) => bot.transformers.snowflake(id)),
     joinedAt: Date.parse(payload.joined_at),
-    premiumSince: payload.premium_since
-      ? Date.parse(payload.premium_since)
-      : undefined,
-    avatar: payload.avatar
-      ? bot.utils.iconHashToBigInt(payload.avatar)
-      : undefined,
-    permissions: payload.permissions
-      ? bot.transformers.snowflake(payload.permissions)
-      : undefined,
+    premiumSince: payload.premium_since ? Date.parse(payload.premium_since) : undefined,
+    avatar: payload.avatar ? bot.utils.iconHashToBigInt(payload.avatar) : undefined,
+    permissions: payload.permissions ? bot.transformers.snowflake(payload.permissions) : undefined,
     communicationDisabledUntil: payload.communication_disabled_until
       ? Date.parse(payload.communication_disabled_until)
       : undefined,

--- a/transformers/member.ts
+++ b/transformers/member.ts
@@ -9,7 +9,9 @@ export function transformUser(bot: Bot, payload: DiscordUser) {
     id: bot.transformers.snowflake(payload.id || ""),
     username: payload.username,
     discriminator: payload.discriminator,
-    avatar: payload.avatar ? bot.utils.iconHashToBigInt(payload.avatar) : undefined,
+    avatar: payload.avatar
+      ? bot.utils.iconHashToBigInt(payload.avatar)
+      : undefined,
     locale: payload.locale,
     email: payload.email ?? undefined,
     flags: payload.flags,
@@ -21,17 +23,33 @@ export function transformUser(bot: Bot, payload: DiscordUser) {
   return user as Optionalize<typeof user>;
 }
 
-export function transformMember(bot: Bot, payload: DiscordMember, guildId: bigint, userId: bigint) {
+export function transformMember(
+  bot: Bot,
+  payload: DiscordMember,
+  guildId: bigint,
+  userId: bigint,
+  author?: DiscordUser
+) {
   const member = {
     id: userId,
     guildId,
-    user: payload.user ? bot.transformers.user(bot, payload.user) : undefined,
+    user: payload.user
+      ? bot.transformers.user(bot, payload.user)
+      : author
+      ? bot.transformers.user(bot, author)
+      : undefined,
     nick: payload.nick ?? undefined,
     roles: payload.roles.map((id) => bot.transformers.snowflake(id)),
     joinedAt: Date.parse(payload.joined_at),
-    premiumSince: payload.premium_since ? Date.parse(payload.premium_since) : undefined,
-    avatar: payload.avatar ? bot.utils.iconHashToBigInt(payload.avatar) : undefined,
-    permissions: payload.permissions ? bot.transformers.snowflake(payload.permissions) : undefined,
+    premiumSince: payload.premium_since
+      ? Date.parse(payload.premium_since)
+      : undefined,
+    avatar: payload.avatar
+      ? bot.utils.iconHashToBigInt(payload.avatar)
+      : undefined,
+    permissions: payload.permissions
+      ? bot.transformers.snowflake(payload.permissions)
+      : undefined,
     communicationDisabledUntil: payload.communication_disabled_until
       ? Date.parse(payload.communication_disabled_until)
       : undefined,

--- a/transformers/message.ts
+++ b/transformers/message.ts
@@ -16,16 +16,9 @@ export function transformMessage(bot: Bot, payload: DiscordMessage) {
     isFromBot: payload.author.bot || false,
     tag: `${payload.author.username}#${payload.author.discriminator}`,
     timestamp: Date.parse(payload.timestamp),
-    editedTimestamp: payload.edited_timestamp
-      ? Date.parse(payload.edited_timestamp)
-      : undefined,
-    bitfield:
-      (payload.tts ? 1n : 0n) |
-      (payload.mention_everyone ? 2n : 0n) |
-      (payload.pinned ? 4n : 0n),
-    attachments: payload.attachments?.map((attachment) =>
-      bot.transformers.attachment(bot, attachment)
-    ),
+    editedTimestamp: payload.edited_timestamp ? Date.parse(payload.edited_timestamp) : undefined,
+    bitfield: (payload.tts ? 1n : 0n) | (payload.mention_everyone ? 2n : 0n) | (payload.pinned ? 4n : 0n),
+    attachments: payload.attachments?.map((attachment) => bot.transformers.attachment(bot, attachment)),
     embeds: payload.embeds?.map((embed) => bot.transformers.embed(bot, embed)),
     reactions: payload.reactions?.map((reaction) => ({
       me: reaction.me,
@@ -35,9 +28,9 @@ export function transformMessage(bot: Bot, payload: DiscordMessage) {
     type: payload.type,
     activity: payload.activity
       ? {
-          type: payload.activity.type,
-          partyId: payload.activity.party_id,
-        }
+        type: payload.activity.type,
+        partyId: payload.activity.party_id,
+      }
       : undefined,
     application: payload.application,
     flags: payload.flags,
@@ -48,46 +41,33 @@ export function transformMessage(bot: Bot, payload: DiscordMessage) {
           name: payload.interaction.name,
           user: bot.transformers.user(bot, payload.interaction.user),
           member: payload.interaction.member
-            ? {
-                id: userId,
-                guildId,
-                nick: payload.interaction.member.nick ?? undefined,
-                roles: payload.interaction.member.roles?.map((id) =>
-                  bot.transformers.snowflake(id)
-                ),
-                joinedAt: payload.interaction.member.joined_at
-                  ? Date.parse(payload.interaction.member.joined_at)
-                  : undefined,
-                premiumSince: payload.interaction.member.premium_since
-                  ? Date.parse(payload.interaction.member.premium_since)
-                  : undefined,
-                toggles: new MemberToggles(payload.interaction.member),
-                avatar: payload.interaction.member.avatar
-                  ? bot.utils.iconHashToBigInt(
-                      payload.interaction.member.avatar
-                    )
-                  : undefined,
-                permissions: payload.interaction.member.permissions
-                  ? bot.transformers.snowflake(
-                      payload.interaction.member.permissions
-                    )
-                  : undefined,
-                communicationDisabledUntil: payload.interaction.member
-                  .communication_disabled_until
-                  ? Date.parse(
-                      payload.interaction.member.communication_disabled_until
-                    )
-                  : undefined,
-              }
-            : undefined,
-        }
+          ? {
+            id: userId,
+            guildId,
+            nick: payload.interaction.member.nick ?? undefined,
+            roles: payload.interaction.member.roles?.map((id) => bot.transformers.snowflake(id)),
+            joinedAt: payload.interaction.member.joined_at
+              ? Date.parse(payload.interaction.member.joined_at)
+              : undefined,
+            premiumSince: payload.interaction.member.premium_since
+              ? Date.parse(payload.interaction.member.premium_since)
+              : undefined,
+            toggles: new MemberToggles(payload.interaction.member),
+            avatar: payload.interaction.member.avatar
+              ? bot.utils.iconHashToBigInt(payload.interaction.member.avatar)
+              : undefined,
+            permissions: payload.interaction.member.permissions
+              ? bot.transformers.snowflake(payload.interaction.member.permissions)
+              : undefined,
+            communicationDisabledUntil: payload.interaction.member.communication_disabled_until
+              ? Date.parse(payload.interaction.member.communication_disabled_until)
+              : undefined,
+          }
+          : undefined,
+      }
       : undefined,
-    thread: payload.thread
-      ? bot.transformers.channel(bot, { channel: payload.thread, guildId })
-      : undefined,
-    components: payload.components?.map((component) =>
-      bot.transformers.component(bot, component)
-    ),
+    thread: payload.thread ? bot.transformers.channel(bot, { channel: payload.thread, guildId }) : undefined,
+    components: payload.components?.map((component) => bot.transformers.component(bot, component)),
     stickerItems: payload.sticker_items?.map((sticker) => ({
       id: bot.transformers.snowflake(sticker.id),
       name: sticker.name,
@@ -107,36 +87,29 @@ export function transformMessage(bot: Bot, payload: DiscordMessage) {
       : undefined,
     messageReference: payload.message_reference
       ? {
-          messageId: payload.message_reference.message_id
-            ? bot.transformers.snowflake(payload.message_reference.message_id)
-            : undefined,
-          channelId: payload.message_reference.channel_id
-            ? bot.transformers.snowflake(payload.message_reference.channel_id)
-            : undefined,
-          guildId: payload.message_reference.guild_id
-            ? bot.transformers.snowflake(payload.message_reference.guild_id)
-            : undefined,
-        }
+        messageId: payload.message_reference.message_id
+        ? bot.transformers.snowflake(payload.message_reference.message_id)
+        : undefined,
+        channelId: payload.message_reference.channel_id
+          ? bot.transformers.snowflake(payload.message_reference.channel_id)
+          : undefined,
+        guildId: payload.message_reference.guild_id
+          ? bot.transformers.snowflake(payload.message_reference.guild_id)
+          : undefined,
+      }
       : undefined,
-    mentionedUserIds: payload.mentions
-      ? payload.mentions.map((m) => bot.transformers.snowflake(m.id))
-      : [],
-    mentionedRoleIds: payload.mention_roles
-      ? payload.mention_roles.map((id) => bot.transformers.snowflake(id))
-      : [],
+    mentionedUserIds: payload.mentions ? payload.mentions.map((m) => bot.transformers.snowflake(m.id)) : [],
+    mentionedRoleIds: payload.mention_roles ? payload.mention_roles.map((id) => bot.transformers.snowflake(id)) : [],
     mentionedChannelIds: [
       // Keep any ids tht discord sends
-      ...(payload.mention_channels ?? []).map((m) =>
-        bot.transformers.snowflake(m.id)
-      ),
+      ...(payload.mention_channels ?? []).map((m) => bot.transformers.snowflake(m.id)),
       // Add any other ids that can be validated in a channel mention format
       ...(payload.content?.match(CHANNEL_MENTION_REGEX) || []).map((text) =>
         // converts the <#123> into 123
         bot.transformers.snowflake(text.substring(2, text.length - 1))
       ),
     ],
-    member:
-      payload.member && guildId
+    member: payload.member && guildId
         ? bot.transformers.member(
             bot,
             payload.member,

--- a/transformers/message.ts
+++ b/transformers/message.ts
@@ -5,7 +5,9 @@ import { CHANNEL_MENTION_REGEX } from "../util/constants.ts";
 import { MemberToggles } from "./toggles/member.ts";
 
 export function transformMessage(bot: Bot, payload: DiscordMessage) {
-  const guildId = payload.guild_id ? bot.transformers.snowflake(payload.guild_id) : undefined;
+  const guildId = payload.guild_id
+    ? bot.transformers.snowflake(payload.guild_id)
+    : undefined;
   const userId = bot.transformers.snowflake(payload.author.id);
 
   const message = {
@@ -14,9 +16,16 @@ export function transformMessage(bot: Bot, payload: DiscordMessage) {
     isFromBot: payload.author.bot || false,
     tag: `${payload.author.username}#${payload.author.discriminator}`,
     timestamp: Date.parse(payload.timestamp),
-    editedTimestamp: payload.edited_timestamp ? Date.parse(payload.edited_timestamp) : undefined,
-    bitfield: (payload.tts ? 1n : 0n) | (payload.mention_everyone ? 2n : 0n) | (payload.pinned ? 4n : 0n),
-    attachments: payload.attachments?.map((attachment) => bot.transformers.attachment(bot, attachment)),
+    editedTimestamp: payload.edited_timestamp
+      ? Date.parse(payload.edited_timestamp)
+      : undefined,
+    bitfield:
+      (payload.tts ? 1n : 0n) |
+      (payload.mention_everyone ? 2n : 0n) |
+      (payload.pinned ? 4n : 0n),
+    attachments: payload.attachments?.map((attachment) =>
+      bot.transformers.attachment(bot, attachment)
+    ),
     embeds: payload.embeds?.map((embed) => bot.transformers.embed(bot, embed)),
     reactions: payload.reactions?.map((reaction) => ({
       me: reaction.me,
@@ -26,46 +35,59 @@ export function transformMessage(bot: Bot, payload: DiscordMessage) {
     type: payload.type,
     activity: payload.activity
       ? {
-        type: payload.activity.type,
-        partyId: payload.activity.party_id,
-      }
+          type: payload.activity.type,
+          partyId: payload.activity.party_id,
+        }
       : undefined,
     application: payload.application,
     flags: payload.flags,
     interaction: payload.interaction
       ? {
-        id: bot.transformers.snowflake(payload.interaction.id),
-        type: payload.interaction.type,
-        name: payload.interaction.name,
-        user: bot.transformers.user(bot, payload.interaction.user),
-        member: payload.interaction.member
-          ? {
-            id: userId,
-            guildId,
-            nick: payload.interaction.member.nick ?? undefined,
-            roles: payload.interaction.member.roles?.map((id) => bot.transformers.snowflake(id)),
-            joinedAt: payload.interaction.member.joined_at
-              ? Date.parse(payload.interaction.member.joined_at)
-              : undefined,
-            premiumSince: payload.interaction.member.premium_since
-              ? Date.parse(payload.interaction.member.premium_since)
-              : undefined,
-            toggles: new MemberToggles(payload.interaction.member),
-            avatar: payload.interaction.member.avatar
-              ? bot.utils.iconHashToBigInt(payload.interaction.member.avatar)
-              : undefined,
-            permissions: payload.interaction.member.permissions
-              ? bot.transformers.snowflake(payload.interaction.member.permissions)
-              : undefined,
-            communicationDisabledUntil: payload.interaction.member.communication_disabled_until
-              ? Date.parse(payload.interaction.member.communication_disabled_until)
-              : undefined,
-          }
-          : undefined,
-      }
+          id: bot.transformers.snowflake(payload.interaction.id),
+          type: payload.interaction.type,
+          name: payload.interaction.name,
+          user: bot.transformers.user(bot, payload.interaction.user),
+          member: payload.interaction.member
+            ? {
+                id: userId,
+                guildId,
+                nick: payload.interaction.member.nick ?? undefined,
+                roles: payload.interaction.member.roles?.map((id) =>
+                  bot.transformers.snowflake(id)
+                ),
+                joinedAt: payload.interaction.member.joined_at
+                  ? Date.parse(payload.interaction.member.joined_at)
+                  : undefined,
+                premiumSince: payload.interaction.member.premium_since
+                  ? Date.parse(payload.interaction.member.premium_since)
+                  : undefined,
+                toggles: new MemberToggles(payload.interaction.member),
+                avatar: payload.interaction.member.avatar
+                  ? bot.utils.iconHashToBigInt(
+                      payload.interaction.member.avatar
+                    )
+                  : undefined,
+                permissions: payload.interaction.member.permissions
+                  ? bot.transformers.snowflake(
+                      payload.interaction.member.permissions
+                    )
+                  : undefined,
+                communicationDisabledUntil: payload.interaction.member
+                  .communication_disabled_until
+                  ? Date.parse(
+                      payload.interaction.member.communication_disabled_until
+                    )
+                  : undefined,
+              }
+            : undefined,
+        }
       : undefined,
-    thread: payload.thread ? bot.transformers.channel(bot, { channel: payload.thread, guildId }) : undefined,
-    components: payload.components?.map((component) => bot.transformers.component(bot, component)),
+    thread: payload.thread
+      ? bot.transformers.channel(bot, { channel: payload.thread, guildId })
+      : undefined,
+    components: payload.components?.map((component) =>
+      bot.transformers.component(bot, component)
+    ),
     stickerItems: payload.sticker_items?.map((sticker) => ({
       id: bot.transformers.snowflake(sticker.id),
       name: sticker.name,
@@ -76,34 +98,53 @@ export function transformMessage(bot: Bot, payload: DiscordMessage) {
     id: bot.transformers.snowflake(payload.id),
     guildId,
     channelId: bot.transformers.snowflake(payload.channel_id),
-    webhookId: payload.webhook_id ? bot.transformers.snowflake(payload.webhook_id) : undefined,
+    webhookId: payload.webhook_id
+      ? bot.transformers.snowflake(payload.webhook_id)
+      : undefined,
     authorId: userId,
-    applicationId: payload.application_id ? bot.transformers.snowflake(payload.application_id) : undefined,
+    applicationId: payload.application_id
+      ? bot.transformers.snowflake(payload.application_id)
+      : undefined,
     messageReference: payload.message_reference
       ? {
-        messageId: payload.message_reference.message_id
-          ? bot.transformers.snowflake(payload.message_reference.message_id)
-          : undefined,
-        channelId: payload.message_reference.channel_id
-          ? bot.transformers.snowflake(payload.message_reference.channel_id)
-          : undefined,
-        guildId: payload.message_reference.guild_id
-          ? bot.transformers.snowflake(payload.message_reference.guild_id)
-          : undefined,
-      }
+          messageId: payload.message_reference.message_id
+            ? bot.transformers.snowflake(payload.message_reference.message_id)
+            : undefined,
+          channelId: payload.message_reference.channel_id
+            ? bot.transformers.snowflake(payload.message_reference.channel_id)
+            : undefined,
+          guildId: payload.message_reference.guild_id
+            ? bot.transformers.snowflake(payload.message_reference.guild_id)
+            : undefined,
+        }
       : undefined,
-    mentionedUserIds: payload.mentions ? payload.mentions.map((m) => bot.transformers.snowflake(m.id)) : [],
-    mentionedRoleIds: payload.mention_roles ? payload.mention_roles.map((id) => bot.transformers.snowflake(id)) : [],
+    mentionedUserIds: payload.mentions
+      ? payload.mentions.map((m) => bot.transformers.snowflake(m.id))
+      : [],
+    mentionedRoleIds: payload.mention_roles
+      ? payload.mention_roles.map((id) => bot.transformers.snowflake(id))
+      : [],
     mentionedChannelIds: [
       // Keep any ids tht discord sends
-      ...(payload.mention_channels ?? []).map((m) => bot.transformers.snowflake(m.id)),
+      ...(payload.mention_channels ?? []).map((m) =>
+        bot.transformers.snowflake(m.id)
+      ),
       // Add any other ids that can be validated in a channel mention format
       ...(payload.content?.match(CHANNEL_MENTION_REGEX) || []).map((text) =>
         // converts the <#123> into 123
         bot.transformers.snowflake(text.substring(2, text.length - 1))
       ),
     ],
-    member: payload.member && guildId ? bot.transformers.member(bot, payload.member, guildId, userId) : undefined,
+    member:
+      payload.member && guildId
+        ? bot.transformers.member(
+            bot,
+            payload.member,
+            guildId,
+            userId,
+            payload.author
+          )
+        : undefined,
     nonce: payload.nonce,
   };
 


### PR DESCRIPTION
Most of the times when message.member is present but message.member.user is not present.

https://github.com/discordeno/discordeno/blob/3a5bdce32d632f15ef8b6d3363ba4ea137698d17/types/discord.ts#L992
As seen here a discordmessage always has a user.

So if a member is present but member.user is not present add it.