### PR TITLE
ci: add w-unverified to new issues and prs, change labels tracked for stale issues

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,12 +3,26 @@ name: Labeler
 on:
   pull_request_target:
     types: ['edited', 'opened', 'reopened', 'synchronize']
+  issues:
+    types: ['opened', 'reopened']
 
 jobs:
   labeler:
     name: Labeler
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request_target'
     steps:
       - uses: fuxingloh/multi-labeler@v2
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
+  
+  w_unverified_labeler:
+    name: Add w-unverified Label
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh issue edit "$NUMBER" --add-label "$LABELS"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          LABELS: w-unverified

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,5 +25,7 @@ jobs:
         stale-pr-message: 'This pull request has gone stale for over a month. If this pull request is still useful, leave a comment below. Otherwise, it will be closed shortly.'
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'
-        exempt-issue-labels: 'api-docs-commits,help-wanted'
+        only-labels: 'w-unverified'
+        exempt-issue-labels: 'api-docs-commits,help-wanted,w-verified,w-pending'
+        exempt-pr-labels: 'w-verified'
         close-issue-reason: 'not_planned'


### PR DESCRIPTION
Add `w-unverified` to all new issues and prs. For stale issues, only close the ones with `w-unverified` labels, with added exemptions to `w-verified` label, along with `w-pending` label for issues