### PR TITLE
fix: await importDirectory call

### DIFF
--- a/plugins/fileloader/mod.ts
+++ b/plugins/fileloader/mod.ts
@@ -55,12 +55,11 @@ export async function fastFileLoader(
   before?: (uniqueFilePathCounter: number, paths: string[]) => void,
 ) {
   await Promise.all(
-    [...paths].map((path) => {
+    [...paths].map(async (path) => {
       if (between) between(path, uniqueFilePathCounter, paths);
-      importDirectory(path);
+      await importDirectory(path);
     }),
   );
-
   if (before) before(uniqueFilePathCounter, paths);
 
   await fileLoader();


### PR DESCRIPTION
When working with multiple directories that have many sub-directories all with multiple files that need to be loaded, it is possible for the `fileLoader` to be called prematurely as shown here:

![screenshot from Discord](https://cdn.discordapp.com/attachments/1071701118821875763/1071889808772837486/image.png)
*The imports as they would be written is logged directly from the `fileLoader` function while the individual paths are logged from the `importDirectory` function*

By awaiting the original call `importDirectory` we can wait for all recursive calls to finish running before calling `fileLoader`.

Test results locally:
![screenshot](https://cdn.discordapp.com/attachments/1071701118821875763/1071890008195219466/image.png)

Testing with multiple sub-directories that broke originally:
![screenshot](https://cdn.discordapp.com/attachments/1071701118821875763/1071890233748115497/image.png)

You can read more in the [Discord thread titled _"Fileloader having issues with directories."_](https://discord.com/channels/785384884197392384/1071701118821875763).
