### PR TITLE
feat(rest): Improve rest errors

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -57,13 +57,7 @@ import {
   type ModifyGuildTemplate,
 } from '@discordeno/types'
 import { createRoutes } from './routes.js'
-import {
-  type CreateRequestBodyOptions,
-  type CreateRestManagerOptions,
-  type MakeRequestOptions,
-  type RestManager,
-  type SendRequestOptions,
-} from './types.js'
+import type { CreateRequestBodyOptions, CreateRestManagerOptions, MakeRequestOptions, RestManager, SendRequestOptions } from './types.js'
 
 // TODO: make dynamic based on package.json file
 const version = '19.0.0-alpha.1'


### PR DESCRIPTION
Currently the errors that the REST manager produces are very confusing and require a lot of guessing to what is actually the user invoked function that is causing the error. This is even worse if discord responded with a body that is a very generic error like the 404 errors, or with Bun where, due to a bug(?) it simply displays the red text `Error` with no details in any way.

This pull request modifies how the rest rejects the promise created by `makeRequest` function by using an error object along with the normal object, below are the before and after of the errors.

One more thing we could do is pass the full `fetch` `Request` object inside the error for the user, I'm not convinced because then the full request object will get converted to string into the console on an error

### BEFORE

#### Node
![node](https://github.com/discordeno/discordeno/assets/45207244/5a3975cc-cbd7-4ec2-8a9b-b5f62d5a244f)
*without rejection handler*

![node with unhandled rejection handler](https://github.com/discordeno/discordeno/assets/45207244/e2105540-0e09-4df9-8701-575a72a56daa)
*with rejection handler*

#### Deno
![deno](https://github.com/discordeno/discordeno/assets/45207244/3d250252-77f8-4b83-9754-29bf8c11bde8)
*please, ignore the deno warn, it's the only way i found to make it use the local built package*

#### Bun
![bun](https://github.com/discordeno/discordeno/assets/45207244/d1dd7fb6-ec48-4061-860a-f7eeaa6d0239)

### AFTER

#### Node
![node](https://github.com/discordeno/discordeno/assets/45207244/cd0dffe1-f8bf-46f6-a51c-9234b3df5aba)

#### Deno
![deno](https://github.com/discordeno/discordeno/assets/45207244/6169c811-145b-4e2c-8a1d-b1fc6749501d)
*please, ignore the import warn by deno, it's the only way i found to make it use the local built package, and i have no clue what the warning about what the warning for the stack trace is about*

#### Bun
![bun](https://github.com/discordeno/discordeno/assets/45207244/2e6f58af-c40c-4982-8b14-1518a8885627)
