### PR TITLE
feat(types): Add `enforceNonce` to `CreateMessageOptions`

### DIFF
--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -77,6 +77,8 @@ export interface CreateMessageOptions {
   stickerIds?: [BigString] | [BigString, BigString] | [BigString, BigString, BigString]
   /** Message flags combined as a bitfield, only SUPPRESS_EMBEDS and SUPPRESS_NOTIFICATIONS can be set */
   flags?: DiscordMessageFlag
+  /** If true and nonce is present, it will be checked for uniqueness in the past few minutes. If another message was created by the same author with the same nonce, that message will be returned and no new message will be created. */
+  enforceNonce?: boolean
 }
 
 export type MessageComponents = ActionRow[]


### PR DESCRIPTION
Add support for `enforce_nonce` in `CreateMessageOptions` according to #3431 

closes #3431