### PR TITLE
test(bot): fix test type

### DIFF
--- a/packages/bot/tests/e2e/resetguilds.spec.ts
+++ b/packages/bot/tests/e2e/resetguilds.spec.ts
@@ -17,12 +17,12 @@ describe('[Bot] Delete any guild owned guilds', () => {
         events: {
           message: async (shard, data) => {
             // TRIGGER RAW EVENT
-            bot.events.raw?.(data, shard)
+            bot.events.raw?.(data, shard.id)
 
             if (!data.t) return
 
             // RUN DISPATCH CHECK
-            await bot.events.dispatchRequirements?.(data, shard)
+            await bot.events.dispatchRequirements?.(data, shard.id)
             bot.events[
               data.t.toLowerCase().replace(/_([a-z])/g, function (g) {
                 return g[1].toUpperCase()


### PR DESCRIPTION
fix type error in ci
```
Error: @discordeno/bot:test:test-type: tests/e2e/resetguilds.spec.ts(20,36): error TS2345: Argument of type 'DiscordenoShard' is not assignable to parameter of type 'number'.
Error: @discordeno/bot:test:test-type: tests/e2e/resetguilds.spec.ts(25,59): error TS2345: Argument of type 'DiscordenoShard' is not assignable to parameter of type 'number'.```
