### PR TITLE
fix: cjs extensions for require

### DIFF
--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -4,7 +4,7 @@
   "main": "./dist/esm/index.js",
   "exports": {
     "import": "./dist/esm/index.js",
-    "require": "./dist/cjs/index.js",
+    "require": "./dist/cjs/index.cjs",
     "types": "./dist/types/index.d.ts"
   },
   "types": "./dist/types/index.d.ts",

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -4,7 +4,7 @@
   "main": "./dist/esm/index.js",
   "exports": {
     "import": "./dist/esm/index.js",
-    "require": "./dist/cjs/index.js",
+    "require": "./dist/cjs/index.cjs",
     "types": "./dist/types/index.d.ts"
   },
   "types": "./dist/types/index.d.ts",

--- a/packages/discordeno/package.json
+++ b/packages/discordeno/package.json
@@ -4,7 +4,7 @@
   "main": "./dist/esm/index.js",
   "exports": {
     "import": "./dist/esm/index.js",
-    "require": "./dist/cjs/index.js",
+    "require": "./dist/cjs/index.cjs",
     "types": "./dist/types/index.d.ts"
   },
   "bin": "./bin/disocrdeno.js",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -4,7 +4,7 @@
   "main": "./dist/esm/index.js",
   "exports": {
     "import": "./dist/esm/index.js",
-    "require": "./dist/cjs/index.js",
+    "require": "./dist/cjs/index.cjs",
     "types": "./dist/types/index.d.ts"
   },
   "types": "./dist/types/index.d.ts",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -4,7 +4,7 @@
   "main": "./dist/esm/index.js",
   "exports": {
     "import": "./dist/esm/index.js",
-    "require": "./dist/cjs/index.js",
+    "require": "./dist/cjs/index.cjs",
     "types": "./dist/types/index.d.ts"
   },
   "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
This PR fixes few packages's require use .js extension instead .cjs extension, during cjs rewrite, 