### PR TITLE
feat: only require one guild delete event

### DIFF
--- a/packages/bot/src/handlers/guilds/GUILD_DELETE.ts
+++ b/packages/bot/src/handlers/guilds/GUILD_DELETE.ts
@@ -2,14 +2,14 @@ import type { DiscordGatewayPayload, DiscordUnavailableGuild } from '@discordeno
 import type { Bot } from '../../bot.js'
 
 export async function handleGuildDelete(bot: Bot, data: DiscordGatewayPayload, shardId: number): Promise<void> {
-  if (!bot.events.guildDelete || !bot.events.guildUnavailable) return
-
   const payload = data.d as DiscordUnavailableGuild
 
-  if (payload.unavailable) {
+  if (bot.events.guildUnavailable && payload.unavailable) {
     bot.events.guildUnavailable(bot.transformers.snowflake(payload.id), shardId)
     return
   }
 
-  bot.events.guildDelete(bot.transformers.snowflake(payload.id), shardId)
+  if (bot.events.guildDelete) {
+    bot.events.guildDelete(bot.transformers.snowflake(payload.id), shardId)
+  }
 }


### PR DESCRIPTION
Currently right now you need both `guildDelete` and `guildUnavailable` events defined if you want to process either event. This PR makes it so you only need the event you want to handle defined, in case you don't want to have to process unavailable events. 

This has the same amount of logic checks as before.