### PR TITLE
fix(workflows/stale): Update stale action config

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: '0 0 1 * *'
+  - cron: '0 0 * * 1'
 
 jobs:
   stale:
@@ -25,3 +25,5 @@ jobs:
         stale-pr-message: 'This pull request has gone stale for over a month. If this pull request is still useful, leave a comment below. Otherwise, it will be closed shortly.'
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'
+        exempt-issue-labels: 'api-docs-commits,[HELP WANTED] good first issue'
+        close-issue-reason: 'not_planned'


### PR DESCRIPTION
The stale action currently makes the issues related to [discord/discord-api-docs](https://github.com/discord/discord-api-docs) or the issues that are a good first issue for new contributors as stale and close them consequentially

Edits to the stale workflow:
- Issues that have the `api-docs-commits` or the `[HELP WANTED] good first issue` label are now ignored
- The scheduled run of the action is now once a week (on Monday at midnight UTC) instead of the first of the month