### PR TITLE
fix(rest): remove has_message from forum route

### DIFF
--- a/packages/rest/src/routes.ts
+++ b/packages/rest/src/routes.ts
@@ -103,7 +103,7 @@ export function createRoutes(): RestRoutes {
       },
 
       forum: (channelId) => {
-        return `/channels/${channelId}/threads?has_message=true`
+        return `/channels/${channelId}/threads`
       },
 
       invites: (channelId) => {


### PR DESCRIPTION
This removes `has_message` from the forum route which causes a bug when creating a thread in a forum channel that requires a root level `content` even though the message content is contained inside a `message` object.