### PR TITLE
[helper] Fix entity metadata

### DIFF
--- a/helpers/guilds/events/editScheduledEvent.ts
+++ b/helpers/guilds/events/editScheduledEvent.ts
@@ -6,7 +6,7 @@ import {
   BigString,
   ScheduledEventEntityType,
   ScheduledEventPrivacyLevel,
-  ScheduledEventStatus,
+  ScheduledEventStatus
 } from "../../../types/shared.ts";
 
 /**
@@ -53,7 +53,7 @@ export async function editScheduledEvent(
     bot.constants.routes.GUILD_SCHEDULED_EVENT(guildId, eventId),
     {
       channel_id: options.channelId === null ? null : options.channelId?.toString(),
-      entity_metadata: options.location ? { location: options.location } : undefined,
+      entity_metadata: options.location ? { location: options.location } : null,
       name: options.name,
       description: options.description,
       scheduled_start_time: options.scheduledStartTime ? new Date(options.scheduledStartTime).toISOString() : undefined,

--- a/helpers/guilds/events/editScheduledEvent.ts
+++ b/helpers/guilds/events/editScheduledEvent.ts
@@ -6,7 +6,7 @@ import {
   BigString,
   ScheduledEventEntityType,
   ScheduledEventPrivacyLevel,
-  ScheduledEventStatus
+  ScheduledEventStatus,
 } from "../../../types/shared.ts";
 
 /**


### PR DESCRIPTION
As the discord docs, https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-field-requirements-by-entity-type said beside ENTITY TYPE is EXTERNAL, it should be null but it was undefined before. This should fix the integration test failing

Close #2592