### PR TITLE
feat(types): add SUPPRESS_NOTIFICATIONS to interaction response flags

### DIFF
--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -482,7 +482,7 @@ export interface InteractionCallbackData {
   title?: string
   /** The components you would like to have sent in this message */
   components?: MessageComponents
-  /** Message flags combined as a bit field (only SUPPRESS_EMBEDS and EPHEMERAL can be set) */
+  /** Message flags combined as a bit field (only `SUPPRESS_EMBEDS`, `EPHEMERAL` and `SUPPRESS_NOTIFICATIONS` can be set) */
   flags?: number
   /** Autocomplete choices (max of 25 choices) */
   choices?: Camelize<DiscordApplicationCommandOptionChoice[]>


### PR DESCRIPTION
Add the `SUPPRESS_NOTIFICATIONS` flag for the interaction callback data according to #3447 

*This effectively changes only a comment because we use number for the flags.*

closes #3447 