### PR TITLE
Bug(gateway) Fix fetch of discord gateway session information

### DIFF
--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -71,13 +71,13 @@ export function createBot(options: CreateBotOptions): Bot {
         bot.gateway.connection = await bot.rest.getSessionInfo()
 
         // Check for overrides in the configuration
-        if (bot.gateway.url === 'wss://gateway.discord.gg')
+        if (!options.gateway?.url)
             bot.gateway.url = bot.gateway.connection.url;
 
-        if (bot.gateway.totalShards === 1)
+        if (!options.gateway?.totalShards)
             bot.gateway.totalShards = bot.gateway.connection.shards;
 
-        if (bot.gateway.lastShardId === 0)
+        if (!options.gateway?.lastShardId)
             bot.gateway.lastShardId = bot.gateway.connection.shards - 1;
       }
 

--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -69,8 +69,19 @@ export function createBot(options: CreateBotOptions): Bot {
     async start() {
       if (!options.gateway?.connection) {
         bot.gateway.connection = await bot.rest.getSessionInfo()
+
+        // Check for overrides in the configuration
+        if (bot.gateway.url === 'wss://gateway.discord.gg')
+            bot.gateway.url = bot.gateway.connection.url;
+
+        if (bot.gateway.totalShards === 1)
+            bot.gateway.totalShards = bot.gateway.connection.shards;
+
+        if (bot.gateway.lastShardId === 0)
+            bot.gateway.lastShardId = bot.gateway.connection.shards - 1;
       }
-      return await bot.gateway.spawnShards()
+
+      await bot.gateway.spawnShards()
     },
 
     async shutdown() {

--- a/packages/gateway/src/manager.ts
+++ b/packages/gateway/src/manager.ts
@@ -5,17 +5,15 @@ import Shard from './Shard.js'
 import type { ShardEvents, StatusUpdate, UpdateVoiceState } from './types.js'
 
 export function createGatewayManager(options: CreateGatewayManagerOptions): GatewayManager {
-  if (!options.connection) {
-    options.connection = {
-      url: 'wss://gateway.discord.gg',
-      shards: 1,
-      sessionStartLimit: {
-        maxConcurrency: 1,
-        remaining: 1000,
-        total: 1000,
-        resetAfter: 1000 * 60 * 60 * 24,
-      },
-    }
+  const connectionOptions = options.connection ?? {
+    url: 'wss://gateway.discord.gg',
+    shards: 1,
+    sessionStartLimit: {
+      maxConcurrency: 1,
+      remaining: 1000,
+      total: 1000,
+      resetAfter: 1000 * 60 * 60 * 24,
+    },
   }
 
   const gateway: GatewayManager = {
@@ -28,11 +26,11 @@ export function createGatewayManager(options: CreateGatewayManagerOptions): Gate
       device: options.properties?.device ?? 'Discordeno',
     },
     token: options.token,
-    url: options.url ?? options.connection.url ?? 'wss://gateway.discord.gg',
+    url: options.url ?? connectionOptions.url ?? 'wss://gateway.discord.gg',
     version: options.version ?? 10,
-    connection: options.connection,
-    totalShards: options.totalShards ?? options.connection.shards ?? 1,
-    lastShardId: options.lastShardId ?? (options.totalShards ? options.totalShards - 1 : (options.connection ? options.connection.shards - 1 : 0)),
+    connection: connectionOptions,
+    totalShards: options.totalShards ?? connectionOptions.shards ?? 1,
+    lastShardId: options.lastShardId ?? (options.totalShards ? options.totalShards - 1 : (connectionOptions ? connectionOptions.shards - 1 : 0)),
     firstShardId: options.firstShardId ?? 0,
     totalWorkers: options.totalWorkers ?? 4,
     shardsPerWorker: options.shardsPerWorker ?? 25,


### PR DESCRIPTION
* Fix for the `bot.start()` method where the `if (!options.gateway?.connection)` always return false since the create `createGatewayManager` function created the value if non-existing.

* Add checks to try to avoid changing user options when doing the fetching