### PR TITLE
refactor(rest)!: remove falsy token check

### DIFF
--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -32,7 +32,7 @@ import type { VoiceState } from './transformers/voiceState.js'
  * @returns Bot
  */
 export function createBot(options: CreateBotOptions): Bot {
-  if (!options.rest) options.rest = { token: options.token, applicationId: getBotIdFromToken(options.token) }
+  if (!options.rest) options.rest = { token: options.token }
   if (!options.gateway) options.gateway = { token: options.token, events: {} }
   if (!options.gateway.events.message) {
     options.gateway.events.message = async (shard, data) => {

--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -32,7 +32,7 @@ import type { VoiceState } from './transformers/voiceState.js'
  * @returns Bot
  */
 export function createBot(options: CreateBotOptions): Bot {
-  if (!options.rest) options.rest = { token: options.token }
+  if (!options.rest) options.rest = { token: options.token, applicationId: getBotIdFromToken(options.token) }
   if (!options.gateway) options.gateway = { token: options.token, events: {} }
   if (!options.gateway.events.message) {
     options.gateway.events.message = async (shard, data) => {

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -6,7 +6,6 @@ import {
   camelize,
   camelToSnakeCase,
   delay,
-  getBotIdFromToken,
   isGetMessagesAfter,
   isGetMessagesAround,
   isGetMessagesBefore,
@@ -71,7 +70,7 @@ const version = '19.0.0-alpha.1'
 export function createRestManager(options: CreateRestManagerOptions): RestManager {
   const rest: RestManager = {
     token: options.token,
-    applicationId: options.applicationId ? BigInt(options.applicationId) : getBotIdFromToken(options.token),
+    applicationId: BigInt(options.applicationId),
     version: options.version ?? 10,
     baseUrl: options.proxy?.baseUrl ?? 'https://discord.com/api',
     maxRetryCount: Infinity,

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -6,6 +6,7 @@ import {
   camelize,
   camelToSnakeCase,
   delay,
+  getBotIdFromToken,
   isGetMessagesAfter,
   isGetMessagesAround,
   isGetMessagesBefore,
@@ -70,7 +71,7 @@ const version = '19.0.0-alpha.1'
 export function createRestManager(options: CreateRestManagerOptions): RestManager {
   const rest: RestManager = {
     token: options.token,
-    applicationId: BigInt(options.applicationId),
+    applicationId: options.applicationId ? BigInt(options.applicationId) : options.token ? getBotIdFromToken(options.token) : undefined,
     version: options.version ?? 10,
     baseUrl: options.proxy?.baseUrl ?? 'https://discord.com/api',
     maxRetryCount: Infinity,

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -69,9 +69,16 @@ import type { CreateRequestBodyOptions, CreateRestManagerOptions, RestManager, S
 const version = '19.0.0-alpha.1'
 
 export function createRestManager(options: CreateRestManagerOptions): RestManager {
+  const applicationId = options.applicationId ? BigInt(options.applicationId) : options.token ? getBotIdFromToken(options.token) : undefined
+  if (!applicationId) {
+    throw new Error(
+      '`applicationId` was not provided and was not able to extract the id from the bots token. Please explicitly pass `applicationId` to the rest manager.',
+    )
+  }
+
   const rest: RestManager = {
     token: options.token,
-    applicationId: options.applicationId ? BigInt(options.applicationId) : options.token ? getBotIdFromToken(options.token) : undefined,
+    applicationId,
     version: options.version ?? 10,
     baseUrl: options.proxy?.baseUrl ?? 'https://discord.com/api',
     maxRetryCount: Infinity,

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -69,9 +69,6 @@ import type { CreateRequestBodyOptions, CreateRestManagerOptions, RestManager, S
 const version = '19.0.0-alpha.1'
 
 export function createRestManager(options: CreateRestManagerOptions): RestManager {
-  // Falsy token string check
-  if (!options.token) throw new Error('You must provide a valid token.')
-
   const rest: RestManager = {
     token: options.token,
     applicationId: options.applicationId ? BigInt(options.applicationId) : getBotIdFromToken(options.token),

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -104,7 +104,7 @@ export interface CreateRestManagerOptions {
    * For old bots that have a different bot id and application id.
    * @default bot id from token
    */
-  applicationId: BigString
+  applicationId?: BigString
   /** Configuration when using a proxy. */
   proxy?: {
     /**

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -99,12 +99,12 @@ import type { RestRoutes } from './typings/routes.js'
 
 export interface CreateRestManagerOptions {
   /** The bot token which will be used to make requests. */
-  token: string
+  token?: string
   /**
    * For old bots that have a different bot id and application id.
    * @default bot id from token
    */
-  applicationId?: BigString
+  applicationId: BigString
   /** Configuration when using a proxy. */
   proxy?: {
     /**
@@ -125,7 +125,7 @@ export interface CreateRestManagerOptions {
 
 export interface RestManager {
   /** The bot token which will be used to make requests. */
-  token: string
+  token?: string
   /** The application id. Normally this is not required for recent bots but old bot's application id is sometimes different from the bot id so it is required for those bots. */
   applicationId: bigint
   /** The api version to use when making requests. Only the latest supported version will be tested. */

--- a/packages/rest/tests/unit/manager.spec.ts
+++ b/packages/rest/tests/unit/manager.spec.ts
@@ -173,7 +173,7 @@ describe('[rest] manager', () => {
     let time: sinon.SinonFakeTimers
 
     beforeEach(() => {
-      rest = createRestManager({ token: ' ' })
+      rest = createRestManager({ applicationId: 1n })
       time = sinon.useFakeTimers()
     })
 


### PR DESCRIPTION
This is in favour for interaction only bots, which still need rest but cannot provide a valid bot token. If you want to use rest for your normal bot it should be your own responsibility to pass a valid token.

Further more `applicationId` is now a required property since we cannot extract the id from the token anymore.