### PR TITLE
feat(utils): add embed builder

### DIFF
--- a/packages/utils/src/builders.ts
+++ b/packages/utils/src/builders.ts
@@ -1,1 +1,7 @@
+import { EmbedsBuilder } from './builders/embeds.js';
+
 export * from './builders/embeds.js';
+
+export const builder = {
+  embeds: () => new EmbedsBuilder()
+}

--- a/packages/utils/src/builders.ts
+++ b/packages/utils/src/builders.ts
@@ -1,0 +1,1 @@
+export * from './builders/embeds.js';

--- a/packages/utils/src/builders.ts
+++ b/packages/utils/src/builders.ts
@@ -1,5 +1,5 @@
-import { EmbedsBuilder } from './builders/embeds.js';
+import { EmbedsBuilder } from './builders/embeds.js'
 
-export * from './builders/embeds.js';
+export * from './builders/embeds.js'
 
 export const createEmbeds = (): EmbedsBuilder => new EmbedsBuilder()

--- a/packages/utils/src/builders.ts
+++ b/packages/utils/src/builders.ts
@@ -2,6 +2,4 @@ import { EmbedsBuilder } from './builders/embeds.js';
 
 export * from './builders/embeds.js';
 
-export const builder = {
-  embeds: () => new EmbedsBuilder()
-}
+export const createEmbeds = (): EmbedsBuilder => new EmbedsBuilder()

--- a/packages/utils/src/builders/embeds.ts
+++ b/packages/utils/src/builders/embeds.ts
@@ -47,7 +47,7 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
    */
   newEmbed(): EmbedsBuilder {
     if (this.length >= 10) {
-      throw new EmbedsBuilderError("Maximum embed count exceeded. You can not have more than 10 embeds.")
+      throw new Error("Maximum embed count exceeded. You can not have more than 10 embeds.")
     }
 
     this.push({})
@@ -106,7 +106,7 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
     }
 
     if (index >= this.length || index < 0) {
-      throw new EmbedsBuilderError("Can not set the current embed to a index out of bounds.")
+      throw new Error("Can not set the current embed to a index out of bounds.")
     }
 
     this.#currentEmbedIndex = index;
@@ -281,7 +281,7 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
     let totalCharacters = 0;
 
     if (this.length > 10) {
-      throw new EmbedsBuilderError('You can not have more than 10 embeds on a single message.')
+      throw new Error('You can not have more than 10 embeds on a single message.')
     }
 
     this.forEach(({ author, description, fields, footer, title}, index) => {
@@ -289,7 +289,7 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
         const trimmedTitle = title.trim()
 
         if (trimmedTitle.length > 256) {
-          throw new EmbedsBuilderError(`Title of embed ${index} can not be longer than 256 characters.`)
+          throw new Error(`Title of embed ${index} can not be longer than 256 characters.`)
         }
 
         totalCharacters += trimmedTitle.length
@@ -299,7 +299,7 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
         const trimmedDescription = description.trim()
 
         if (trimmedDescription.length > 4096) {
-          throw new EmbedsBuilderError(`Description of embed ${index} can not be longer than 4096 characters.`)
+          throw new Error(`Description of embed ${index} can not be longer than 4096 characters.`)
         }
 
         totalCharacters += trimmedDescription.length
@@ -307,7 +307,7 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
 
       if (fields) {
         if (fields.length > 25) {
-          throw new EmbedsBuilderError(`embed ${index} can not have more than 25 fields.`)
+          throw new Error(`embed ${index} can not have more than 25 fields.`)
         }
 
         fields.forEach(({ name, value }, fieldIndex) => {
@@ -315,11 +315,11 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
           const trimmedValue = value.trim()
 
           if (trimmedName.length > 256) {
-            throw new EmbedsBuilderError(`Name of field ${fieldIndex} on embed ${index} can not be longer than 256 characters.`)
+            throw new Error(`Name of field ${fieldIndex} on embed ${index} can not be longer than 256 characters.`)
           }
 
           if (trimmedValue.length > 4096) {
-            throw new EmbedsBuilderError(`Value of field ${fieldIndex} on embed ${index} can not be longer than 1024 characters.`)
+            throw new Error(`Value of field ${fieldIndex} on embed ${index} can not be longer than 1024 characters.`)
           }
 
           totalCharacters += trimmedName.length
@@ -331,7 +331,7 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
         const trimmedFooterText = footer.text.trim()
 
         if (trimmedFooterText.length > 2048) {
-          throw new EmbedsBuilderError(`Footer text of embed ${index} can not be longer than 2048 characters.`)
+          throw new Error(`Footer text of embed ${index} can not be longer than 2048 characters.`)
         }
 
         totalCharacters += trimmedFooterText.length
@@ -341,7 +341,7 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
         const trimmedAuthorName = author.name.trim()
 
         if (trimmedAuthorName.length > 256) {
-          throw new EmbedsBuilderError(`Author name of embed ${index} can not be longer than 256 characters.`)
+          throw new Error(`Author name of embed ${index} can not be longer than 256 characters.`)
         }
 
         totalCharacters += trimmedAuthorName.length
@@ -349,7 +349,7 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
     })
 
     if (totalCharacters > 6000) {
-      throw new EmbedsBuilderError('Total character length of all embeds can not exceed 6000 characters.')
+      throw new Error('Total character length of all embeds can not exceed 6000 characters.')
     }
 
     return this
@@ -368,20 +368,5 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
     }
  
     return this[this.#currentEmbedIndex]
-  }
-}
-
-/**
- * Custom EmbedsBuilder error.
- *
- * @class EmbedsBuilderError
- * @typedef {EmbedsBuilderError}
- * @extends {Error}
- */
-class EmbedsBuilderError extends Error {
-  constructor(message: string) {
-    super(message);
-
-    this.name = "EmbedBuilderError"
   }
 }

--- a/packages/utils/src/builders/embeds.ts
+++ b/packages/utils/src/builders/embeds.ts
@@ -262,9 +262,87 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
 
     return this
   }
-
-  // TODO: This method
+  
+  /**
+   * Validate all embeds available against current known Discord limits to help prevent bad requests.
+   *
+   * @returns {EmbedsBuilder}
+   */
   validate(): EmbedsBuilder {
+    let totalCharacters = 0;
+
+    if (this.length > 10) {
+      throw new EmbedsBuilderError('You can not have more than 10 embeds on a single message.')
+    }
+
+    this.forEach(({ author, description, fields, footer, title}, index) => {
+      if (title) {
+        const trimmedTitle = title.trim()
+
+        if (trimmedTitle.length > 256) {
+          throw new EmbedsBuilderError(`Title of embed ${index} can not be longer than 256 characters.`)
+        }
+
+        totalCharacters += trimmedTitle.length
+      }
+
+      if (description) {
+        const trimmedDescription = description.trim()
+
+        if (trimmedDescription.length > 4096) {
+          throw new EmbedsBuilderError(`Description of embed ${index} can not be longer than 4096 characters.`)
+        }
+
+        totalCharacters += trimmedDescription.length
+      }
+
+      if (fields) {
+        if (fields.length > 25) {
+          throw new EmbedsBuilderError(`embed ${index} can not have more than 25 fields.`)
+        }
+
+        fields.forEach(({ name, value }, fieldIndex) => {
+          const trimmedName = name.trim()
+          const trimmedValue = value.trim()
+
+          if (trimmedName.length > 256) {
+            throw new EmbedsBuilderError(`Name of field ${fieldIndex} on embed ${index} can not be longer than 256 characters.`)
+          }
+
+          if (trimmedValue.length > 4096) {
+            throw new EmbedsBuilderError(`Value of field ${fieldIndex} on embed ${index} can not be longer than 1024 characters.`)
+          }
+
+          totalCharacters += trimmedName.length
+          totalCharacters += trimmedValue.length
+        })
+      }
+
+      if (footer) { 
+        const trimmedFooterText = footer.text.trim()
+
+        if (trimmedFooterText.length > 2048) {
+          throw new EmbedsBuilderError(`Footer text of embed ${index} can not be longer than 2048 characters.`)
+        }
+
+        totalCharacters += trimmedFooterText.length
+      }
+
+      if (author) {
+        const trimmedAuthorName = author.name.trim()
+
+        if (trimmedAuthorName.length > 256) {
+          throw new EmbedsBuilderError(`Author name of embed ${index} can not be longer than 256 characters.`)
+        }
+
+        totalCharacters += trimmedAuthorName.length
+      }
+    })
+
+    if (totalCharacters > 6000) {
+      throw new EmbedsBuilderError('Total character length of all embeds can not exceed 6000 characters.')
+    }
+
     return this
   }
   

--- a/packages/utils/src/builders/embeds.ts
+++ b/packages/utils/src/builders/embeds.ts
@@ -105,7 +105,7 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
       return this
     }
 
-    if (index > this.length || index < 0) {
+    if (index >= this.length || index < 0) {
       throw new EmbedsBuilderError("Can not set the current embed to a index out of bounds.")
     }
 

--- a/packages/utils/src/builders/embeds.ts
+++ b/packages/utils/src/builders/embeds.ts
@@ -1,9 +1,26 @@
 import type { DiscordEmbed, DiscordEmbedAuthor, DiscordEmbedField, DiscordEmbedFooter, DiscordEmbedImage, DiscordEmbedThumbnail, DiscordEmbedVideo } from "@discordeno/types";
 
+
+/**
+ * A builder to help create Discord embeds.
+ *
+ * @export
+ * @class EmbedsBuilder
+ * @typedef {EmbedsBuilder}
+ * @extends {Array<DiscordEmbed>}
+ */
 export class EmbedsBuilder extends Array<DiscordEmbed> {
   // TODO: Maybe make all interfaces camelcase and use cameltosnakecase?
   // TODO: add timestamp method
-
+  
+  /**
+   * Adds a new field to the embed fields array.
+   *
+   * @param {string} name - Field name
+   * @param {string} value - Field value
+   * @param {?boolean} [inline=false] - Field should be inline or not. 
+   * @returns {EmbedsBuilder}
+   */
   addField(name: string, value: string, inline?: boolean): EmbedsBuilder {
     if (this.#currentEmbed.fields === undefined) {
       this.#currentEmbed.fields = []
@@ -18,9 +35,15 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
     return this
   }
 
+  
+  /**
+   * Creates a blank embed.
+   *
+   * @returns {EmbedsBuilder}
+   */
   newEmbed(): EmbedsBuilder {
     if (this.length >= 10) {
-      throw new EmbedBuilderError("Maximum embed count exceeded. You can not have more than 10 embeds.")
+      throw new EmbedsBuilderError("Maximum embed count exceeded. You can not have more than 10 embeds.")
     }
 
     this.push({})
@@ -28,6 +51,14 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
     return this
   }
 
+  
+  /**
+   * Set the current embed author.
+   *
+   * @param {string} name - Name of the author
+   * @param {?Omit<DiscordEmbedAuthor, 'name'>} [options] - Extra author options
+   * @returns {EmbedsBuilder}
+   */
   setAuthor(name: string, options?: Omit<DiscordEmbedAuthor, 'name'>): EmbedsBuilder {
     this.#currentEmbed.author = {
       ...this.#currentEmbed.author,
@@ -38,6 +69,13 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
     return this
   }
 
+  
+  /**
+   * Set the color on the side of the current embed.
+   *
+   * @param {(number | string)} color - The color, in base16 or hex color code
+   * @returns {EmbedsBuilder}
+   */
   setColor(color: number | string): EmbedsBuilder {
     if (typeof color === 'string') {
       const convertedValue = parseInt(color.replace('#', ''), 16)
@@ -49,24 +87,40 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
     return this
   }
 
+  
+  /**
+   * Set the description of the current embed.
+   *
+   * @param {string} description - Description
+   * @returns {EmbedsBuilder}
+   */
   setDescription(description: string): EmbedsBuilder {
     this.#currentEmbed.description = description
 
     return this
   }
 
+  
+  /**
+   * Overwrite all fields on the current embed.
+   *
+   * @param {DiscordEmbedField[]} fields 
+   * @returns {EmbedsBuilder}
+   */
   setFields(fields: DiscordEmbedField[]): EmbedsBuilder {
-    if (this.#currentEmbed.fields === undefined) {
-      this.#currentEmbed.fields = fields
-
-      return this
-    }
-
-    this.#currentEmbed.fields.push(...fields)
+    this.#currentEmbed.fields = fields
 
     return this
   }
 
+  
+  /**
+   * Set the footer in the current embed.
+   *
+   * @param {string} text - The text to display in the footer
+   * @param {?Omit<DiscordEmbedFooter, 'text'>} [options]
+   * @returns {EmbedsBuilder}
+   */
   setFooter(text: string, options?: Omit<DiscordEmbedFooter, 'text'>): EmbedsBuilder {
     this.#currentEmbed.footer = {
       ...this.#currentEmbed.footer,
@@ -77,6 +131,14 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
     return this
   }
 
+  
+  /**
+   * Set the image in the current embed.
+   *
+   * @param {string} url - URL of the image
+   * @param {?Omit<DiscordEmbedImage, 'url'>} [options]
+   * @returns {EmbedsBuilder}
+   */
   setImage(url: string, options?: Omit<DiscordEmbedImage, 'url'>): EmbedsBuilder {
     this.#currentEmbed.image = {
       ...this.#currentEmbed.image,
@@ -87,6 +149,14 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
     return this
   }
 
+  
+  /**
+   * Set the provider of the current embed.
+   *
+   * @param {string} name
+   * @param {?string} [url]
+   * @returns {EmbedsBuilder}
+   */
   setProvider(name: string, url?: string): EmbedsBuilder {
     this.#currentEmbed.provider = {
       name,
@@ -96,20 +166,42 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
     return this
   }
 
+  
+  /**
+   * Set the color of the current embed to a random value.
+   *
+   * @returns {EmbedsBuilder}
+   */
   setRandomColor(): EmbedsBuilder {
     return this.setColor(Math.floor(Math.random() * (0xffffff + 1)))
   }
 
+  
+  /**
+   * Set the title of the current embed.
+   *
+   * @param {string} title
+   * @param {?string} [url]
+   * @returns {EmbedsBuilder}
+   */
   setTitle(title: string, url?: string): EmbedsBuilder {
     this.#currentEmbed.title = title
 
     if (url) {
-      this.#currentEmbed.url = url
+      this.setUrl(url)
     }
 
     return this
   }
 
+  
+  /**
+   * Set the thumbnail of the current embed.
+   *
+   * @param {string} url - URL of the image
+   * @param {?Omit<DiscordEmbedThumbnail, 'url'>} [options]
+   * @returns {EmbedsBuilder}
+   */
   setThumbnail(url: string, options?: Omit<DiscordEmbedThumbnail, 'url'>): EmbedsBuilder {
     this.#currentEmbed.thumbnail = {
       ...this.#currentEmbed.thumbnail,
@@ -120,12 +212,27 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
     return this
   }
 
+  
+  /**
+   * Set the URL of the current embed title.
+   *
+   * @param {string} url
+   * @returns {EmbedsBuilder}
+   */
   setUrl(url: string): EmbedsBuilder {
     this.#currentEmbed.url = url
 
     return this
   }
 
+  
+  /**
+   * Set the video of the current embed.
+   *
+   * @param {string} url
+   * @param {?Omit<DiscordEmbedVideo, 'url'>} [options]
+   * @returns {EmbedsBuilder}
+   */
   setVideo(url: string, options?: Omit<DiscordEmbedVideo, 'url'>): EmbedsBuilder {
     this.#currentEmbed.video = {
       ...this.#currentEmbed.video,
@@ -141,6 +248,13 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
     return this
   }
 
+  
+  /**
+   * Returns the current embed.
+   *
+   * @readonly
+   * @type {DiscordEmbed}
+   */
   get #currentEmbed(): DiscordEmbed {
     if (this.length === 0) {
       this.newEmbed()
@@ -152,7 +266,15 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
   }
 }
 
-class EmbedBuilderError extends Error {
+
+/**
+ * Custom EmbedsBuilder error.
+ *
+ * @class EmbedsBuilderError
+ * @typedef {EmbedsBuilderError}
+ * @extends {Error}
+ */
+class EmbedsBuilderError extends Error {
   constructor(message: string) {
     super(message);
 

--- a/packages/utils/src/builders/embeds.ts
+++ b/packages/utils/src/builders/embeds.ts
@@ -1,5 +1,12 @@
-import type { DiscordEmbed, DiscordEmbedAuthor, DiscordEmbedField, DiscordEmbedFooter, DiscordEmbedImage, DiscordEmbedThumbnail, DiscordEmbedVideo } from "@discordeno/types";
-
+import type {
+  DiscordEmbed,
+  DiscordEmbedAuthor,
+  DiscordEmbedField,
+  DiscordEmbedFooter,
+  DiscordEmbedImage,
+  DiscordEmbedThumbnail,
+  DiscordEmbedVideo,
+} from '@discordeno/types'
 
 /**
  * A builder to help create Discord embeds.
@@ -17,13 +24,13 @@ import type { DiscordEmbed, DiscordEmbedAuthor, DiscordEmbedField, DiscordEmbedF
  */
 export class EmbedsBuilder extends Array<DiscordEmbed> {
   #currentEmbedIndex: number = 0
-  
+
   /**
    * Adds a new field to the embed fields array.
    *
    * @param {string} name - Field name
    * @param {string} value - Field value
-   * @param {?boolean} [inline=false] - Field should be inline or not. 
+   * @param {?boolean} [inline=false] - Field should be inline or not.
    * @returns {EmbedsBuilder}
    */
   addField(name: string, value: string, inline?: boolean): EmbedsBuilder {
@@ -34,12 +41,12 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
     this.#currentEmbed.fields.push({
       name,
       value,
-      inline
+      inline,
     })
 
     return this
   }
-  
+
   /**
    * Creates a blank embed.
    *
@@ -47,7 +54,7 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
    */
   newEmbed(): EmbedsBuilder {
     if (this.length >= 10) {
-      throw new Error("Maximum embed count exceeded. You can not have more than 10 embeds.")
+      throw new Error('Maximum embed count exceeded. You can not have more than 10 embeds.')
     }
 
     this.push({})
@@ -55,7 +62,7 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
 
     return this
   }
-  
+
   /**
    * Set the current embed author.
    *
@@ -67,12 +74,12 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
     this.#currentEmbed.author = {
       ...this.#currentEmbed.author,
       ...options,
-      name
+      name,
     }
 
     return this
   }
-  
+
   /**
    * Set the color on the side of the current embed.
    *
@@ -92,7 +99,7 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
 
   /**
    * Set the current embed to a different index.
-   * 
+   *
    * WARNING: Only use this method if you know what you're doing. Make sure to set it back to the latest when you're done.
    *
    * @param {?number} [index] - The index of the embed in the EmbedsBuilder array
@@ -106,14 +113,14 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
     }
 
     if (index >= this.length || index < 0) {
-      throw new Error("Can not set the current embed to a index out of bounds.")
+      throw new Error('Can not set the current embed to a index out of bounds.')
     }
 
-    this.#currentEmbedIndex = index;
- 
+    this.#currentEmbedIndex = index
+
     return this
   }
-  
+
   /**
    * Set the description of the current embed.
    *
@@ -125,11 +132,11 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
 
     return this
   }
-  
+
   /**
    * Overwrite all fields on the current embed.
    *
-   * @param {DiscordEmbedField[]} fields 
+   * @param {DiscordEmbedField[]} fields
    * @returns {EmbedsBuilder}
    */
   setFields(fields: DiscordEmbedField[]): EmbedsBuilder {
@@ -137,7 +144,7 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
 
     return this
   }
-  
+
   /**
    * Set the footer in the current embed.
    *
@@ -149,12 +156,12 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
     this.#currentEmbed.footer = {
       ...this.#currentEmbed.footer,
       ...options,
-      text
+      text,
     }
 
     return this
   }
-  
+
   /**
    * Set the image in the current embed.
    *
@@ -166,12 +173,12 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
     this.#currentEmbed.image = {
       ...this.#currentEmbed.image,
       ...options,
-      url
+      url,
     }
 
     return this
   }
-  
+
   /**
    * Set the provider of the current embed.
    *
@@ -182,12 +189,12 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
   setProvider(name: string, url?: string): EmbedsBuilder {
     this.#currentEmbed.provider = {
       name,
-      url
+      url,
     }
 
     return this
   }
-  
+
   /**
    * Set the color of the current embed to a random value.
    *
@@ -225,7 +232,7 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
 
     return this
   }
-  
+
   /**
    * Set the thumbnail of the current embed.
    *
@@ -237,12 +244,12 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
     this.#currentEmbed.thumbnail = {
       ...this.#currentEmbed.thumbnail,
       ...options,
-      url
+      url,
     }
 
     return this
   }
-  
+
   /**
    * Set the URL of the current embed title.
    *
@@ -266,25 +273,25 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
     this.#currentEmbed.video = {
       ...this.#currentEmbed.video,
       ...options,
-      url
+      url,
     }
 
     return this
   }
-  
+
   /**
    * Validate all embeds available against current known Discord limits to help prevent bad requests.
    *
    * @returns {EmbedsBuilder}
    */
   validate(): EmbedsBuilder {
-    let totalCharacters = 0;
+    let totalCharacters = 0
 
     if (this.length > 10) {
       throw new Error('You can not have more than 10 embeds on a single message.')
     }
 
-    this.forEach(({ author, description, fields, footer, title}, index) => {
+    this.forEach(({ author, description, fields, footer, title }, index) => {
       if (title) {
         const trimmedTitle = title.trim()
 
@@ -327,7 +334,7 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
         })
       }
 
-      if (footer) { 
+      if (footer) {
         const trimmedFooterText = footer.text.trim()
 
         if (trimmedFooterText.length > 2048) {
@@ -354,7 +361,7 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
 
     return this
   }
-  
+
   /**
    * Returns the current embed.
    *
@@ -366,7 +373,7 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
       this.newEmbed()
       this.setCurrentEmbed()
     }
- 
+
     return this[this.#currentEmbedIndex]
   }
 }

--- a/packages/utils/src/builders/embeds.ts
+++ b/packages/utils/src/builders/embeds.ts
@@ -1,0 +1,160 @@
+import type { DiscordEmbed, DiscordEmbedAuthor, DiscordEmbedField, DiscordEmbedFooter, DiscordEmbedImage, DiscordEmbedThumbnail, DiscordEmbedVideo } from "@discordeno/types";
+
+export class EmbedsBuilder extends Array<DiscordEmbed> {
+  // TODO: Maybe make all interfaces camelcase and use cameltosnakecase?
+  // TODO: add timestamp method
+
+  addField(name: string, value: string, inline?: boolean): EmbedsBuilder {
+    if (this.#currentEmbed.fields === undefined) {
+      this.#currentEmbed.fields = []
+    }
+
+    this.#currentEmbed.fields.push({
+      name,
+      value,
+      inline
+    })
+
+    return this
+  }
+
+  newEmbed(): EmbedsBuilder {
+    if (this.length >= 10) {
+      throw new EmbedBuilderError("Maximum embed count exceeded. You can not have more than 10 embeds.")
+    }
+
+    this.push({})
+
+    return this
+  }
+
+  setAuthor(name: string, options?: Omit<DiscordEmbedAuthor, 'name'>): EmbedsBuilder {
+    this.#currentEmbed.author = {
+      ...this.#currentEmbed.author,
+      ...options,
+      name
+    }
+
+    return this
+  }
+
+  setColor(color: number | string): EmbedsBuilder {
+    if (typeof color === 'string') {
+      color = parseInt(color.replace('#', ''), 16)
+    }
+
+    this.#currentEmbed.color = color
+
+    return this
+  }
+
+  setDescription(description: string): EmbedsBuilder {
+    this.#currentEmbed.description = description
+
+    return this
+  }
+
+  setFields(fields: DiscordEmbedField[]): EmbedsBuilder {
+    if (this.#currentEmbed.fields === undefined) {
+      this.#currentEmbed.fields = fields
+
+      return this
+    }
+
+    this.#currentEmbed.fields.push(...fields)
+
+    return this
+  }
+
+  setFooter(text: string, options?: Omit<DiscordEmbedFooter, 'text'>): EmbedsBuilder {
+    this.#currentEmbed.footer = {
+      ...this.#currentEmbed.footer,
+      ...options,
+      text
+    }
+
+    return this
+  }
+
+  setImage(url: string, options?: Omit<DiscordEmbedImage, 'url'>): EmbedsBuilder {
+    this.#currentEmbed.image = {
+      ...this.#currentEmbed.image,
+      ...options,
+      url
+    }
+
+    return this
+  }
+
+  setProvider(name: string, url?: string): EmbedsBuilder {
+    this.#currentEmbed.provider = {
+      name,
+      url
+    }
+
+    return this
+  }
+
+  setRandomColor(): EmbedsBuilder {
+    return this.setColor(Math.floor(Math.random() * (0xffffff + 1)))
+  }
+
+  setTitle(title: string, url?: string): EmbedsBuilder {
+    this.#currentEmbed.title = title
+
+    if (url) {
+      this.#currentEmbed.url = url
+    }
+
+    return this
+  }
+
+  setThumbnail(url: string, options?: Omit<DiscordEmbedThumbnail, 'url'>): EmbedsBuilder {
+    this.#currentEmbed.thumbnail = {
+      ...this.#currentEmbed.thumbnail,
+      ...options,
+      url
+    }
+
+    return this
+  }
+
+  setUrl(url: string): EmbedsBuilder {
+    this.#currentEmbed.url = url
+
+    return this
+  }
+
+  setVideo(url: string, options?: Omit<DiscordEmbedVideo, 'url'>): EmbedsBuilder {
+    this.#currentEmbed.video = {
+      ...this.#currentEmbed.video,
+      ...options,
+      url
+    }
+
+    return this
+  }
+
+  // TODO: This method
+  validate(): EmbedsBuilder {
+    return this
+  }
+
+  get #currentEmbed(): DiscordEmbed {
+    if (this.length === 0) {
+      this.newEmbed()
+
+      return this.at(0)!
+    }
+ 
+    return this.at(-1)!
+  }
+}
+
+class EmbedBuilderError extends Error {
+  constructor(message: string) {
+    super(message);
+
+    this.name = "EmbedBuilderError"
+  }
+}

--- a/packages/utils/src/builders/embeds.ts
+++ b/packages/utils/src/builders/embeds.ts
@@ -18,6 +18,8 @@ import type { DiscordEmbed, DiscordEmbedAuthor, DiscordEmbedField, DiscordEmbedF
 export class EmbedsBuilder extends Array<DiscordEmbed> {
   // TODO: Maybe make all interfaces camelcase and use cameltosnakecase?
   // TODO: add timestamp method
+
+  #currentEmbedIndex: number = 0
   
   /**
    * Adds a new field to the embed fields array.
@@ -53,6 +55,7 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
     }
 
     this.push({})
+    this.setCurrentEmbed()
 
     return this
   }
@@ -90,6 +93,31 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
 
     this.#currentEmbed.color = color
 
+    return this
+  }
+
+  
+  /**
+   * Set the current embed to a different index.
+   * 
+   * WARNING: Only use this method if you know what you're doing. Make sure to set it back to the latest when you're done.
+   *
+   * @param {?number} [index] - The index of the embed in the EmbedsBuilder array
+   * @returns {EmbedsBuilder}
+   */
+  setCurrentEmbed(index?: number): EmbedsBuilder {
+    if (index === undefined) {
+      this.#currentEmbedIndex = this.length - 1
+
+      return this
+    }
+
+    if (index > this.length || index < 0) {
+      throw new EmbedsBuilderError("Can not set the current embed to a index out of bounds.")
+    }
+
+    this.#currentEmbedIndex = index;
+ 
     return this
   }
 
@@ -264,11 +292,10 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
   get #currentEmbed(): DiscordEmbed {
     if (this.length === 0) {
       this.newEmbed()
-
-      return this.at(0)!
+      this.setCurrentEmbed()
     }
  
-    return this.at(-1)!
+    return this[this.#currentEmbedIndex]
   }
 }
 

--- a/packages/utils/src/builders/embeds.ts
+++ b/packages/utils/src/builders/embeds.ts
@@ -42,7 +42,6 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
 
     return this
   }
-
   
   /**
    * Creates a blank embed.
@@ -59,7 +58,6 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
 
     return this
   }
-
   
   /**
    * Set the current embed author.
@@ -77,7 +75,6 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
 
     return this
   }
-
   
   /**
    * Set the color on the side of the current embed.
@@ -96,7 +93,6 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
     return this
   }
 
-  
   /**
    * Set the current embed to a different index.
    * 
@@ -120,7 +116,6 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
  
     return this
   }
-
   
   /**
    * Set the description of the current embed.
@@ -133,7 +128,6 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
 
     return this
   }
-
   
   /**
    * Overwrite all fields on the current embed.
@@ -146,7 +140,6 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
 
     return this
   }
-
   
   /**
    * Set the footer in the current embed.
@@ -164,7 +157,6 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
 
     return this
   }
-
   
   /**
    * Set the image in the current embed.
@@ -182,7 +174,6 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
 
     return this
   }
-
   
   /**
    * Set the provider of the current embed.
@@ -199,7 +190,6 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
 
     return this
   }
-
   
   /**
    * Set the color of the current embed to a random value.
@@ -210,7 +200,6 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
     return this.setColor(Math.floor(Math.random() * (0xffffff + 1)))
   }
 
-  
   /**
    * Set the title of the current embed.
    *
@@ -227,7 +216,6 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
 
     return this
   }
-
   
   /**
    * Set the thumbnail of the current embed.
@@ -245,7 +233,6 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
 
     return this
   }
-
   
   /**
    * Set the URL of the current embed title.
@@ -259,7 +246,6 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
     return this
   }
 
-  
   /**
    * Set the video of the current embed.
    *
@@ -281,7 +267,6 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
   validate(): EmbedsBuilder {
     return this
   }
-
   
   /**
    * Returns the current embed.
@@ -298,7 +283,6 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
     return this[this.#currentEmbedIndex]
   }
 }
-
 
 /**
  * Custom EmbedsBuilder error.

--- a/packages/utils/src/builders/embeds.ts
+++ b/packages/utils/src/builders/embeds.ts
@@ -40,7 +40,8 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
 
   setColor(color: number | string): EmbedsBuilder {
     if (typeof color === 'string') {
-      color = parseInt(color.replace('#', ''), 16)
+      const convertedValue = parseInt(color.replace('#', ''), 16)
+      color = Number.isNaN(convertedValue) ? 0 : convertedValue
     }
 
     this.#currentEmbed.color = color

--- a/packages/utils/src/builders/embeds.ts
+++ b/packages/utils/src/builders/embeds.ts
@@ -8,6 +8,12 @@ import type { DiscordEmbed, DiscordEmbedAuthor, DiscordEmbedField, DiscordEmbedF
  * @class EmbedsBuilder
  * @typedef {EmbedsBuilder}
  * @extends {Array<DiscordEmbed>}
+ * @example
+ * const embeds = new EmbedBuilder()
+ *  .setTitle('My Embed')
+ *  .setDescription('This is my new embed')
+ *  .newEmbed()
+ *  .setTitle('My Second Embed')
  */
 export class EmbedsBuilder extends Array<DiscordEmbed> {
   // TODO: Maybe make all interfaces camelcase and use cameltosnakecase?

--- a/packages/utils/src/builders/embeds.ts
+++ b/packages/utils/src/builders/embeds.ts
@@ -16,9 +16,6 @@ import type { DiscordEmbed, DiscordEmbedAuthor, DiscordEmbedField, DiscordEmbedF
  *  .setTitle('My Second Embed')
  */
 export class EmbedsBuilder extends Array<DiscordEmbed> {
-  // TODO: Maybe make all interfaces camelcase and use cameltosnakecase?
-  // TODO: add timestamp method
-
   #currentEmbedIndex: number = 0
   
   /**
@@ -213,6 +210,18 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
     if (url) {
       this.setUrl(url)
     }
+
+    return this
+  }
+
+  /**
+   * Set the timestamp of the current embed.
+   *
+   * @param {?(string | number | Date)} [timestamp]
+   * @returns {EmbedsBuilder}
+   */
+  setTimestamp(timestamp?: string | number | Date): EmbedsBuilder {
+    this.#currentEmbed.timestamp = new Date(timestamp!).toISOString()
 
     return this
   }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,6 +1,7 @@
 export * from './Collection.js'
 export * from './base64.js'
 export * from './bucket.js'
+export * from './builders.js'
 export * from './casing.js'
 export * from './colors.js'
 export * from './hash.js'

--- a/packages/utils/tests/builders.spec.ts
+++ b/packages/utils/tests/builders.spec.ts
@@ -1,0 +1,34 @@
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
+import { EmbedsBuilder } from '../src/builders.js'
+
+describe('builders/embeds.ts', () => {
+  it('should create a new blank embed JSON', () => {
+    expect(new EmbedsBuilder().newEmbed()).to.eql([{}])
+  })
+
+  /*
+  it('should set the  in the embed JSON', () => {
+    expect(new EmbedsBuilder()).to.eql([{}])
+  })
+  */
+ 
+  it('should set the author name in the embed JSON', () => {
+    expect(new EmbedsBuilder().setAuthor('Author')).to.eql([{ author: { name: 'Author'}}])
+  })
+
+  it('should set the color in the embed JSON', () => {
+    expect(new EmbedsBuilder().setColor('#000000')).to.eql([{ color: 0 }])
+    expect(new EmbedsBuilder().setColor('#21fa99')).to.eql([ { color: 2226841 }])
+    expect(new EmbedsBuilder().setColor('#thisisnotacolor')).to.eql([{ color: 0 }])
+    expect(new EmbedsBuilder().setColor(13530)).to.eql([{ color: 13530 }])
+  })
+
+  it('should set the title in the embed JSON', () => {
+    expect(new EmbedsBuilder().setTitle('My Title')).to.eql([{ title: 'My Title'}])
+  })
+
+  it('should set the description in the embed JSON', () => {
+    expect(new EmbedsBuilder().setDescription('My Description')).to.eql([{ description: 'My Description'}])
+  })
+})

--- a/packages/utils/tests/builders.spec.ts
+++ b/packages/utils/tests/builders.spec.ts
@@ -7,28 +7,56 @@ describe('builders/embeds.ts', () => {
     expect(new EmbedsBuilder().newEmbed()).to.eql([{}])
   })
 
-  /*
-  it('should set the  in the embed JSON', () => {
-    expect(new EmbedsBuilder()).to.eql([{}])
-  })
-  */
- 
   it('should set the author name in the embed JSON', () => {
-    expect(new EmbedsBuilder().setAuthor('Author')).to.eql([{ author: { name: 'Author'}}])
+    expect(new EmbedsBuilder().setAuthor('Author')).to.eql([{ author: { name: 'Author' } }])
   })
 
   it('should set the color in the embed JSON', () => {
     expect(new EmbedsBuilder().setColor('#000000')).to.eql([{ color: 0 }])
-    expect(new EmbedsBuilder().setColor('#21fa99')).to.eql([ { color: 2226841 }])
+    expect(new EmbedsBuilder().setColor('#21fa99')).to.eql([{ color: 2226841 }])
     expect(new EmbedsBuilder().setColor('#thisisnotacolor')).to.eql([{ color: 0 }])
     expect(new EmbedsBuilder().setColor(13530)).to.eql([{ color: 13530 }])
   })
 
-  it('should set the title in the embed JSON', () => {
-    expect(new EmbedsBuilder().setTitle('My Title')).to.eql([{ title: 'My Title'}])
+  it('should set the description in the embed JSON', () => {
+    expect(new EmbedsBuilder().setDescription('My Description')).to.eql([{ description: 'My Description' }])
   })
 
-  it('should set the description in the embed JSON', () => {
-    expect(new EmbedsBuilder().setDescription('My Description')).to.eql([{ description: 'My Description'}])
+  it('should set the fields in the embed JSON', () => {
+    expect(
+      new EmbedsBuilder().setFields([
+        { name: 'firstname', value: 'firstvalue' },
+        { name: 'secondname', value: 'secondvalue', inline: true },
+      ]),
+    ).to.eql([
+      {
+        fields: [
+          { name: 'firstname', value: 'firstvalue' },
+          { name: 'secondname', value: 'secondvalue', inline: true },
+        ],
+      },
+    ])
+  })
+
+  it('should set the footer text in the embed JSON', () => {
+    expect(new EmbedsBuilder().setFooter('footer text')).to.eql([{ footer: { text: 'footer text' } }])
+  })
+
+  it('should set the set a random color in the embed JSON', () => {
+    expect(new EmbedsBuilder().setRandomColor()[0]).to.haveOwnProperty('color')
+  })
+
+  it('should set the timestamp in the embed JSON', () => {
+    const now = new Date()
+
+    expect(new EmbedsBuilder().setTimestamp(now)).to.eql([{ timestamp: now.toISOString() }])
+  })
+
+  it('should set the title in the embed JSON', () => {
+    expect(new EmbedsBuilder().setTitle('My Title')).to.eql([{ title: 'My Title' }])
+  })
+
+  it('should set the url in the embed JSON', () => {
+    expect(new EmbedsBuilder().setUrl('https://google.com')).to.eql([{ url: 'https://google.com' }])
   })
 })


### PR DESCRIPTION
This is a PR implementing the embed builder from #3124, based on PR #2931.

# Differences from other PR
- This is only embed builders, others will come later.
- Uses DD Discord interfaces and uses `Omit` to pull out any key we use as required.
- Uses [ECMAScript private getter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields#private_methods) to get the current embed instead of a method.
- Simplified code a bit, the modifying the getter directly vs setting new variable and modifying. This is more preference.
- Using `set` before method names to make it more descriptive of intent of method
- Custom `EmbedBuilderError`
- Use spread operations where possible.
- Optional `validate` method that check all embeds to ensure they're in the [documented embed limits](https://discord.com/developers/docs/resources/channel#embed-object-embed-limits) for added safety if desired.

----

```[tasklist]
# TODO
- [x] Complete `TODO` in code
- [x] Add method documentation
- [x] Finish the `validate` method
- [x] Testing
```
