### PR TITLE
docs(types): update `CreateGuildStickerOptions` file size

### DIFF
--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -1022,7 +1022,7 @@ export interface CreateGuildStickerOptions extends WithReason {
   description: string
   /** Autocomplete/suggestion tags for the sticker (max 200 characters) */
   tags: string
-  /** The sticker file to upload, must be a PNG, APNG, or Lottie JSON file, max 500 KB */
+  /** The sticker file to upload, must be a PNG, APNG, or Lottie JSON file, max 512 KB */
   file: FileContent
 }
 


### PR DESCRIPTION
Previously the maximum file size has been documented as 500 KB. This has now been updated to 512 KB.

Closes: https://github.com/discordeno/discordeno/issues/2875