### PR TITLE
fix(rest): Add support for getGuilds with bot token

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -1098,14 +1098,14 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
     },
 
     async getGuilds(token, options) {
-      const options: MakeRequestOptions | undefined = token ? {
+      const makeRequestOptions: MakeRequestOptions | undefined = token ? {
         headers: {
           authorization: `Bearer ${token}`,
         },
         unauthorized: true,
       } : undefined
 
-      return await rest.get<DiscordPartialGuild[]>(rest.routes.guilds.userGuilds(options))
+      return await rest.get<DiscordPartialGuild[]>(rest.routes.guilds.userGuilds(options), makeRequestOptions)
     },
 
     async getGuildApplicationCommand(commandId, guildId) {

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -1098,12 +1098,14 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
     },
 
     async getGuilds(token, options) {
-      return await rest.get<DiscordPartialGuild[]>(rest.routes.guilds.userGuilds(options), {
+      const options: MakeRequestOptions | undefined = token ? {
         headers: {
           authorization: `Bearer ${token}`,
         },
         unauthorized: true,
-      })
+      } : undefined
+
+      return await rest.get<DiscordPartialGuild[]>(rest.routes.guilds.userGuilds(options))
     },
 
     async getGuildApplicationCommand(commandId, guildId) {

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -1098,12 +1098,14 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
     },
 
     async getGuilds(token, options) {
-      const makeRequestOptions: MakeRequestOptions | undefined = token ? {
-        headers: {
-          authorization: `Bearer ${token}`,
-        },
-        unauthorized: true,
-      } : undefined
+      const makeRequestOptions: MakeRequestOptions | undefined = token
+        ? {
+            headers: {
+              authorization: `Bearer ${token}`,
+            },
+            unauthorized: true,
+          }
+        : undefined
 
       return await rest.get<DiscordPartialGuild[]>(rest.routes.guilds.userGuilds(options), makeRequestOptions)
     },

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -1794,16 +1794,16 @@ export interface RestManager {
   /**
    * Get the user guilds.
    *
-   * @param bearerToken - The access token of the user
+   * @param bearerToken - The access token of the user, if unspecified the bot token is used instead
    * @param options - The parameters for the fetching of the guild.
    * @returns An instance of {@link Guild}.
    *
    * @remarks
-   * The access tokens needs to have the `guilds` scope
+   * If used with an access token, the token needs to have the `guilds` scope
    *
    * @see {@link https://discord.com/developers/docs/resources/user#get-current-user-guilds}
    */
-  getGuilds: (bearerToken: string, options?: GetUserGuilds) => Promise<CamelizedDiscordPartialGuild[]>
+  getGuilds: (bearerToken?: string, options?: GetUserGuilds) => Promise<CamelizedDiscordPartialGuild[]>
   /**
    * Gets a guild application command by its ID.
    *


### PR DESCRIPTION
The getGuilds rest manager method assumed that the token was always a bearer token and it required it to be present. The method now does not require the token as a required parameter and checks for it when sending the request