### PR TITLE
feat: add support for new username system

### DIFF
--- a/packages/bot/src/transformers.ts
+++ b/packages/bot/src/transformers.ts
@@ -334,6 +334,7 @@ export interface Transformers {
     }
     user: {
       username: boolean
+      globalName: boolean
       locale: boolean
       flags: boolean
       premiumType: boolean

--- a/packages/bot/src/transformers/user.ts
+++ b/packages/bot/src/transformers/user.ts
@@ -32,6 +32,7 @@ export function transformUser(bot: Bot, payload: DiscordUser): User {
   if (props.publicFlags) user.publicFlags = new ToggleBitfield(payload.public_flags)
   if (payload.id && props.id) user.id = bot.transformers.snowflake(payload.id)
   if (payload.username && props.username) user.username = payload.username
+  if (payload.global_name && props.globalName) user.globalName = payload.global_name
   if (payload.discriminator && props.discriminator) user.discriminator = payload.discriminator
   if (payload.locale && props.locale) user.locale = payload.locale
   if (payload.email && props.email) user.email = payload.email
@@ -59,8 +60,10 @@ export interface BaseUser {
 export interface User extends BaseUser {
   /** Compressed version of all the booleans on a user. */
   toggles?: UserToggles
-  /** The user's username, not unique across the platform */
+  /** The user's username, unique across the platform */
   username: string
+  /** The user's display name, not unique across the platform */
+  globalName?: string
   /** The user's chosen language option */
   locale?: string
   /** The flags on a user's account */

--- a/packages/utils/src/images.ts
+++ b/packages/utils/src/images.ts
@@ -22,13 +22,11 @@ export function emojiUrl(emojiId: BigString, animated = false): string {
  * Builds a URL to a user's avatar stored in the Discord CDN.
  *
  * @param userId - The ID of the user to get the avatar of.
- * @param discriminator - The user's discriminator. (4-digit tag after the hashtag.)
  * @param options - The parameters for the building of the URL.
  * @returns The link to the resource.
  */
 export function avatarUrl(
   userId: BigString,
-  discriminator: string,
   options?: {
     avatar: BigString | undefined
     size?: ImageSize
@@ -41,7 +39,7 @@ export function avatarUrl(
         options?.size ?? 128,
         options?.format,
       )
-    : `https://cdn.discordapp.com/embed/avatars/${discriminator === '0' ? BigInt(userId) >> BigInt(22) : Number(discriminator) % 5}.png`
+    : `https://cdn.discordapp.com/embed/avatars/${(BigInt(userId) >> BigInt(22)) % BigInt(5)}.png`
 }
 
 /**

--- a/packages/utils/src/images.ts
+++ b/packages/utils/src/images.ts
@@ -41,7 +41,7 @@ export function avatarUrl(
         options?.size ?? 128,
         options?.format,
       )
-    : `https://cdn.discordapp.com/embed/avatars/${Number(discriminator) % 5}.png`
+    : `https://cdn.discordapp.com/embed/avatars/${discriminator === '0' ? BigInt(userId) >> BigInt(22) : Number(discriminator) % 5}.png`
 }
 
 /**


### PR DESCRIPTION
This is a draft until [docs](https://github.com/discord/discord-api-docs/pull/6130) are finalized.

### Changes:
- Added `globalName` to `transformers.desiredProperties.user`
- Added `globalName` to `User` object in `transformUser`
- Calculate as `(user_id % 22) % 5` in `avatarUrl` of `utils` package for default avatars

### Note:
In `avatarUrl()`, I had to use `BigInt(X)` because using `Xn` directly gives the error: `BigInt literals are not available when targeting lower than ES2020. ts(2737)`, we might need to look into this, as `Xn` is probably better compared to `BigInt(X)` performance wise