### PR TITLE
fix(types): `DiscordCreateApplicationCommand.description` is optional

### DIFF
--- a/packages/types/src/discord.ts
+++ b/packages/types/src/discord.ts
@@ -1805,7 +1805,7 @@ export interface DiscordCreateApplicationCommand {
   name: string
   /** Localization object for `name` field. Values follow the same restrictions as `name` */
   name_localizations?: Localization | null
-  /** Description for `ApplicationCommandTypes.ChatInput` commands, 1-100 characters. Empty string for `ApplicationCommandTypes.User` and `ApplicationCommandTypes.Message` commands */
+  /** Description for `ApplicationCommandTypes.ChatInput` commands, 1-100 characters. */
   description?: string
   /** Localization object for `description` field. Values follow the same restrictions as `description` */
   description_localizations?: Localization | null

--- a/packages/types/src/discord.ts
+++ b/packages/types/src/discord.ts
@@ -1806,7 +1806,7 @@ export interface DiscordCreateApplicationCommand {
   /** Localization object for `name` field. Values follow the same restrictions as `name` */
   name_localizations?: Localization | null
   /** Description for `ApplicationCommandTypes.ChatInput` commands, 1-100 characters. Empty string for `ApplicationCommandTypes.User` and `ApplicationCommandTypes.Message` commands */
-  description: string
+  description?: string
   /** Localization object for `description` field. Values follow the same restrictions as `description` */
   description_localizations?: Localization | null
   /** Parameters for the command, max of 25 */


### PR DESCRIPTION
https://discord.com/developers/docs/interactions/application-commands#create-global-application-command
states that description is optional. This is when using message commands for example