### PR TITLE
🐛 - fix: snakelize json when files are used

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable no-const-assign */
-import { calculateBits, camelToSnakeCase, camelize, delay, getBotIdFromToken, logger, processReactionString, urlToBase64 } from '@discordeno/utils'
+import { calculateBits, camelToSnakeCase, camelize, delay, getBotIdFromToken, logger, processReactionString, urlToBase64, snakelize } from '@discordeno/utils'
 
 import { createInvalidRequestBucket } from './invalidBucket.js'
 import { Queue } from './queue.js'
@@ -175,7 +175,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
           form.append(`file${i}`, options.files[i].blob, options.files[i].name)
         }
 
-        form.append('payload_json', JSON.stringify({ ...options.body, files: undefined }))
+        form.append('payload_json', JSON.stringify(snakelize({ ...options.body, files: undefined })))
 
         body = form
 


### PR DESCRIPTION
Maybe it needs to be done here too? 
https://github.com/Yaikava/discordeno/blob/33d260e2bb583eaa779ff3a0b3762a3c819dabe1/packages/rest/src/manager.ts#L185

This  should probably be looked into too, but I do not really know.
https://discord.com/channels/785384884197392384/1123611467934085190/1123955065674281050