### PR TITLE
fix(bot): Transform hashes correctly

### DIFF
--- a/packages/bot/src/transformers/auditLogEntry.ts
+++ b/packages/bot/src/transformers/auditLogEntry.ts
@@ -1,5 +1,5 @@
 import type { DiscordAuditLogEntry } from '@discordeno/types'
-import type { Bot } from '../index.js'
+import { iconHashToBigInt, type Bot } from '../index.js'
 import type { Optionalize } from '../optionalize.js'
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -21,13 +21,8 @@ export function transformAuditLogEntry(bot: Bot, payload: DiscordAuditLogEntry) 
               name: val?.name,
             })),
           }
-        case 'discovery_splash_hash':
-        case 'banner_hash':
         case 'rules_channel_id':
         case 'public_updates_channel_id':
-        case 'icon_hash':
-        case 'image_hash':
-        case 'splash_hash':
         case 'owner_id':
         case 'widget_channel_id':
         case 'system_channel_id':
@@ -37,12 +32,22 @@ export function transformAuditLogEntry(bot: Bot, payload: DiscordAuditLogEntry) 
         case 'deny':
         case 'channel_id':
         case 'inviter_id':
-        case 'avatar_hash':
         case 'id':
           return {
             key: change.key,
             old: change.old_value ? bot.transformers.snowflake(change.old_value) : undefined,
             new: change.new_value ? bot.transformers.snowflake(change.new_value) : undefined,
+          }
+        case 'discovery_splash_hash':
+        case 'banner_hash':
+        case 'icon_hash':
+        case 'image_hash':
+        case 'splash_hash':
+        case 'avatar_hash':
+          return {
+            key: change.key,
+            old: change.old_value ? iconHashToBigInt(change.old_value) : undefined,
+            new: change.new_value ? iconHashToBigInt(change.new_value) : undefined,
           }
         case 'name':
         case 'description':

--- a/packages/bot/src/transformers/reverse/auditLogEntry.ts
+++ b/packages/bot/src/transformers/reverse/auditLogEntry.ts
@@ -1,5 +1,5 @@
 import type { DiscordAuditLogEntry } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import { iconBigintToHash, type Bot } from '../../index.js'
 import type { AuditLogEntry } from '../auditLogEntry.js'
 
 export function transformAuditLogEntryToDiscordAuditLogEntry(bot: Bot, payload: AuditLogEntry): DiscordAuditLogEntry {
@@ -33,13 +33,8 @@ export function transformAuditLogEntryToDiscordAuditLogEntry(bot: Bot, payload: 
               name: val?.name,
             })),
           }
-        case 'discovery_splash_hash':
-        case 'banner_hash':
         case 'rules_channel_id':
         case 'public_updates_channel_id':
-        case 'icon_hash':
-        case 'image_hash':
-        case 'splash_hash':
         case 'owner_id':
         case 'widget_channel_id':
         case 'system_channel_id':
@@ -49,12 +44,22 @@ export function transformAuditLogEntryToDiscordAuditLogEntry(bot: Bot, payload: 
         case 'deny':
         case 'channel_id':
         case 'inviter_id':
-        case 'avatar_hash':
         case 'id':
           return {
             key: change.key,
             old_value: change.old ? bot.transformers.reverse.snowflake(change.old as bigint) : '',
             new_value: change.new ? bot.transformers.reverse.snowflake(change.new as bigint) : '',
+          }
+        case 'discovery_splash_hash':
+        case 'banner_hash':
+        case 'icon_hash':
+        case 'image_hash':
+        case 'splash_hash':
+        case 'avatar_hash':
+          return {
+            key: change.key,
+            old_value: change.old ? iconBigintToHash(change.old as bigint) : '',
+            new_value: change.new ? iconBigintToHash(change.new as bigint) : '',
           }
         case 'name':
         case 'description':


### PR DESCRIPTION
This fixes audit log entries which contain changes to guild icon, webhook icon etc. The problem was that hashes were incorrectly interpreted as snowflake IDs.