### PR TITLE
fix: Resolve resolution error for prettier

### DIFF
--- a/packages/eslint-config-discordeno/package.json
+++ b/packages/eslint-config-discordeno/package.json
@@ -14,6 +14,7 @@
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-require-extensions": "^0.1.3",
+    "prettier": "^3.1.0",
     "typescript": "5.2.2"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2219,6 +2219,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^5.0.1"
     eslint-plugin-promise: "npm:^6.1.1"
     eslint-plugin-require-extensions: "npm:^0.1.3"
+    prettier: "npm:^3.1.0"
     typescript: "npm:5.2.2"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Resolve the Prettier resolution error caused by prettier being only marked as a peer dependency of `eslint-plugin-prettier` and not a dependency of the `eslint-config-discordeno` package