### PR TITLE
fix(vscode): Explicitly sort the code actions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,10 +2,7 @@
   "editor.tabSize": 2,
   "editor.formatOnSave": true,
   "editor.formatOnPaste": true,
-  "editor.codeActionsOnSave": {
-    "source.organizeImports": true,
-    "source.fixAll.eslint": true
-  },
+  "editor.codeActionsOnSave": ["source.organizeImports", "source.fixAll.eslint"],
   "eslint.validate": ["typescript", "javascript"],
   "files.associations": {
     "*.ts": "typescript",


### PR DESCRIPTION
Using an array for code actions (introduced in 1.44, 2020-04-08) allows for explicitly say the order of the actions. The current approach does not guarantee that the actions are runner in order, and it seems that in `1.85-insider` it is causing problems