### PR TITLE
refactor(rest): interaction handling

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -939,7 +939,9 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       const url = rest.simplifyUrl(request.url, request.method)
 
       if (request.runThroughQueue === false) {
-        return rest.sendRequest(request)
+        rest.sendRequest(request)
+
+        return
       }
 
       const queue = rest.queues.get(url)

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -924,7 +924,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       return parts.join('/')
     },
 
-    processRequest(request: SendRequestOptions) {
+    async processRequest(request: SendRequestOptions) {
       const route = request.url.substring(request.url.indexOf('api/'))
       const parts = route.split('/')
       // Remove the api/
@@ -937,7 +937,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       const url = rest.simplifyUrl(request.url, request.method)
 
       if (request.runThroughQueue === false) {
-        rest.sendRequest(request)
+        await rest.sendRequest(request)
 
         return
       }
@@ -971,14 +971,14 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
         return result.status !== 204 ? ((await result.json()) as any) : undefined
       }
 
-      return await new Promise((resolve, reject) => {
+      return await new Promise(async (resolve, reject) => {
         const payload: SendRequestOptions = {
           url,
           method,
           requestBodyOptions: options,
           retryCount: 0,
           retryRequest: async function (payload: SendRequestOptions) {
-            rest.processRequest(payload)
+            await rest.processRequest(payload)
           },
           resolve: (data) => {
             resolve(data.status !== 204 ? JSON.parse(data.body ?? '{}') : undefined)
@@ -987,7 +987,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
           runThroughQueue: options?.runThroughQueue,
         }
 
-        rest.processRequest(payload)
+        await rest.processRequest(payload)
       })
     },
 

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -1699,7 +1699,6 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       return await rest.post(rest.routes.webhooks.webhook(rest.applicationId, token), {
         body: options,
         files: options.files,
-        runThroughQueue: false,
         unauthorized: true,
       })
     },

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -1705,7 +1705,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
     async sendInteractionResponse(interactionId, token, options) {
       return await rest.post(rest.routes.interactions.responses.callback(interactionId, token), {
         body: options,
-        files: options.files,
+        files: options.data?.files,
         runThroughQueue: false,
         unauthorized: true,
       })

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -171,7 +171,7 @@ export interface RestManager {
   /** Make a request to be sent to the api. */
   makeRequest: <T = unknown>(method: RequestMethods, url: string, options?: MakeRequestOptions) => Promise<T>
   /** Takes a request and processes it into a queue. */
-  processRequest: (request: SendRequestOptions) => void
+  processRequest: (request: SendRequestOptions) => Promise<void>
   /** Make a get request to the api */
   get: <T = void>(url: string, options?: Omit<MakeRequestOptions, 'body'>) => Promise<Camelize<T>>
   /** Make a post request to the api. */

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -169,19 +169,19 @@ export interface RestManager {
   /** Split a url to separate rate limit buckets based on major/minor parameters. */
   simplifyUrl: (url: string, method: RequestMethods) => string
   /** Make a request to be sent to the api. */
-  makeRequest: <T = unknown>(method: RequestMethods, url: string, options?: Omit<CreateRequestBodyOptions, 'method'>) => Promise<T>
+  makeRequest: <T = unknown>(method: RequestMethods, url: string, options?: MakeRequestOptions) => Promise<T>
   /** Takes a request and processes it into a queue. */
   processRequest: (request: SendRequestOptions) => void
   /** Make a get request to the api */
-  get: <T = void>(url: string, options?: Omit<CreateRequestBodyOptions, 'body' | 'method'>) => Promise<Camelize<T>>
+  get: <T = void>(url: string, options?: Omit<MakeRequestOptions, 'body'>) => Promise<Camelize<T>>
   /** Make a post request to the api. */
-  post: <T = void>(url: string, options?: Omit<CreateRequestBodyOptions, 'method'>) => Promise<Camelize<T>>
+  post: <T = void>(url: string, options?: MakeRequestOptions) => Promise<Camelize<T>>
   /** Make a put request to the api. */
-  put: <T = void>(url: string, options?: Omit<CreateRequestBodyOptions, 'method'>) => Promise<Camelize<T>>
+  put: <T = void>(url: string, options?: MakeRequestOptions) => Promise<Camelize<T>>
   /** Make a delete request to the api. */
-  delete: (url: string, options?: Omit<CreateRequestBodyOptions, 'body' | 'method'>) => Promise<void>
+  delete: (url: string, options?: Omit<MakeRequestOptions, 'body'>) => Promise<void>
   /** Make a patch request to the api. */
-  patch: <T = void>(url: string, options?: Omit<CreateRequestBodyOptions, 'method'>) => Promise<Camelize<T>>
+  patch: <T = void>(url: string, options?: MakeRequestOptions) => Promise<Camelize<T>>
   /**
    * Adds a reaction to a message.
    *
@@ -2460,6 +2460,8 @@ export interface CreateRequestBodyOptions {
   files?: FileContent[]
 }
 
+export type MakeRequestOptions = Omit<CreateRequestBodyOptions, 'method'> & Pick<SendRequestOptions, 'runThroughQueue'>
+
 export interface RequestBody {
   headers: Record<string, string>
   body?: string | FormData
@@ -2483,6 +2485,11 @@ export interface SendRequestOptions {
   bucketId?: string
   /** Additional request options, used for things like overriding authorization header. */
   requestBodyOptions?: CreateRequestBodyOptions
+  /**
+   * Whether the request should be run through the queue.
+   * Useful for routes which do not have any rate limits.
+   */
+  runThroughQueue?: boolean
 }
 
 export interface RestRateLimitedPath {


### PR DESCRIPTION
Currently some interaction handling uses `sendRequest` directly. This adds the `runThroughQueue` option, which prevents the request to be handled by a queue effectively giving the same effect as using `sendRequest` directly. This prevents code repetition and supports future endpoints which might not have a rate limit too.

Further more all interaction related endpoints have now been set to not send the bots authorization header.