### PR TITLE
fix(rest): failing to convert to Discord format for permission related fields in object in changeToDiscordFormat() with proxy rest

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -126,10 +126,10 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
               case 'permissions':
               case 'allow':
               case 'deny':
-                newObj[key] = calculateBits(value)
+                newObj[key] = typeof value === 'string' ? value : calculateBits(value)
                 continue
               case 'defaultMemberPermissions':
-                newObj.default_member_permissions = calculateBits(value)
+                newObj.default_member_permissions = typeof value === 'string' ? value : calculateBits(value)
                 continue
               case 'nameLocalizations':
                 newObj.name_localizations = value


### PR DESCRIPTION
When you use proxy rest, the request object is already converted to Discord format in the bot side, and then sent to the proxy rest, this means it runs `changeToDiscordFormat()` again, which means the fields `allow`, `deny`, `permissions` and `defaultMemberPermissions` will have a string instead of a permission string array in the rest side. When a string is passed to `calculateBits()`, it's not processing and is freezing the request, causing it to timeout. This PR fixes that issue but we might need to think of a better approach overall to prevent running `changeToDiscordFormat()` twice (once in bot side, once in rest proxy side)