### PR TITLE
fix(gateway): lastShardId

### DIFF
--- a/packages/gateway/src/manager.ts
+++ b/packages/gateway/src/manager.ts
@@ -32,7 +32,7 @@ export function createGatewayManager(options: CreateGatewayManagerOptions): Gate
     version: options.version ?? 10,
     connection: options.connection,
     totalShards: options.totalShards ?? options.connection.shards ?? 1,
-    lastShardId: options.lastShardId ?? 0,
+    lastShardId: options.lastShardId ?? (options.totalShards ? options.totalShards - 1 : (options.connection ? options.connection.shards - 1 : 0)),
     firstShardId: options.firstShardId ?? 0,
     totalWorkers: options.totalWorkers ?? 4,
     shardsPerWorker: options.shardsPerWorker ?? 25,


### PR DESCRIPTION
Use `options.totalShards - 1` if `options.lastShardId` doesn't exist, which if not exists, use `options.connection.shards - 1`