### PR TITLE
perf(utils): optimize snake to camel case conversion

### DIFF
--- a/packages/utils/src/casing.ts
+++ b/packages/utils/src/casing.ts
@@ -23,7 +23,10 @@ export const camelize = <T>(object: T): Camelize<T> => {
   return object as Camelize<T>
 }
 
+const regex = /(_[a-z])/;
 function snakeToCamelCase(str: string) {
+  if (!regex.test(str)) return str
+
   let result = ''
   for (let i = 0, len = str.length; i < len; ++i) {
     if (str[i] === '_') {

--- a/packages/utils/src/casing.ts
+++ b/packages/utils/src/casing.ts
@@ -23,9 +23,8 @@ export const camelize = <T>(object: T): Camelize<T> => {
   return object as Camelize<T>
 }
 
-const regex = /(_[a-z])/;
 function snakeToCamelCase(str: string) {
-  if (!regex.test(str)) return str
+  if (!str.includes('_')) return str
 
   let result = ''
   for (let i = 0, len = str.length; i < len; ++i) {

--- a/packages/utils/src/casing.ts
+++ b/packages/utils/src/casing.ts
@@ -31,7 +31,7 @@ function snakeToCamelCase(str: string) {
     if (str[i] === '_') {
       result += str[i++].toUpperCase()
 
-      continue;
+      continue
     }
 
     result += str[i]

--- a/packages/utils/src/casing.ts
+++ b/packages/utils/src/casing.ts
@@ -1,4 +1,4 @@
-import type { Camelize } from '@discordeno/types';
+import type { Camelize } from '@discordeno/types'
 
 export const camelize = <T>(object: T): Camelize<T> => {
   if (Array.isArray(object)) {
@@ -24,16 +24,16 @@ export const camelize = <T>(object: T): Camelize<T> => {
 }
 
 function snakeToCamelCase(str: string) {
-  let result = "";
+  let result = ''
   for (let i = 0, len = str.length; i < len; ++i) {
-    if (str[i] === "_") {
-      result += str[i++].toUpperCase();
+    if (str[i] === '_') {
+      result += str[i++].toUpperCase()
 
       continue;
     }
 
-    result += str[i];
+    result += str[i]
   }
 
-  return result;
+  return result
 }

--- a/packages/utils/src/casing.ts
+++ b/packages/utils/src/casing.ts
@@ -1,4 +1,4 @@
-import type { Camelize } from '@discordeno/types'
+import type { Camelize } from '@discordeno/types';
 
 export const camelize = <T>(object: T): Camelize<T> => {
   if (Array.isArray(object)) {
@@ -12,9 +12,7 @@ export const camelize = <T>(object: T): Camelize<T> => {
       // @ts-expect-error
       (obj[
         typeof key === 'string'
-          ? key.replace(/([-_][a-z])/gi, ($1) => {
-            return $1.toUpperCase().replace('-', '').replace('_', '')
-          })
+          ? snakeToCamelCase(key)
           : key
       ] as Camelize<(T & object)[keyof T]>) = camelize(
         object[key]
@@ -23,4 +21,19 @@ export const camelize = <T>(object: T): Camelize<T> => {
     return obj
   }
   return object as Camelize<T>
+}
+
+function snakeToCamelCase(str: string) {
+  let result = "";
+  for (let i = 0, len = str.length; i < len; ++i) {
+    if (str[i] === "_") {
+      result += str[i++].toUpperCase();
+
+      continue;
+    }
+
+    result += str[i];
+  }
+
+  return result;
 }


### PR DESCRIPTION
Sometimes regex replaces can be pretty slow. Therefore I suggest to add a more performant converter function. 
This PR makes the related part of the code ~3.3 times faster.

@H01001000 Compared the old and new `camelize` functions on a `GUILD_CREATE` payload, the improvement was ~2.2x.