### PR TITLE
feat(rest): Add option for the header of authorization on rest proxy

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -84,6 +84,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
   const rest: RestManager = {
     applicationId,
     authorization: options.proxy?.authorization,
+    authorizationHeader: options.proxy?.authorizationHeader ?? 'authorization',
     baseUrl,
     deleteQueueDelay: 60000,
     globallyRateLimited: false,
@@ -464,7 +465,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
         if (rest.authorization !== undefined) {
           options ??= {}
           options.headers ??= {}
-          options.headers.authorization = rest.authorization
+          options.headers[rest.authorizationHeader] = rest.authorization
         }
 
         const result = await fetch(`${rest.baseUrl}/v${rest.version}${route}`, rest.createRequestBody(method, options))

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -129,8 +129,18 @@ export interface CreateRestManagerOptions {
      * @default https://discord.com/api
      */
     baseUrl: string
-    /** The authorization header to attach when sending requests to the proxy. */
+    /** The authorization header value to attach when sending requests to the proxy. */
     authorization: string
+    /**
+     * The authorization header name to use when sending requests to the proxy
+     *
+     * @remarks
+     * If the `authorization` header is used it will override any authorization that is given even if
+     * the requests uses OAuth2 Bearer tokens / Basic tokens
+     *
+     * @default "authorization" // For compatibility purposes
+     */
+    authorizationHeader?: string
   }
   /**
    * The api versions which can be used to make requests.
@@ -158,8 +168,10 @@ export interface RestManager {
    * Mostly used only for intern functions.
    */
   isProxied: boolean
-  /** The authorization header to attach when sending requests to the proxy. */
+  /** The authorization header value to attach when sending requests to the proxy. */
   authorization?: string
+  /** The authorization header name to attach when sending requests to the proxy */
+  authorizationHeader: string
   /** The maximum amount of times a request should be retried. Defaults to Infinity */
   maxRetryCount: number
   /** Whether or not the manager is rate limited globally across all requests. Defaults to false. */


### PR DESCRIPTION
Add of an option on the `CreateRestManagerOptions.proxy` object to specify a different header from `authorization` to allow for non-generable headers (eg. `Bot <bot token>`) to be sent to the rest proxy for situation like OAuth2 required endpoint using Bearer tokens, and for the exchange and revocation of Bearer tokens using a Basic authentication.

The `CreateRestManagerOptions.proxy.authorizationHeader` defaults to `authorization` to keep compatibility with the alredy exiting rest proxies