### PR TITLE
fix(rest, types)!: support auditlog reason

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -1065,8 +1065,8 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       return await rest.post<DiscordAutoModerationRule>(rest.routes.guilds.automod.rules(guildId), { body, reason })
     },
 
-    async createChannel(guildId, body) {
-      return await rest.post<DiscordChannel>(rest.routes.guilds.channels(guildId), { body })
+    async createChannel(guildId, body, reason) {
+      return await rest.post<DiscordChannel>(rest.routes.guilds.channels(guildId), { body, reason })
     },
 
     async createEmoji(guildId, body, reason) {
@@ -1289,8 +1289,8 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       await rest.patch(rest.routes.guilds.channels(guildId), { body })
     },
 
-    async editEmoji(guildId, id, body) {
-      return await rest.patch<DiscordEmoji>(rest.routes.guilds.emoji(guildId, id), { body })
+    async editEmoji(guildId, id, body, reason) {
+      return await rest.patch<DiscordEmoji>(rest.routes.guilds.emoji(guildId, id), { body, reason })
     },
 
     async editFollowupMessage(token, messageId, body) {

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -1061,16 +1061,16 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       await rest.put(rest.routes.channels.threads.user(channelId, userId))
     },
 
-    async createAutomodRule(guildId, body) {
-      return await rest.post<DiscordAutoModerationRule>(rest.routes.guilds.automod.rules(guildId), { body })
+    async createAutomodRule(guildId, body, reason) {
+      return await rest.post<DiscordAutoModerationRule>(rest.routes.guilds.automod.rules(guildId), { body, reason })
     },
 
     async createChannel(guildId, body) {
       return await rest.post<DiscordChannel>(rest.routes.guilds.channels(guildId), { body })
     },
 
-    async createEmoji(guildId, body) {
-      return await rest.post<DiscordEmoji>(rest.routes.guilds.emojis(guildId), { body })
+    async createEmoji(guildId, body, reason) {
+      return await rest.post<DiscordEmoji>(rest.routes.guilds.emojis(guildId), { body, reason })
     },
 
     async createGlobalApplicationCommand(body) {
@@ -1093,38 +1093,38 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       return await rest.post<DiscordGuild>(rest.routes.guilds.templates.code(templateCode), { body })
     },
 
-    async createGuildSticker(guildId, options) {
+    async createGuildSticker(guildId, options, reason) {
       const form = new FormData()
       form.append('file', options.file.blob, options.file.name)
       form.append('name', options.name)
       form.append('description', options.description)
       form.append('tags', options.tags)
 
-      return await rest.post<DiscordSticker>(rest.routes.guilds.stickers(guildId), { body: form })
+      return await rest.post<DiscordSticker>(rest.routes.guilds.stickers(guildId), { body: form, reason })
     },
 
     async createGuildTemplate(guildId, body) {
       return await rest.post<DiscordTemplate>(rest.routes.guilds.templates.all(guildId), { body })
     },
 
-    async createForumThread(channelId, body) {
-      return await rest.post<DiscordChannel>(rest.routes.channels.forum(channelId), { body, files: body.files })
+    async createForumThread(channelId, body, reason) {
+      return await rest.post<DiscordChannel>(rest.routes.channels.forum(channelId), { body, files: body.files, reason })
     },
 
-    async createInvite(channelId, body = {}) {
-      return await rest.post<DiscordInvite>(rest.routes.channels.invites(channelId), { body })
+    async createInvite(channelId, body = {}, reason) {
+      return await rest.post<DiscordInvite>(rest.routes.channels.invites(channelId), { body, reason })
     },
 
     async createRole(guildId, body, reason) {
       return await rest.post<DiscordRole>(rest.routes.guilds.roles.all(guildId), { body, reason })
     },
 
-    async createScheduledEvent(guildId, body) {
-      return await rest.post<DiscordScheduledEvent>(rest.routes.guilds.events.events(guildId), { body })
+    async createScheduledEvent(guildId, body, reason) {
+      return await rest.post<DiscordScheduledEvent>(rest.routes.guilds.events.events(guildId), { body, reason })
     },
 
-    async createStageInstance(body) {
-      return await rest.post<DiscordStageInstance>(rest.routes.channels.stages(), { body })
+    async createStageInstance(body, reason) {
+      return await rest.post<DiscordStageInstance>(rest.routes.channels.stages(), { body, reason })
     },
 
     async createWebhook(channelId, options, reason) {
@@ -1179,8 +1179,8 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       await rest.delete(rest.routes.guilds.templates.guild(guildId, templateCode))
     },
 
-    async deleteIntegration(guildId, integrationId) {
-      await rest.delete(rest.routes.guilds.integration(guildId, integrationId))
+    async deleteIntegration(guildId, integrationId, reason) {
+      await rest.delete(rest.routes.guilds.integration(guildId, integrationId), { reason })
     },
 
     async deleteInvite(inviteCode, reason) {
@@ -1220,8 +1220,8 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       await rest.delete(rest.routes.channels.reactions.emoji(channelId, messageId, reaction))
     },
 
-    async deleteRole(guildId, roleId) {
-      await rest.delete(rest.routes.guilds.roles.one(guildId, roleId))
+    async deleteRole(guildId, roleId, reason) {
+      await rest.delete(rest.routes.guilds.roles.one(guildId, roleId), { reason })
     },
 
     async deleteScheduledEvent(guildId, eventId) {
@@ -1262,8 +1262,8 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       )
     },
 
-    async editAutomodRule(guildId, ruleId, body) {
-      return await rest.patch<DiscordAutoModerationRule>(rest.routes.guilds.automod.rule(guildId, ruleId), { body })
+    async editAutomodRule(guildId, ruleId, body, reason) {
+      return await rest.patch<DiscordAutoModerationRule>(rest.routes.guilds.automod.rule(guildId, ruleId), { body, reason })
     },
 
     async editBotProfile(options) {
@@ -1277,12 +1277,12 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       })
     },
 
-    async editChannel(channelId, body) {
-      return await rest.patch<DiscordChannel>(rest.routes.channels.channel(channelId), { body })
+    async editChannel(channelId, body, reason) {
+      return await rest.patch<DiscordChannel>(rest.routes.channels.channel(channelId), { body, reason })
     },
 
-    async editChannelPermissionOverrides(channelId, body) {
-      await rest.put(rest.routes.channels.overwrite(channelId, body.id), { body })
+    async editChannelPermissionOverrides(channelId, body, reason) {
+      await rest.put(rest.routes.channels.overwrite(channelId, body.id), { body, reason })
     },
 
     async editChannelPositions(guildId, body) {
@@ -1304,8 +1304,8 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       return await rest.patch<DiscordApplicationCommand>(rest.routes.interactions.commands.command(rest.applicationId, commandId), { body })
     },
 
-    async editGuild(guildId, body) {
-      return await rest.patch<DiscordGuild>(rest.routes.guilds.guild(guildId), { body })
+    async editGuild(guildId, body, reason) {
+      return await rest.patch<DiscordGuild>(rest.routes.guilds.guild(guildId), { body, reason })
     },
 
     async editGuildApplicationCommand(commandId, guildId, body) {
@@ -1318,8 +1318,8 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       await rest.post(rest.routes.guilds.mfa(guildId), { body: { level: mfaLevel }, reason })
     },
 
-    async editGuildSticker(guildId, stickerId, body) {
-      return await rest.patch<DiscordSticker>(rest.routes.guilds.sticker(guildId, stickerId), { body })
+    async editGuildSticker(guildId, stickerId, body, reason) {
+      return await rest.patch<DiscordSticker>(rest.routes.guilds.sticker(guildId, stickerId), { body, reason })
     },
 
     async editGuildTemplate(guildId, templateCode: string, body: ModifyGuildTemplate): Promise<Camelize<DiscordTemplate>> {
@@ -1358,16 +1358,16 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       })
     },
 
-    async editScheduledEvent(guildId, eventId, body) {
-      return await rest.patch<DiscordScheduledEvent>(rest.routes.guilds.events.event(guildId, eventId), { body })
+    async editScheduledEvent(guildId, eventId, body, reason) {
+      return await rest.patch<DiscordScheduledEvent>(rest.routes.guilds.events.event(guildId, eventId), { body, reason })
     },
 
-    async editRole(guildId, roleId, body) {
-      return await rest.patch<DiscordRole>(rest.routes.guilds.roles.one(guildId, roleId), { body })
+    async editRole(guildId, roleId, body, reason) {
+      return await rest.patch<DiscordRole>(rest.routes.guilds.roles.one(guildId, roleId), { body, reason })
     },
 
-    async editRolePositions(guildId, body) {
-      return await rest.patch<DiscordRole[]>(rest.routes.guilds.roles.all(guildId), { body })
+    async editRolePositions(guildId, body, reason) {
+      return await rest.patch<DiscordRole[]>(rest.routes.guilds.roles.all(guildId), { body, reason })
     },
 
     async editStageInstance(channelId, topic, reason?: string) {
@@ -1378,8 +1378,8 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       await rest.patch(rest.routes.guilds.voice(guildId, options.userId), { body: options })
     },
 
-    async editWebhook(webhookId, body) {
-      return await rest.patch<DiscordWebhook>(rest.routes.webhooks.id(webhookId), { body })
+    async editWebhook(webhookId, body, reason) {
+      return await rest.patch<DiscordWebhook>(rest.routes.webhooks.id(webhookId), { body, reason })
     },
 
     async editWebhookMessage(webhookId, token, messageId, options) {
@@ -1393,12 +1393,12 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       return await rest.patch<DiscordWebhook>(rest.routes.webhooks.webhook(webhookId, token), { body })
     },
 
-    async editWelcomeScreen(guildId, body) {
-      return await rest.patch<DiscordWelcomeScreen>(rest.routes.guilds.welcome(guildId), { body })
+    async editWelcomeScreen(guildId, body, reason) {
+      return await rest.patch<DiscordWelcomeScreen>(rest.routes.guilds.welcome(guildId), { body, reason })
     },
 
-    async editWidgetSettings(guildId, body) {
-      return await rest.patch<DiscordGuildWidgetSettings>(rest.routes.guilds.widget(guildId), { body })
+    async editWidgetSettings(guildId, body, reason) {
+      return await rest.patch<DiscordGuildWidgetSettings>(rest.routes.guilds.widget(guildId), { body, reason })
     },
 
     async executeWebhook(webhookId, token, options) {
@@ -1729,28 +1729,28 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       return await rest.post<DiscordMessage>(rest.routes.channels.messages(channelId), { body, files: body.files })
     },
 
-    async startThreadWithMessage(channelId, messageId, body) {
-      return await rest.post<DiscordChannel>(rest.routes.channels.threads.message(channelId, messageId), { body })
+    async startThreadWithMessage(channelId, messageId, body, reason) {
+      return await rest.post<DiscordChannel>(rest.routes.channels.threads.message(channelId, messageId), { body, reason })
     },
 
-    async startThreadWithoutMessage(channelId, body) {
-      return await rest.post<DiscordChannel>(rest.routes.channels.threads.all(channelId), { body })
+    async startThreadWithoutMessage(channelId, body, reason) {
+      return await rest.post<DiscordChannel>(rest.routes.channels.threads.all(channelId), { body, reason })
     },
 
     async syncGuildTemplate(guildId) {
       return await rest.put<DiscordTemplate>(rest.routes.guilds.templates.all(guildId))
     },
 
-    async banMember(guildId, userId, body) {
-      await rest.put<void>(rest.routes.guilds.members.ban(guildId, userId), { body })
+    async banMember(guildId, userId, body, reason) {
+      await rest.put<void>(rest.routes.guilds.members.ban(guildId, userId), { body, reason })
     },
 
-    async editBotMember(guildId, body) {
-      return await rest.patch<DiscordMember>(rest.routes.guilds.members.bot(guildId), { body })
+    async editBotMember(guildId, body, reason) {
+      return await rest.patch<DiscordMember>(rest.routes.guilds.members.bot(guildId), { body, reason })
     },
 
-    async editMember(guildId, userId, body) {
-      return await rest.patch<DiscordMemberWithUser>(rest.routes.guilds.members.member(guildId, userId), { body })
+    async editMember(guildId, userId, body, reason) {
+      return await rest.patch<DiscordMemberWithUser>(rest.routes.guilds.members.member(guildId, userId), { body, reason })
     },
 
     async getMember(guildId, userId) {
@@ -1771,16 +1771,16 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       await rest.put(rest.routes.channels.pin(channelId, messageId), { reason })
     },
 
-    async pruneMembers(guildId, body) {
-      return await rest.post<{ pruned: number | null }>(rest.routes.guilds.members.prune(guildId), { body })
+    async pruneMembers(guildId, body, reason) {
+      return await rest.post<{ pruned: number | null }>(rest.routes.guilds.members.prune(guildId), { body, reason })
     },
 
     async searchMembers(guildId, query, options) {
       return await rest.get<DiscordMemberWithUser[]>(rest.routes.guilds.members.search(guildId, query, options))
     },
 
-    async unbanMember(guildId, userId) {
-      await rest.delete(rest.routes.guilds.members.ban(guildId, userId))
+    async unbanMember(guildId, userId, reason) {
+      await rest.delete(rest.routes.guilds.members.ban(guildId, userId), { reason })
     },
 
     async unpinMessage(channelId, messageId, reason) {

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -226,6 +226,7 @@ export interface RestManager {
    * @param guildId - The ID of the guild the member to add the role to is in.
    * @param userId - The user ID of the member to add the role to.
    * @param roleId - The ID of the role to add to the member.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    *
    * @remarks
    * Requires the `MANAGE_ROLES` permission.
@@ -255,6 +256,7 @@ export interface RestManager {
    *
    * @param guildId - The ID of the guild to create the rule in.
    * @param options - The parameters for the creation of the rule.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @returns An instance of the created {@link CamelizedDiscordAutoModerationRule}.
    *
    * @remarks
@@ -264,12 +266,13 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/auto-moderation#create-auto-moderation-rule}
    */
-  createAutomodRule: (guildId: BigString, options: CreateAutoModerationRuleOptions) => Promise<CamelizedDiscordAutoModerationRule>
+  createAutomodRule: (guildId: BigString, options: CreateAutoModerationRuleOptions, reason?: string) => Promise<CamelizedDiscordAutoModerationRule>
   /**
    * Creates a channel within a guild.
    *
    * @param guildId - The ID of the guild to create the channel within.
    * @param options - The parameters for the creation of the channel.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @returns An instance of the created {@link CamelizedDiscordChannel}.
    *
    * @remarks
@@ -283,12 +286,13 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/guild#create-guild-channel}
    */
-  createChannel: (guildId: BigString, options: CreateGuildChannel) => Promise<CamelizedDiscordChannel>
+  createChannel: (guildId: BigString, options: CreateGuildChannel, reason?: string) => Promise<CamelizedDiscordChannel>
   /**
    * Creates an emoji in a guild.
    *
    * @param guildId - The ID of the guild in which to create the emoji.
    * @param options - The parameters for the creation of the emoji.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @returns An instance of the created {@link CamelizedDiscordEmoji}.
    *
    * @remarks
@@ -300,12 +304,13 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/emoji#create-guild-emoji}
    */
-  createEmoji: (guildId: BigString, options: CreateGuildEmoji) => Promise<CamelizedDiscordEmoji>
+  createEmoji: (guildId: BigString, options: CreateGuildEmoji, reason?: string) => Promise<CamelizedDiscordEmoji>
   /**
    * Creates a new thread in a forum channel, and sends a message within the created thread.
    *
    * @param channelId - The ID of the forum channel to create the thread within.
    * @param options - The parameters for the creation of the thread.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @returns An instance of {@link CamelizedDiscordChannel} with a nested {@link Message} object.
    *
    * @remarks
@@ -318,7 +323,7 @@ export interface RestManager {
    *
    * @experimental
    */
-  createForumThread: (channelId: BigString, options: CreateForumPostWithMessage) => Promise<CamelizedDiscordChannel>
+  createForumThread: (channelId: BigString, options: CreateForumPostWithMessage, reason?: string) => Promise<CamelizedDiscordChannel>
   /**
    * Creates an application command accessible globally; across different guilds and channels.
    *
@@ -380,6 +385,7 @@ export interface RestManager {
    * Create a new sticker for the guild.
    *
    * @param guildId The ID of the guild to get
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @return A {@link CamelizedDiscordSticker}
    *
    * @remarks
@@ -390,7 +396,7 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/sticker#create-guild-sticker}
    */
-  createGuildSticker: (guildId: BigString, options: CreateGuildStickerOptions) => Promise<CamelizedDiscordSticker>
+  createGuildSticker: (guildId: BigString, options: CreateGuildStickerOptions, reason?: string) => Promise<CamelizedDiscordSticker>
   /**
    * Creates a template from a guild.
    *
@@ -411,6 +417,7 @@ export interface RestManager {
    *
    * @param channelId - The ID of the channel to create the invite to.
    * @param options - The parameters for the creation of the invite.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @returns An instance of the created {@link CamelizedDiscordInvite}.
    *
    * @remarks
@@ -423,12 +430,13 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/channel#create-channel-invite}
    */
-  createInvite: (channelId: BigString, options?: CreateChannelInvite) => Promise<CamelizedDiscordInvite>
+  createInvite: (channelId: BigString, options?: CreateChannelInvite, reason?: string) => Promise<CamelizedDiscordInvite>
   /**
    * Creates a role in a guild.
    *
    * @param guildId - The ID of the guild to create the role in.
    * @param options - The parameters for the creation of the role.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @returns An instance of the created {@link CamelizedDiscordRole}.
    *
    * @remarks
@@ -444,6 +452,7 @@ export interface RestManager {
    *
    * @param guildId - The ID of the guild to create the scheduled event in.
    * @param options - The parameters for the creation of the scheduled event.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @returns An instance of the created {@link ScheduledEvent}.
    *
    * @remarks
@@ -455,11 +464,12 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/guild-scheduled-event#create-guild-scheduled-event}
    */
-  createScheduledEvent: (guildId: BigString, options: CreateScheduledEvent) => Promise<CamelizedDiscordScheduledEvent>
+  createScheduledEvent: (guildId: BigString, options: CreateScheduledEvent, reason?: string) => Promise<CamelizedDiscordScheduledEvent>
   /**
    * Creates a stage instance associated with a stage channel.
    *
    * @param options - The parameters for the creation of the stage instance.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @returns An instance of the created {@link CamelizedDiscordStageInstance}.
    *
    * @remarks
@@ -469,12 +479,13 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/stage-instance#create-stage-instance}
    */
-  createStageInstance: (options: CreateStageInstance) => Promise<CamelizedDiscordStageInstance>
+  createStageInstance: (options: CreateStageInstance, reason?: string) Promise<CamelizedDiscordStageInstance>
   /**
    * Creates a webhook.
    *
    * @param channelId - The ID of the channel to create the webhook in.
    * @param options - The parameters for the creation of the webhook.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @returns An instance of the created {@link CamelizedDiscordWebhook}.
    *
    * @remarks
@@ -492,6 +503,7 @@ export interface RestManager {
    *
    * @param guildId - The ID of the guild to delete the rule from.
    * @param ruleId - The ID of the automod rule to delete.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    *
    * @remarks
    * Requires the `MANAGE_GUILD` permission.
@@ -505,6 +517,7 @@ export interface RestManager {
    * Deletes a channel from within a guild.
    *
    * @param channelId - The ID of the channel to delete.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @returns An instance of the deleted {@link Channel}.
    *
    * @remarks
@@ -531,6 +544,7 @@ export interface RestManager {
    *
    * @param channelId - The ID of the channel to delete the permission override of.
    * @param overwriteId - The ID of the permission override to delete.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    *
    * @remarks
    * Requires the `MANAGE_ROLES` permission.
@@ -545,6 +559,7 @@ export interface RestManager {
    *
    * @param guildId - The ID of the guild from which to delete the emoji.
    * @param id - The ID of the emoji to delete.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    *
    * @remarks
    * Requires the `MANAGE_EMOJIS_AND_STICKERS` permission.
@@ -602,6 +617,7 @@ export interface RestManager {
    * Delete a new sticker for the guild.
    *
    * @param guildId The ID of the guild to get
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @return A {@link CamelizedDiscordSticker}
    *
    * @remarks
@@ -632,6 +648,7 @@ export interface RestManager {
    *
    * @param guildId - The ID of the guild from which to delete the integration.
    * @param integrationId - The ID of the integration to delete from the guild.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    *
    * @remarks
    * Requires the `MANAGE_GUILD` permission.
@@ -643,11 +660,12 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/guild#delete-guild-integration}
    */
-  deleteIntegration: (guildId: BigString, integrationId: BigString) => Promise<void>
+  deleteIntegration: (guildId: BigString, integrationId: BigString, reason?: string) => Promise<void>
   /**
    * Deletes an invite to a channel.
    *
    * @param inviteCode - The invite code of the invite to delete.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    *
    * @remarks
    * Requires the `MANAGE_CHANNELS` permission.
@@ -662,6 +680,7 @@ export interface RestManager {
    *
    * @param channelId - The ID of the channel to delete the message from.
    * @param messageId - The ID of the message to delete from the channel.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    *
    * @remarks
    * If not deleting own message:
@@ -677,6 +696,7 @@ export interface RestManager {
    *
    * @param channelId - The ID of the channel to delete the messages from.
    * @param messageIds - The IDs of the messages to delete from the channel.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    *
    * @remarks
    * Requires the `MANAGE_MESSAGES` permission.
@@ -754,6 +774,7 @@ export interface RestManager {
    *
    * @param guildId - The ID of the guild to delete the role from.
    * @param roleId - The ID of the role to delete.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    *
    * @remarks
    * Requires the `MANAGE_ROLES` permission.
@@ -762,7 +783,7 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/guild#delete-guild-role}
    */
-  deleteRole: (guildId: BigString, roleId: BigString) => Promise<void>
+  deleteRole: (guildId: BigString, roleId: BigString, reason?: string) => Promise<void>
   /**
    * Deletes a scheduled event from a guild.
    *
@@ -781,6 +802,7 @@ export interface RestManager {
    * Deletes the stage instance associated with a stage channel, if one exists.
    *
    * @param channelId - The ID of the stage channel the stage instance is associated with.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    *
    * @remarks
    * Requires the user to be a moderator of the stage channel.
@@ -873,6 +895,7 @@ export interface RestManager {
    * @param guildId - The ID of the guild to edit the rule in.
    * @param ruleId - The ID of the rule to edit.
    * @param options - The parameters for the edit of the rule.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @returns An instance of the edited {@link CamelizedDiscordAutoModerationRule}.
    *
    * @remarks
@@ -886,6 +909,7 @@ export interface RestManager {
     guildId: BigString,
     ruleId: BigString,
     options: Partial<EditAutoModerationRuleOptions>,
+  reason?: string
   ) => Promise<CamelizedDiscordAutoModerationRule>
   /**
    * Modifies the bot's username or avatar.
@@ -897,6 +921,7 @@ export interface RestManager {
    *
    * @param channelId - The ID of the channel to edit.
    * @param options - The parameters for the edit of the channel.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @returns An instance of the edited {@link CamelizedDiscordChannel}.
    *
    * @remarks
@@ -921,12 +946,13 @@ export interface RestManager {
    * - Otherwise:
    *     - Fires a _Channel Update_ gateway event.
    */
-  editChannel: (channelId: BigString, options: ModifyChannel) => Promise<CamelizedDiscordChannel>
+  editChannel: (channelId: BigString, options: ModifyChannel, reason?: string) => Promise<CamelizedDiscordChannel>
   /**
    * Edits the permission overrides for a user or role in a channel.
    *
    * @param channelId - The ID of the channel to edit the permission overrides of.
    * @param options - The permission override.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    *
    * @remarks
    * Requires the `MANAGE_ROLES` permission.
@@ -937,7 +963,7 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/channel#edit-channel-permissions}
    */
-  editChannelPermissionOverrides: (channelId: BigString, options: EditChannelPermissionOverridesOptions) => Promise<void>
+  editChannelPermissionOverrides: (channelId: BigString, options: EditChannelPermissionOverridesOptions, reason?: string) => Promise<void>
   /**
    * Edits the positions of a set of channels in a guild.
    *
@@ -958,6 +984,7 @@ export interface RestManager {
    * @param guildId - The ID of the guild in which to edit the emoji.
    * @param id - The ID of the emoji to edit.
    * @param options - The parameters for the edit of the emoji.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @returns An instance of the updated {@link CamelizedDiscordEmoji}.
    *
    * @remarks
@@ -967,7 +994,7 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/emoji#modify-guild-emoji}
    */
-  editEmoji: (guildId: BigString, id: BigString, options: ModifyGuildEmoji) => Promise<CamelizedDiscordEmoji>
+  editEmoji: (guildId: BigString, id: BigString, options: ModifyGuildEmoji, reason?: string) => Promise<CamelizedDiscordEmoji>
   /**
    * Edits a follow-up message to an interaction.
    *
@@ -1002,6 +1029,7 @@ export interface RestManager {
    * @param guildId - The ID of the guild to edit.
    * @param shardId - The ID of the shard the guild is in.
    * @param options - The parameters for the edit of the guild.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @returns An instance of the edited {@link Guild}.
    *
    * @remarks
@@ -1014,7 +1042,7 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/guild#modify-guild}
    */
-  editGuild: (guildId: BigString, options: ModifyGuild) => Promise<CamelizedDiscordGuild>
+  editGuild: (guildId: BigString, options: ModifyGuild, reason?: string) => Promise<CamelizedDiscordGuild>
   /**
    * Edits an application command registered in a guild.
    *
@@ -1030,12 +1058,15 @@ export interface RestManager {
     guildId: BigString,
     options: CreateApplicationCommand,
   ) => Promise<CamelizedDiscordApplicationCommand>
-  /** Modify a guild's MFA level. Requires guild ownership. */
+  /** Modify a guild's MFA level. Requires guild ownership. 
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
+   */
   editGuildMfaLevel: (guildId: BigString, mfaLevel: MfaLevels, reason?: string) => Promise<void>
   /**
    * Edit the given sticker.
    *
    * @param guildId The ID of the guild to get
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @return A {@link CamelizedDiscordSticker}
    *
    * @remarks
@@ -1044,7 +1075,7 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/sticker#modify-guild-sticker}
    */
-  editGuildSticker: (guildId: BigString, stickerId: BigString, options: AtLeastOne<EditGuildStickerOptions>) => Promise<CamelizedDiscordSticker>
+  editGuildSticker: (guildId: BigString, stickerId: BigString, options: AtLeastOne<EditGuildStickerOptions>, reason?: string) => Promise<CamelizedDiscordSticker>
   /**
    * Edits a template's settings.
    *
@@ -1138,6 +1169,7 @@ export interface RestManager {
    * @param guildId - The ID of the guild to edit the role in.
    * @param roleId - The ID of the role to edit.
    * @param options - The parameters for the edit of the role.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @returns An instance of the edited {@link CamelizedDiscordRole}.
    *
    * @remarks
@@ -1147,12 +1179,13 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/guild#modify-guild-role}
    */
-  editRole: (guildId: BigString, roleId: BigString, options: EditGuildRole) => Promise<CamelizedDiscordRole>
+  editRole: (guildId: BigString, roleId: BigString, options: EditGuildRole, reason?: string) => Promise<CamelizedDiscordRole>
   /**
    * Edits the positions of a set of roles.
    *
    * @param guildId - The ID of the guild to edit the role positions in.
    * @param options - The parameters for the edit of the role positions.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @returns A collection of {@link CamelizedDiscordRole} objects assorted by role ID.
    *
    * @remarks
@@ -1162,12 +1195,13 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/guild#modify-guild-role-positions}
    */
-  editRolePositions: (guildId: BigString, options: ModifyRolePositions[]) => Promise<CamelizedDiscordRole[]>
+  editRolePositions: (guildId: BigString, options: ModifyRolePositions[], reason?: string) => Promise<CamelizedDiscordRole[]>
   /**
    * Edits a scheduled event.
    *
    * @param guildId - The ID of the guild to edit the scheduled event in.
    * @param eventId - The ID of the scheduled event to edit.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @returns An instance of the edited {@link ScheduledEvent}.
    *
    * @remarks
@@ -1181,12 +1215,13 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/guild-scheduled-event#modify-guild-scheduled-event}
    */
-  editScheduledEvent: (guildId: BigString, eventId: BigString, options: Partial<EditScheduledEvent>) => Promise<CamelizedDiscordScheduledEvent>
+  editScheduledEvent: (guildId: BigString, eventId: BigString, options: Partial<EditScheduledEvent>, reason?: string) => Promise<CamelizedDiscordScheduledEvent>
   /**
    * Edits a stage instance.
    *
    * @param channelId - The ID of the stage channel the stage instance is associated with.
    * @param topic - Topic of the Stage instance (1-120 characters).
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @returns An instance of the updated {@link CamelizedDiscordStageInstance}.
    *
    * @remarks
@@ -1215,6 +1250,7 @@ export interface RestManager {
    * Edits a webhook.
    *
    * @param webhookId - The ID of the webhook to edit.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @returns An instance of the edited {@link CamelizedDiscordWebhook}.
    *
    * @remarks
@@ -1224,7 +1260,7 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/webhook#edit-webhook}
    */
-  editWebhook: (webhookId: BigString, options: ModifyWebhook) => Promise<CamelizedDiscordWebhook>
+  editWebhook: (webhookId: BigString, options: ModifyWebhook, reason?: string) => Promise<CamelizedDiscordWebhook>
   /**
    * Edits a webhook message.
    *
@@ -1265,6 +1301,7 @@ export interface RestManager {
    *
    * @param guildId - The ID of the guild to edit the welcome screen of.
    * @param options - The parameters for the edit of the welcome screen.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @returns An instance of the edited {@link WelcomeScreen}.
    *
    * @remarks
@@ -1274,11 +1311,12 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/guild#modify-guild-welcome-screen}
    */
-  editWelcomeScreen: (guildId: BigString, options: CamelizedDiscordModifyGuildWelcomeScreen) => Promise<CamelizedDiscordWelcomeScreen>
+  editWelcomeScreen: (guildId: BigString, options: CamelizedDiscordModifyGuildWelcomeScreen, reason?: string) => Promise<CamelizedDiscordWelcomeScreen>
   /**
    * Edits the settings of a guild's widget.
    *
    * @param guildId - The ID of the guild to edit the settings of the widget of.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @returns An instance of the edited {@link GuildWidgetSettings}.
    *
    * @remarks
@@ -1288,7 +1326,7 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/guild#modify-guild-widget}
    */
-  editWidgetSettings: (guildId: BigString, options: CamelizedDiscordGuildWidgetSettings) => Promise<CamelizedDiscordGuildWidgetSettings>
+  editWidgetSettings: (guildId: BigString, options: CamelizedDiscordGuildWidgetSettings, reason?: string) => Promise<CamelizedDiscordGuildWidgetSettings>
   /**
    * Executes a webhook, causing a message to be posted in the channel configured for the webhook.
    *
@@ -2081,6 +2119,7 @@ export interface RestManager {
    * @param guildId - The ID of the guild the member to remove the role from is in.
    * @param userId - The user ID of the member to remove the role from.
    * @param roleId - The ID of the role to remove from the member.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    *
    * @remarks
    * Requires the `MANAGE_ROLES` permission.
@@ -2183,6 +2222,7 @@ export interface RestManager {
    * @param channelId - The ID of the channel in which to create the thread.
    * @param messageId - The ID of the message to use as the thread's point of origin.
    * @param options - The parameters to use for the creation of the thread.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @returns An instance of the created {@link Channel | Thread}.
    *
    * @remarks
@@ -2196,12 +2236,13 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/channel#start-thread-from-message}
    */
-  startThreadWithMessage: (channelId: BigString, messageId: BigString, options: StartThreadWithMessage) => Promise<CamelizedDiscordChannel>
+  startThreadWithMessage: (channelId: BigString, messageId: BigString, options: StartThreadWithMessage, reason?: string) => Promise<CamelizedDiscordChannel>
   /**
    * Creates a thread without using a message as the thread's point of origin.
    *
    * @param channelId - The ID of the channel in which to create the thread.
    * @param options - The parameters to use for the creation of the thread.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @returns An instance of the created {@link CamelizedDiscordChannel | Thread}.
    *
    * @remarks
@@ -2211,7 +2252,7 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/channel#start-thread-without-message}
    */
-  startThreadWithoutMessage: (channelId: BigString, options: StartThreadWithoutMessage) => Promise<CamelizedDiscordChannel>
+  startThreadWithoutMessage: (channelId: BigString, options: StartThreadWithoutMessage, reason?: string) => Promise<CamelizedDiscordChannel>
   /**
    * Synchronises a template with the current state of a guild.
    *
@@ -2271,9 +2312,9 @@ export interface RestManager {
   /**
    * Bans a user from a guild.
    *
-  
    * @param guildId - The ID of the guild to ban the user from.
    * @param userId - The ID of the user to ban from the guild.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @param options - The parameters for the creation of the ban.
    *
    * @remarks
@@ -2283,12 +2324,13 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/guild#create-guild-ban}
    */
-  banMember: (guildId: BigString, userId: BigString, options?: CreateGuildBan) => Promise<void>
+  banMember: (guildId: BigString, userId: BigString, options?: CreateGuildBan, reason?: string) => Promise<void>
   /**
    * Edits the nickname of the bot user.
    *
    * @param guildId - The ID of the guild to edit the nickname of the bot user in.
    * @param options - The parameters for the edit of the nickname.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @returns An instance of the edited {@link CamelizedDiscordMember}
    *
    * @remarks
@@ -2296,12 +2338,13 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/guild#modify-current-member}
    */
-  editBotMember: (guildId: BigString, options: EditBotMemberOptions) => Promise<CamelizedDiscordMember>
+  editBotMember: (guildId: BigString, options: EditBotMemberOptions, reason?: string) => Promise<CamelizedDiscordMember>
   /**
    * Edits a member's properties.
    *
    * @param guildId - The ID of the guild to edit the member of.
    * @param userId - The user ID of the member to edit.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @param options - The parameters for the edit of the user.
    *
    * @remarks
@@ -2312,7 +2355,7 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/guild#modify-guild-member}
    */
-  editMember: (guildId: BigString, userId: BigString, options: ModifyGuildMember) => Promise<CamelizedDiscordMember>
+  editMember: (guildId: BigString, userId: BigString, options: ModifyGuildMember, reason?: string) => Promise<CamelizedDiscordMember>
   /**
    * Gets the member object by user ID.
    *
@@ -2350,6 +2393,7 @@ export interface RestManager {
   
    * @param guildId - The ID of the guild to kick the member from.
    * @param userId - The user ID of the member to kick from the guild.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    *
    * @remarks
    * Requires the `KICK_MEMBERS` permission.
@@ -2364,6 +2408,7 @@ export interface RestManager {
    *
    * @param channelId - The ID of the channel where the message is to be pinned.
    * @param messageId - The ID of the message to pin.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    *
    * @remarks
    * Requires that the bot user be able to see the contents of the channel in which the messages were posted.
@@ -2383,6 +2428,7 @@ export interface RestManager {
   
    * @param guildId - The ID of the guild to prune the members of.
    * @param options - The parameters for the pruning of members.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @returns A number indicating how many members were pruned.
    *
    * @remarks
@@ -2396,7 +2442,7 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/guild#begin-guild-prune}
    */
-  pruneMembers: (guildId: BigString, options: BeginGuildPrune) => Promise<{ pruned: number | null }>
+  pruneMembers: (guildId: BigString, options: BeginGuildPrune, reason?: string) => Promise<{ pruned: number | null }>
   /**
    * Gets the list of members whose usernames or nicknames start with a provided string.
    *
@@ -2415,6 +2461,7 @@ export interface RestManager {
   
    * @param guildId - The ID of the guild to unban the user in.
    * @param userId - The ID of the user to unban.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    *
    * @remarks
    * Requires the `BAN_MEMBERS` permission.
@@ -2423,12 +2470,13 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/guild#remove-guild-ban}
    */
-  unbanMember: (guildId: BigString, userId: BigString) => Promise<void>
+  unbanMember: (guildId: BigString, userId: BigString, reason?: string) => Promise<void>
   /**
    * Unpins a pinned message in a channel.
    *
    * @param channelId - The ID of the channel where the message is pinned.
    * @param messageId - The ID of the message to unpin.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    *
    * @remarks
    * Requires that the bot user be able to see the contents of the channel in which the messages were posted.

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -479,7 +479,7 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/stage-instance#create-stage-instance}
    */
-  createStageInstance: (options: CreateStageInstance, reason?: string) Promise<CamelizedDiscordStageInstance>
+  createStageInstance: (options: CreateStageInstance, reason?: string) => Promise<CamelizedDiscordStageInstance>
   /**
    * Creates a webhook.
    *
@@ -909,7 +909,7 @@ export interface RestManager {
     guildId: BigString,
     ruleId: BigString,
     options: Partial<EditAutoModerationRuleOptions>,
-  reason?: string
+    reason?: string,
   ) => Promise<CamelizedDiscordAutoModerationRule>
   /**
    * Modifies the bot's username or avatar.
@@ -1058,7 +1058,7 @@ export interface RestManager {
     guildId: BigString,
     options: CreateApplicationCommand,
   ) => Promise<CamelizedDiscordApplicationCommand>
-  /** Modify a guild's MFA level. Requires guild ownership. 
+  /** Modify a guild's MFA level. Requires guild ownership.
    * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    */
   editGuildMfaLevel: (guildId: BigString, mfaLevel: MfaLevels, reason?: string) => Promise<void>
@@ -1075,7 +1075,12 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/sticker#modify-guild-sticker}
    */
-  editGuildSticker: (guildId: BigString, stickerId: BigString, options: AtLeastOne<EditGuildStickerOptions>, reason?: string) => Promise<CamelizedDiscordSticker>
+  editGuildSticker: (
+    guildId: BigString,
+    stickerId: BigString,
+    options: AtLeastOne<EditGuildStickerOptions>,
+    reason?: string,
+  ) => Promise<CamelizedDiscordSticker>
   /**
    * Edits a template's settings.
    *
@@ -1215,7 +1220,12 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/guild-scheduled-event#modify-guild-scheduled-event}
    */
-  editScheduledEvent: (guildId: BigString, eventId: BigString, options: Partial<EditScheduledEvent>, reason?: string) => Promise<CamelizedDiscordScheduledEvent>
+  editScheduledEvent: (
+    guildId: BigString,
+    eventId: BigString,
+    options: Partial<EditScheduledEvent>,
+    reason?: string,
+  ) => Promise<CamelizedDiscordScheduledEvent>
   /**
    * Edits a stage instance.
    *
@@ -1311,7 +1321,11 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/guild#modify-guild-welcome-screen}
    */
-  editWelcomeScreen: (guildId: BigString, options: CamelizedDiscordModifyGuildWelcomeScreen, reason?: string) => Promise<CamelizedDiscordWelcomeScreen>
+  editWelcomeScreen: (
+    guildId: BigString,
+    options: CamelizedDiscordModifyGuildWelcomeScreen,
+    reason?: string,
+  ) => Promise<CamelizedDiscordWelcomeScreen>
   /**
    * Edits the settings of a guild's widget.
    *
@@ -1326,7 +1340,11 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/guild#modify-guild-widget}
    */
-  editWidgetSettings: (guildId: BigString, options: CamelizedDiscordGuildWidgetSettings, reason?: string) => Promise<CamelizedDiscordGuildWidgetSettings>
+  editWidgetSettings: (
+    guildId: BigString,
+    options: CamelizedDiscordGuildWidgetSettings,
+    reason?: string,
+  ) => Promise<CamelizedDiscordGuildWidgetSettings>
   /**
    * Executes a webhook, causing a message to be posted in the channel configured for the webhook.
    *
@@ -2236,7 +2254,12 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/channel#start-thread-from-message}
    */
-  startThreadWithMessage: (channelId: BigString, messageId: BigString, options: StartThreadWithMessage, reason?: string) => Promise<CamelizedDiscordChannel>
+  startThreadWithMessage: (
+    channelId: BigString,
+    messageId: BigString,
+    options: StartThreadWithMessage,
+    reason?: string,
+  ) => Promise<CamelizedDiscordChannel>
   /**
    * Creates a thread without using a message as the thread's point of origin.
    *

--- a/packages/rest/tests/e2e/guild.spec.ts
+++ b/packages/rest/tests/e2e/guild.spec.ts
@@ -82,10 +82,14 @@ describe('Manage Guilds', async () => {
   })
 
   it('Banning members', async () => {
-    await rest.banMember(e2ecache.guild.id, '379643682984296448', {
-      reason: 'Blame Wolf',
-      deleteMessageSeconds: 604800,
-    })
+    await rest.banMember(
+      e2ecache.guild.id,
+      '379643682984296448',
+      {
+        deleteMessageSeconds: 604800,
+      },
+      'Blame Wolf',
+    )
     const fetchedBan = await rest.getBan(e2ecache.guild.id, '379643682984296448')
 
     // Assertions

--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -492,7 +492,7 @@ export interface ApplicationCommandOption {
 }
 
 /** https://discord.com/developers/docs/resources/emoji#create-guild-emoji */
-export interface CreateGuildEmoji extends WithReason {
+export interface CreateGuildEmoji {
   /** Name of the emoji */
   name: string
   /** The 128x128 emoji image. Emojis and animated emojis have a maximum file size of 256kb. Attempting to upload an emoji larger than this limit will fail and return 400 Bad Request and an error message, but not a JSON status code. If a URL is provided to the image parameter, Discordeno will automatically convert it to a base64 string internally. */
@@ -502,7 +502,7 @@ export interface CreateGuildEmoji extends WithReason {
 }
 
 /** https://discord.com/developers/docs/resources/emoji#modify-guild-emoji */
-export interface ModifyGuildEmoji extends WithReason {
+export interface ModifyGuildEmoji {
   /** Name of the emoji */
   name?: string
   /** Roles allowed to use this emoji */
@@ -525,7 +525,7 @@ export interface RequestGuildMembers {
   nonce?: string
 }
 
-export interface CreateGuildChannel extends WithReason {
+export interface CreateGuildChannel {
   /** Channel name (1-100 characters) */
   name: string
   /** The type of channel */
@@ -572,7 +572,7 @@ export interface CreateGuildChannel extends WithReason {
   defaultSortOrder?: SortOrderTypes | null
 }
 
-export interface ModifyChannel extends WithReason {
+export interface ModifyChannel {
   /** 1-100 character channel name */
   name?: string
   /** The type of channel; only conversion between text and news is supported and only in guilds with the "NEWS" feature */
@@ -634,7 +634,7 @@ export interface ModifyChannel extends WithReason {
   defaultSortOrder?: SortOrderTypes | null
 }
 
-export interface EditChannelPermissionOverridesOptions extends OverwriteReadable, WithReason {}
+export interface EditChannelPermissionOverridesOptions extends OverwriteReadable {}
 
 /** https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions */
 export interface ModifyGuildChannelPositions {
@@ -648,7 +648,7 @@ export interface ModifyGuildChannelPositions {
   parentId?: BigString | null
 }
 
-export interface ModifyWebhook extends WithReason {
+export interface ModifyWebhook {
   /** The default name of the webhook */
   name?: string
   /** Image for the default webhook avatar */
@@ -712,7 +712,7 @@ export interface CreateForumPostWithMessage extends WithReason {
   components?: MessageComponents
 }
 
-export interface CreateStageInstance extends WithReason {
+export interface CreateStageInstance {
   channelId: BigString
   topic: string
   /** Notify @everyone that the stage instance has started. Requires the MENTION_EVERYONE permission. */
@@ -724,7 +724,7 @@ export interface EditStageInstanceOptions extends WithReason {
   topic: string
 }
 
-export interface StartThreadWithMessage extends WithReason {
+export interface StartThreadWithMessage {
   /** 1-100 character thread name */
   name: string
   /** Duration in minutes to automatically archive the thread after recent activity */
@@ -733,7 +733,7 @@ export interface StartThreadWithMessage extends WithReason {
   rateLimitPerUser?: number | null
 }
 
-export interface StartThreadWithoutMessage extends WithReason {
+export interface StartThreadWithoutMessage {
   /** 1-100 character thread name */
   name: string
   /** Duration in minutes to automatically archive the thread after recent activity */
@@ -746,7 +746,7 @@ export interface StartThreadWithoutMessage extends WithReason {
   invitable?: boolean
 }
 
-export interface CreateAutoModerationRuleOptions extends WithReason {
+export interface CreateAutoModerationRuleOptions {
   /** The name of the rule. */
   name: string
   /** The type of event to trigger the rule on. */
@@ -784,7 +784,7 @@ export interface CreateAutoModerationRuleOptions extends WithReason {
   exemptChannels?: BigString[]
 }
 
-export interface EditAutoModerationRuleOptions extends WithReason {
+export interface EditAutoModerationRuleOptions {
   /** The name of the rule. */
   name: string
   /** The type of event to trigger the rule on. */
@@ -820,7 +820,7 @@ export interface EditAutoModerationRuleOptions extends WithReason {
   exemptChannels?: BigString[]
 }
 
-export interface CreateScheduledEvent extends WithReason {
+export interface CreateScheduledEvent {
   /** the channel id of the scheduled event. */
   channelId?: BigString
   /** location of the event. Required for events with `entityType: ScheduledEventEntityType.External` */
@@ -839,7 +839,7 @@ export interface CreateScheduledEvent extends WithReason {
   entityType: ScheduledEventEntityType
 }
 
-export interface EditScheduledEvent extends WithReason {
+export interface EditScheduledEvent {
   /** the channel id of the scheduled event. null if switching to external event. */
   channelId: BigString | null
   /** location of the event */
@@ -865,7 +865,7 @@ export interface GetScheduledEvents {
   withUserCount?: boolean
 }
 
-export interface CreateChannelInvite extends WithReason {
+export interface CreateChannelInvite {
   /** Duration of invite in seconds before expiry, or 0 for never. Between 0 and 604800 (7 days). Default: 86400 (24 hours) */
   maxAge?: number
   /** Max number of users or 0 for unlimited. Between 0 and 100. Default: 0 */
@@ -1017,7 +1017,7 @@ export interface ModifyGuild {
   premiumProgressBarEnabled?: boolean
 }
 
-export interface CreateGuildStickerOptions extends WithReason {
+export interface CreateGuildStickerOptions {
   /** Name of the sticker (2-30 characters) */
   name: string
   /** Description of the sticker (empty or 2-100 characters) */
@@ -1028,7 +1028,7 @@ export interface CreateGuildStickerOptions extends WithReason {
   file: FileContent
 }
 
-export interface EditGuildStickerOptions extends WithReason {
+export interface EditGuildStickerOptions {
   /** Name of the sticker (2-30 characters) */
   name?: string
   /** Description of the sticker (empty or 2-100 characters) */
@@ -1095,12 +1095,12 @@ export interface ModifyGuildTemplate {
 }
 
 /** https://discord.com/developers/docs/resources/guild#create-guild-ban */
-export interface CreateGuildBan extends WithReason {
+export interface CreateGuildBan {
   /** Number of seconds to delete messages for, between 0 and 604800 (7 days) */
   deleteMessageSeconds?: number
 }
 
-export interface EditBotMemberOptions extends WithReason {
+export interface EditBotMemberOptions {
   nick?: string | null
 }
 

--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -267,11 +267,6 @@ export interface SearchMembers {
   limit?: number
 }
 
-export interface WithReason {
-  /** The reason which should be added in the audit logs for doing this action. */
-  reason?: string
-}
-
 export interface OverwriteReadable {
   /** Role or user id */
   id: bigint
@@ -693,7 +688,7 @@ export interface DeleteWebhookMessageOptions {
   threadId: BigString
 }
 
-export interface CreateForumPostWithMessage extends WithReason {
+export interface CreateForumPostWithMessage {
   /** 1-100 character thread name */
   name: string
   /** Duration in minutes to automatically archive the thread after recent activity */
@@ -719,7 +714,7 @@ export interface CreateStageInstance {
   sendStartNotification?: boolean
 }
 
-export interface EditStageInstanceOptions extends WithReason {
+export interface EditStageInstanceOptions {
   /** The topic of the Stage instance (1-120 characters) */
   topic: string
 }


### PR DESCRIPTION
Improved the consistency by separating the audit log reason to an optional function parameter. Also added support for 100% documented reason endpoints.