### PR TITLE
fix(gateway): Deno WebSocket

### DIFF
--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -67,14 +67,6 @@ export function createBot(options: CreateBotOptions): Bot {
     // Set up helpers below.
     helpers: {} as BotHelpers,
     async start() {
-      // @ts-expect-error should this work
-      if (typeof Deno !== 'undefined') {
-        // @ts-expect-error should this work
-        const katsura = await import('https://x.nest.land/katsura@1.3.9/src/discordenoFixes/gatewaySocket.ts')
-
-        await katsura(bot.gateway)
-      }
-
       if (!options.gateway?.connection) {
         bot.gateway.connection = await bot.rest.getSessionInfo()
       }

--- a/packages/gateway/src/Shard.ts
+++ b/packages/gateway/src/Shard.ts
@@ -129,13 +129,19 @@ export class DiscordenoShard {
     url.searchParams.set('v', this.gatewayConfig.version.toString())
     url.searchParams.set('encoding', 'json')
 
-    const socket = new WebSocket(url.toString())
+    const socket =
+      // @ts-expect-error Deno
+      typeof Deno !== 'undefined'
+        ? // eslint-disable-next-line no-eval
+          eval('new WebSocket(url.toString())')
+        : new WebSocket(url.toString())
+
     this.socket = socket
 
     // TODO: proper event handling
-    socket.onerror = (event) => console.log({ error: event, shardId: this.id })
-    socket.onclose = async (event) => await this.handleClose(event)
-    socket.onmessage = async (message) => await this.handleMessage(message)
+    socket.onerror = (event: WebSocket.ErrorEvent) => console.log({ error: event, shardId: this.id })
+    socket.onclose = async (event: WebSocket.CloseEvent) => await this.handleClose(event)
+    socket.onmessage = async (message: WebSocket.MessageEvent) => await this.handleMessage(message)
 
     return await new Promise((resolve) => {
       socket.onopen = () => {


### PR DESCRIPTION
Use Deno's ws via eval

The old method imports `fixGateway` from url in `bot` package to overwrite gateway which doesnt work (at least from my testing)