### PR TITLE
docs(rest): webhook names cannot contain 'discord'

### DIFF
--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -480,7 +480,7 @@ export interface RestManager {
    * @remarks
    * Requires the `MANAGE_WEBHOOKS` permission.
    *
-   * ⚠️ The webhook name must not contain the string 'clyde' (case-insensitive).
+   * ⚠️ The webhook name must not contain the substrings 'clyde', or 'discord' (case-insensitive).
    *
    * Fires a _Webhooks Update_ gateway event.
    *


### PR DESCRIPTION
Closes: https://github.com/discordeno/discordeno/issues/2928