### PR TITLE
fix(rest): add missing files for editMessage

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -777,7 +777,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
     },
 
     async editMessage(channelId, messageId, body) {
-      return await rest.patch<DiscordMessage>(rest.routes.channels.message(channelId, messageId), { body })
+      return await rest.patch<DiscordMessage>(rest.routes.channels.message(channelId, messageId), { body, files: body.files })
     },
 
     async editOriginalInteractionResponse(token, body) {

--- a/packages/rest/tests/e2e/message.spec.ts
+++ b/packages/rest/tests/e2e/message.spec.ts
@@ -59,6 +59,26 @@ describe('Send a message', () => {
     expect(fileMsg.id).not.equals(undefined);
     expect(fileMsg.content).equals('222');
     expect(fileMsg.attachments.length).equals(1);
+    expect(fileMsg.attachments.at(0)?.filename).equals('application.txt');
+    expect(fileMsg.attachments.at(0)?.size).equals(11);
+
+    const txtFile2 = new Blob(['hello world edit'], { type: 'text/plain' });
+
+    const edited = await rest.editMessage(e2ecache.channel.id, fileMsg.id, {
+      content: '222 edit',
+      files: [
+        {
+          name: 'application_edit.txt',
+          blob: txtFile2,
+        },
+      ],
+    });
+
+    expect(edited.id).not.equals(undefined);
+    expect(edited.content).equals('222 edit');
+    expect(edited.attachments.length).equals(1);
+    expect(edited.attachments.at(0)?.filename).equals('application_edit.txt');
+    expect(edited.attachments.at(0)?.size).equals(16);
   })
 })
 

--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -853,7 +853,7 @@ export interface EditMessage {
   /** Edit the flags of the message (only `SUPPRESS_EMBEDS` can currently be set/unset) */
   flags?: 4 | null
   /** The contents of the files being sent/edited */
-  files?: FileContent[] | null
+  files?: FileContent[]
   /** Allowed mentions for the message */
   allowedMentions?: AllowedMentions
   /** When specified (adding new attachments), attachments which are not provided in this list will be removed. */


### PR DESCRIPTION
This fixes `editMessage` not sending new files. I also updated the e2e message spec test.