### PR TITLE
Add default_values support for SelectMenu

### DIFF
--- a/packages/types/src/camel.ts
+++ b/packages/types/src/camel.ts
@@ -64,8 +64,8 @@ import type {
   DiscordGuildIntegrationsUpdate,
   DiscordGuildMemberAdd,
   DiscordGuildMemberRemove,
-  DiscordGuildMemberUpdate,
   DiscordGuildMembersChunk,
+  DiscordGuildMemberUpdate,
   DiscordGuildPreview,
   DiscordGuildRoleCreate,
   DiscordGuildRoleDelete,
@@ -124,6 +124,7 @@ import type {
   DiscordScheduledEventUserAdd,
   DiscordScheduledEventUserRemove,
   DiscordSelectMenuComponent,
+  DiscordSelectMenuDefaultValue,
   DiscordSelectOption,
   DiscordSessionStartLimit,
   DiscordStageInstance,
@@ -135,8 +136,8 @@ import type {
   DiscordTemplate,
   DiscordThreadListSync,
   DiscordThreadMember,
-  DiscordThreadMemberUpdate,
   DiscordThreadMembersUpdate,
+  DiscordThreadMemberUpdate,
   DiscordThreadMetadata,
   DiscordTokenExchange,
   DiscordTokenExchangeAuthorizationCode,
@@ -226,6 +227,7 @@ export type CamelizedDiscordMessageComponents = Camelize<DiscordMessageComponent
 export interface CamelizedDiscordActionRow extends Camelize<DiscordActionRow> {}
 export interface CamelizedDiscordSelectMenuComponent extends Camelize<DiscordSelectMenuComponent> {}
 export interface CamelizedDiscordSelectOption extends Camelize<DiscordSelectOption> {}
+export interface CamelizedDiscordSelectMenuDefaultValue extends Camelize<DiscordSelectMenuDefaultValue> {}
 export interface CamelizedDiscordButtonComponent extends Camelize<DiscordButtonComponent> {}
 export interface CamelizedDiscordInputTextComponent extends Camelize<DiscordInputTextComponent> {}
 export interface CamelizedDiscordStickerItem extends Camelize<DiscordStickerItem> {}

--- a/packages/types/src/discord.ts
+++ b/packages/types/src/discord.ts
@@ -1418,6 +1418,7 @@ export interface DiscordActionRow {
   components: Array<DiscordSelectMenuComponent | DiscordButtonComponent | DiscordInputTextComponent>
 }
 
+/** https://discord.com/developers/docs/interactions/message-components#select-menu-object */
 export interface DiscordSelectMenuComponent {
   type: MessageComponentTypes.SelectMenu
   /** A custom identifier for this component. Maximum 100 characters. */
@@ -1452,6 +1453,14 @@ export interface DiscordSelectOption {
   }
   /** Will render this option as already-selected by default. */
   default?: boolean
+}
+
+/** https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-default-value-structure */
+export interface DiscordSelectMenuDefaultValue {
+  /** ID of a user, role, or channel */
+  id: bigint
+  /** Type of value that id represents. */
+  type: 'user' | 'role' | 'channel'
 }
 
 /** https://discord.com/developers/docs/interactions/message-components#buttons-button-object */

--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -144,6 +144,11 @@ export interface SelectMenuUsersComponent {
   customId: string
   /** A custom placeholder text if nothing is selected. Maximum 150 characters. */
   placeholder?: string
+  /**
+   * List of default values for auto-populated select menu components
+   * The number of default values must be in the range defined by minValues and maxValues
+   */
+  defaultValues?: SelectMenuDefaultValue[]
   /** The minimum number of items that must be selected. Default 1. Between 1-25. */
   minValues?: number
   /** The maximum number of items that can be selected. Default 1. Between 1-25. */
@@ -159,6 +164,11 @@ export interface SelectMenuRolesComponent {
   customId: string
   /** A custom placeholder text if nothing is selected. Maximum 150 characters. */
   placeholder?: string
+  /**
+   * List of default values for auto-populated select menu components
+   * The number of default values must be in the range defined by minValues and maxValues
+   */
+  defaultValues?: SelectMenuDefaultValue[]
   /** The minimum number of items that must be selected. Default 1. Between 1-25. */
   minValues?: number
   /** The maximum number of items that can be selected. Default 1. Between 1-25. */
@@ -174,6 +184,11 @@ export interface SelectMenuUsersAndRolesComponent {
   customId: string
   /** A custom placeholder text if nothing is selected. Maximum 150 characters. */
   placeholder?: string
+  /**
+   * List of default values for auto-populated select menu components
+   * The number of default values must be in the range defined by minValues and maxValues
+   */
+  defaultValues?: SelectMenuDefaultValue[]
   /** The minimum number of items that must be selected. Default 1. Between 1-25. */
   minValues?: number
   /** The maximum number of items that can be selected. Default 1. Between 1-25. */
@@ -191,6 +206,11 @@ export interface SelectMenuChannelsComponent {
   customId: string
   /** A custom placeholder text if nothing is selected. Maximum 150 characters. */
   placeholder?: string
+  /**
+   * List of default values for auto-populated select menu components
+   * The number of default values must be in the range defined by minValues and maxValues
+   */
+  defaultValues?: SelectMenuDefaultValue[]
   /** The minimum number of items that must be selected. Default 1. Between 1-25. */
   minValues?: number
   /** The maximum number of items that can be selected. Default 1. Between 1-25. */
@@ -219,6 +239,13 @@ export interface SelectOption {
   }
   /** Will render this option as already-selected by default. */
   default?: boolean
+}
+
+export interface SelectMenuDefaultValue {
+  /** ID of a user, role, or channel */
+  id: bigint
+  /** Type of value that id represents. */
+  type: 'user' | 'role' | 'channel'
 }
 
 /** https://discord.com/developers/docs/interactions/message-components#text-inputs-text-input-structure */


### PR DESCRIPTION
Add the support for Select Menu (type 5[^5] 6[^6] 7[^7] 8[^8]) according to discord/discord-api-docs#6442

[^5]: User select menu
[^6]: Role select menu
[^7]: Mentionable select menu
[^8]: Channel select menu