### PR TITLE
fix(types): rm `options` from `SelectMenuUsersAndRolesComponent`

### DIFF
--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -201,8 +201,6 @@ export interface SelectMenuUsersAndRolesComponent {
   minValues?: number
   /** The maximum number of items that can be selected. Default 1. Between 1-25. */
   maxValues?: number
-  /** The choices! Maximum of 25 items. */
-  options: SelectOption[]
   /** Whether or not this select is disabled */
   disabled?: boolean
 }


### PR DESCRIPTION
doc: [`options` is [...] unavailable for all other select menu components.](https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-menu-structure:~:text=*-,options,\)%2C%20and%20unavailable%20for%20all%20other%20select%20menu%20components,-.)
