### PR TITLE
fix(rest): invert unauthorized check

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -156,7 +156,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
         'user-agent': `DiscordBot (https://github.com/discordeno/discordeno, v${version})`,
       }
 
-      if (options?.unauthorized !== false) headers.authorization = `Bot ${rest.token}`
+      if (options?.unauthorized !== true) headers.authorization = `Bot ${rest.token}`
 
       // IF A REASON IS PROVIDED ENCODE IT IN HEADERS
       if (options?.reason !== undefined) {


### PR DESCRIPTION
Fix bug where the only way to not attach the REST authorization header was setting unauthorized to false. Now the name and behavior match