### PR TITLE
feat(bot,types): Add `channel_types` prop to channel select menu

### DIFF
--- a/packages/bot/src/transformers/component.ts
+++ b/packages/bot/src/transformers/component.ts
@@ -1,4 +1,4 @@
-import type { ButtonStyles, MessageComponentTypes, SelectOption, TextStyles } from '@discordeno/types'
+import type { ButtonStyles, ChannelTypes, MessageComponentTypes, SelectOption, TextStyles } from '@discordeno/types'
 import type { Bot } from '../index.js'
 import type { DiscordComponent } from '../typings.js'
 
@@ -17,6 +17,7 @@ export function transformComponent(bot: Bot, payload: DiscordComponent): Compone
         }
       : undefined,
     url: payload.url,
+    channelTypes: payload.channel_types,
     options: payload.options?.map((option) => ({
       label: option.label,
       value: option.value,
@@ -68,6 +69,8 @@ export interface Component {
   }
   /** optional url for link-style buttons that can navigate a user to the web. Only type 5 Link buttons can have a url */
   url?: string
+  /** List of channel types to include in a channel select menu options list */
+  channelTypes?: ChannelTypes[]
   /** The choices! Maximum of 25 items. */
   options?: SelectOption[]
   /** A custom placeholder text if nothing is selected. Maximum 150 characters. */

--- a/packages/bot/src/transformers/reverse/component.ts
+++ b/packages/bot/src/transformers/reverse/component.ts
@@ -18,6 +18,7 @@ export function transformComponentToDiscordComponent(bot: Bot, payload: Componen
         }
       : undefined,
     url: payload.url,
+    channel_types: payload.channelTypes,
     options: payload.options?.map((option) => ({
       label: option.label,
       value: option.value,

--- a/packages/bot/src/typings.ts
+++ b/packages/bot/src/typings.ts
@@ -2,6 +2,7 @@ import {
   ApplicationCommandTypes,
   type AllowedMentions,
   type ButtonStyles,
+  type ChannelTypes,
   type CreateApplicationCommand,
   type CreateContextApplicationCommand,
   type DiscordAllowedMentions,
@@ -16,13 +17,13 @@ import {
   type DiscordUser,
   type FileContent,
   type InteractionResponseTypes,
-  type MessageComponents,
   type MessageComponentTypes,
+  type MessageComponents,
   type TextStyles,
 } from '@discordeno/types'
 import type * as handlers from './handlers/index.js'
-import type { Embed } from './transformers/embed.js'
 import type { ApplicationCommandOptionChoice } from './transformers/applicationCommandOptionChoice.js'
+import type { Embed } from './transformers/embed.js'
 
 export function isContextApplicationCommand(command: CreateApplicationCommand): command is CreateContextApplicationCommand {
   return command.type === ApplicationCommandTypes.Message || command.type === ApplicationCommandTypes.User
@@ -69,6 +70,8 @@ export interface DiscordComponent {
   }
   /** optional url for link-style buttons that can navigate a user to the web. Only type 5 Link buttons can have a url */
   url?: string
+  /** List of channel types to include in a channel select menu options list */
+  channel_types?: ChannelTypes[]
   /** The choices! Maximum of 25 items. */
   options?: DiscordSelectOption[]
   /** A custom placeholder text if nothing is selected. Maximum 150 characters. */
@@ -205,7 +208,7 @@ export interface BotGatewayHandlerOptions {
 
 export enum MessageFlags {
   /** Whether this message has been published to subscribed channels (via Channel Following) */
-  Crossposted =	1 << 0,	
+  Crossposted = 1 << 0,
   /** Whether this message originated from a message in another channel (via Channel Following) */
   IsCrosspost = 1 << 1,
   /** Whether do not include any embeds when serializing this message */

--- a/packages/types/src/discord.ts
+++ b/packages/types/src/discord.ts
@@ -1134,6 +1134,8 @@ export interface DiscordSelectMenuComponent {
   min_values?: number
   /** The maximum number of items that can be selected. Default 1. Between 1-25. */
   max_values?: number
+  /** List of channel types to include in a channel select menu options list */
+  channelTypes?: ChannelTypes[]
   /** The choices! Maximum of 25 items. */
   options: DiscordSelectOption[]
 }

--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -195,6 +195,8 @@ export interface SelectMenuChannelsComponent {
   minValues?: number
   /** The maximum number of items that can be selected. Default 1. Between 1-25. */
   maxValues?: number
+  /** List of channel types to include in the options list */
+  channelTypes?: ChannelTypes[]
   /** Whether or not this select is disabled */
   disabled?: boolean
 }


### PR DESCRIPTION
https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-menu-structure