### PR TITLE
fix(bot, types): `description` being a required property on `CreateSlashApplicationCommand`.

### DIFF
--- a/packages/bot/src/transformers/reverse/createApplicationCommand.ts
+++ b/packages/bot/src/transformers/reverse/createApplicationCommand.ts
@@ -10,8 +10,6 @@ export function transformCreateApplicationCommandToDiscordCreateApplicationComma
     return {
       name: payload.name,
       name_localizations: payload.nameLocalizations,
-      description: '',
-      description_localizations: {},
       type: payload.type,
       default_member_permissions: payload.defaultMemberPermissions ? calculateBits(payload.defaultMemberPermissions) : null,
       dm_permission: payload.dmPermission,

--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -443,7 +443,7 @@ export interface CreateSlashApplicationCommand {
   /** Localization object for the `name` field. Values follow the same restrictions as `name` */
   nameLocalizations?: Localization
   /** 1-100 character description */
-  description: string
+  description?: string
   /** Localization object for the `description` field. Values follow the same restrictions as `description` */
   descriptionLocalizations?: Localization
   /** Type of command, defaults `ApplicationCommandTypes.ChatInput` if not set  */


### PR DESCRIPTION
The `description` is not required as indicated here:
https://discord.com/developers/docs/interactions/application-commands#create-guild-application-command