### PR TITLE
helpers: add appliedTags to editHelper options

### DIFF
--- a/helpers/channels/editChannel.ts
+++ b/helpers/channels/editChannel.ts
@@ -97,6 +97,7 @@ export async function editChannel(bot: Bot, channelId: BigString, options: Modif
           emoji_name: availableTag.emojiName,
         }))
         : undefined,
+      applied_tags: options.appliedTags?.map((appliedTag) => appliedTag.toString()),
       default_reaction_emoji: options.defaultReactionEmoji
         ? {
           emoji_id: options.defaultReactionEmoji.emojiId,
@@ -215,6 +216,8 @@ export interface ModifyChannel extends WithReason {
     /** The unicode character of the emoji */
     emojiName: string;
   }[];
+  /** The IDs of the set of tags that have been applied to a thread in a GUILD_FORUM channel; limited to 5 */
+  appliedTags?: BigString[];
   /** the emoji to show in the add reaction button on a thread in a GUILD_FORUM channel */
   defaultReactionEmoji?: {
     /** The id of a guild's custom emoji */

--- a/plugins/permissions/src/channels/editChannel.ts
+++ b/plugins/permissions/src/channels/editChannel.ts
@@ -40,6 +40,8 @@ export function editChannel(bot: BotWithCache) {
         } else {
           perms.push("MANAGE_THREADS");
         }
+
+        if (options.appliedTags && options.appliedTags.length > 5) throw new Error("thread applied tags is limit to 5");
       } else {
         perms.push("MANAGE_CHANNELS");
 
@@ -68,6 +70,10 @@ export function editChannel(bot: BotWithCache) {
           if (category && category.type !== ChannelTypes.GuildCategory) {
             throw new Error("The parent id must be for a category channel type.");
           }
+        }
+
+        if (options.availableTags && options.availableTags.length > 20) {
+          throw new Error("channel available tags is limited to 20");
         }
       }
 


### PR DESCRIPTION
Closes: #2570 
Upstream: https://github.com/discord/discord-api-docs/commit/ebd68c8088d37d6082ab133ff4698c4c97f379b3
Docs:
[applied_tags: Edit Channel (Thread)](https://discord.com/developers/docs/resources/channel#modify-channel-json-params-thread)
[available_tags: Edit Channel (Guild Channel)](https://discord.com/developers/docs/resources/channel#modify-channel-json-params-guild-channel)