### PR TITLE
feat: add Discordeno team to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-*                          @Skillz4Killz @itohatweb
+*                          @discordeno/team @discordeno/core
 
 /.github/workflows/        @H01001000
 /.github/sync.yml          @H01001000

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 *                          @discordeno/team @Skillz4Killz @itohatweb
 
+/.github/CODEOWNERS        @Skillz4Killz @itohatweb
 /.github/workflows/        @H01001000
 /.github/sync.yml          @H01001000
 /.yarn/                    @H01001000

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-*                          @discordeno/team @discordeno/core
+*                          @discordeno/team @Skillz4Killz @itohatweb
 
 /.github/workflows/        @H01001000
 /.github/sync.yml          @H01001000


### PR DESCRIPTION
Was thinking about looking at the other sections too. Wanted to ask @H01001000 on that though.

Before we can merge though, the @discordeno/core team may need a permission update so it has write access? There's an error with the core team that makes it invalid. Not sure what's going on there.