### PR TITLE
fix: typing of button component label to be optional

### DIFF
--- a/packages/types/src/discord.ts
+++ b/packages/types/src/discord.ts
@@ -1249,7 +1249,7 @@ export interface DiscordMessage {
 //   /** All button components have type 2 */
 //   type: MessageComponentTypes.Button
 //   /** for what the button says (max 80 characters) */
-//   label: string
+//   label?: string
 //   /** a dev-defined unique string sent on click (max 100 characters). type 5 Link buttons can not have a custom_id */
 //   custom_id?: string
 //   /** For different styles/colors of the buttons */

--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -83,7 +83,7 @@ export interface CreateMessageOptions {
 //   /** All button components have type 2 */
 //   type: MessageComponentTypes.Button
 //   /** for what the button says (max 80 characters) */
-//   label: string
+//   label?: string
 //   /** a dev-defined unique string sent on click (max 100 characters). type 5 Link buttons can not have a custom_id */
 //   customId?: string
 //   /** For different styles/colors of the buttons */


### PR DESCRIPTION
In the [docs](https://discord.com/developers/docs/interactions/message-components#button-object-button-structure), label is an optional property but it's not in discordeno, this PR fixes that issue