### PR TITLE
fix(rest-proxy): check for multi-part bodies

### DIFF
--- a/docker-apps/rest-passthrough/package.json
+++ b/docker-apps/rest-passthrough/package.json
@@ -11,9 +11,10 @@
     "setup-dd": ""
   },
   "dependencies": {
-    "@discordeno/rest": "19.0.0-next.9006572",
+    "@discordeno/rest": "19.0.0-next.d81b28a",
     "@fastify/env": "^4.3.0",
     "@fastify/helmet": "^11.1.1",
+    "@fastify/multipart": "^8.1.0",
     "fastify": "^4.26.2"
   },
   "devDependencies": {

--- a/docker-apps/rest-passthrough/src/fastify.ts
+++ b/docker-apps/rest-passthrough/src/fastify.ts
@@ -1,3 +1,4 @@
+import fastifyMultipart from '@fastify/multipart'
 import fastifyEnv from '@fastify/env'
 import fastifyHelmet from '@fastify/helmet'
 import fastify, { type FastifyInstance } from 'fastify'
@@ -27,6 +28,7 @@ export const buildFastifyApp = async (): Promise<FastifyInstance> => {
   })
 
   await app.register(fastifyHelmet)
+  app.register(fastifyMultipart, { attachFieldsToBody: true })
 
   app.addHook('onRequest', async (request, reply) => {
     if (request.headers.authorization !== request.server.config.AUTHORIZATION_TOKEN) {

--- a/docker-apps/rest-passthrough/yarn.lock
+++ b/docker-apps/rest-passthrough/yarn.lock
@@ -5,31 +5,31 @@ __metadata:
   version: 8
   cacheKey: 10
 
-"@discordeno/rest@npm:19.0.0-next.9006572":
-  version: 19.0.0-next.9006572
-  resolution: "@discordeno/rest@npm:19.0.0-next.9006572"
+"@discordeno/rest@npm:19.0.0-next.d81b28a":
+  version: 19.0.0-next.d81b28a
+  resolution: "@discordeno/rest@npm:19.0.0-next.d81b28a"
   dependencies:
-    "@discordeno/types": "npm:19.0.0-next.9006572"
-    "@discordeno/utils": "npm:19.0.0-next.9006572"
-    dotenv: "npm:^16.0.3"
-  checksum: b6298a3af305f44a21ef8326f878ec01c48651d16431c96130e2976237ff166752e9b41a4f6741d528be667ccc5056b70ffa666826e37e38922f8ded27fd93db
+    "@discordeno/types": "npm:19.0.0-next.d81b28a"
+    "@discordeno/utils": "npm:19.0.0-next.d81b28a"
+    dotenv: "npm:^16.3.1"
+  checksum: 63c02953008962365996944e61feae361872b01a6dfe68d0ca2c13ca38cdcd464dd0e78724c496579d4bd55757507b4dfb00c72130d44f32ba575a800b4d1829
   languageName: node
   linkType: hard
 
-"@discordeno/types@npm:19.0.0-next.9006572":
-  version: 19.0.0-next.9006572
-  resolution: "@discordeno/types@npm:19.0.0-next.9006572"
-  checksum: 54a4d4b5e2f8caea94fdfb164dc859ca4d61cc3d8bed849a458f944c73523ddf1857b14d6c93754d2eef42c705b813f966959e6870b4835c4b31505e42c72806
+"@discordeno/types@npm:19.0.0-next.d81b28a":
+  version: 19.0.0-next.d81b28a
+  resolution: "@discordeno/types@npm:19.0.0-next.d81b28a"
+  checksum: cf3bbb8a8d4cf539733550d68c7048800c9c8de7039aac7231fd4f6102994957eb1656b56fed554d86724058cb10f68f0d97651303981a4f6921d810a6b1fb2e
   languageName: node
   linkType: hard
 
-"@discordeno/utils@npm:19.0.0-next.9006572":
-  version: 19.0.0-next.9006572
-  resolution: "@discordeno/utils@npm:19.0.0-next.9006572"
+"@discordeno/utils@npm:19.0.0-next.d81b28a":
+  version: 19.0.0-next.d81b28a
+  resolution: "@discordeno/utils@npm:19.0.0-next.d81b28a"
   dependencies:
-    "@discordeno/types": "npm:19.0.0-next.9006572"
+    "@discordeno/types": "npm:19.0.0-next.d81b28a"
     tweetnacl: "npm:^1.0.3"
-  checksum: f19b9cefbc00c0e345c10fe409f132a7a7bfeaec57aa458d9abd4d63dc1d1f5f32f34db6cfba236f9798773269d7b09484f481cea5e0404a285c52cca397fe6c
+  checksum: 98fa3b99e7a8f3c1d639bc268f8df76f8d6b2ea861c5baeec53d507c8efa87bb9795d143354961a7fd0936ba9c6064a97be3c6528df8b37d4c0c9953344e156a
   languageName: node
   linkType: hard
 
@@ -41,6 +41,15 @@ __metadata:
     ajv-formats: "npm:^2.1.1"
     fast-uri: "npm:^2.0.0"
   checksum: c46c4680bf583e37b97ffc85b69070712c9c47e18ddf89b9fb93dbc0b6ba3c6496cf624aabe9aac25dafc4a404b738ab0fedcff66503df0ce18d9dcad9e44b26
+  languageName: node
+  linkType: hard
+
+"@fastify/busboy@npm:^1.0.0":
+  version: 1.2.1
+  resolution: "@fastify/busboy@npm:1.2.1"
+  dependencies:
+    text-decoding: "npm:^1.0.0"
+  checksum: 1d1963c64992c5f4cd26aceb399dbddfcf2824e5259a7b92c77d2137e67d55e6bc416efe430bf59e897e3a57dad66fec8e51297f4858b855c3b38c7c17818b43
   languageName: node
   linkType: hard
 
@@ -61,7 +70,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fastify/error@npm:^3.3.0, @fastify/error@npm:^3.4.0":
+"@fastify/error@npm:^3.0.0, @fastify/error@npm:^3.3.0, @fastify/error@npm:^3.4.0":
   version: 3.4.1
   resolution: "@fastify/error@npm:3.4.1"
   checksum: 4d63660f7d4a0d6091abf869208d30898bde82f513ca7be542243d9d740df743dd4be293e7db30858fca612dd512d28a818ea06dc674e06b445278fcefcdda92
@@ -84,6 +93,20 @@ __metadata:
     fastify-plugin: "npm:^4.2.1"
     helmet: "npm:^7.0.0"
   checksum: f21d1d5492bf29c143f6130355d6c9c4c26545954f1d82707021146017d24b2b20c88269b72d7f35c068cb50672cf172515b54b985f781d03f04f148c30f8bd6
+  languageName: node
+  linkType: hard
+
+"@fastify/multipart@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "@fastify/multipart@npm:8.1.0"
+  dependencies:
+    "@fastify/busboy": "npm:^1.0.0"
+    "@fastify/deepmerge": "npm:^1.0.0"
+    "@fastify/error": "npm:^3.0.0"
+    fastify-plugin: "npm:^4.0.0"
+    secure-json-parse: "npm:^2.4.0"
+    stream-wormhole: "npm:^1.1.0"
+  checksum: 427aa1a3590d22467bf9121fc036dc58dd48125f7c74ee5aa5b18a6c64e02f4b3be2aa23cdeec4068cba6ce4abc0dde352b7706ca7f0ba36cf589261f2becc0a
   languageName: node
   linkType: hard
 
@@ -919,14 +942,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^16.0.0, dotenv@npm:^16.0.3":
+"dotenv@npm:^16.0.0":
   version: 16.3.1
   resolution: "dotenv@npm:16.3.1"
   checksum: dbb778237ef8750e9e3cd1473d3c8eaa9cc3600e33a75c0e36415d0fa0848197f56c3800f77924c70e7828f0b03896818cd52f785b07b9ad4d88dba73fbba83f
   languageName: node
   linkType: hard
 
-"dotenv@npm:^16.4.5":
+"dotenv@npm:^16.3.1, dotenv@npm:^16.4.5":
   version: 16.4.5
   resolution: "dotenv@npm:16.4.5"
   checksum: 55a3134601115194ae0f924e54473459ed0d9fc340ae610b676e248cca45aa7c680d86365318ea964e6da4e2ea80c4514c1adab5adb43d6867fb57ff068f95c8
@@ -2429,9 +2452,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "rest-passthrough@workspace:."
   dependencies:
-    "@discordeno/rest": "npm:19.0.0-next.9006572"
+    "@discordeno/rest": "npm:19.0.0-next.d81b28a"
     "@fastify/env": "npm:^4.3.0"
     "@fastify/helmet": "npm:^11.1.1"
+    "@fastify/multipart": "npm:^8.1.0"
     "@favware/cliff-jumper": "npm:^3.0.1"
     "@swc/cli": "npm:^0.3.10"
     "@swc/core": "npm:^1.4.5"
@@ -2507,7 +2531,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"secure-json-parse@npm:^2.7.0":
+"secure-json-parse@npm:^2.4.0, secure-json-parse@npm:^2.7.0":
   version: 2.7.0
   resolution: "secure-json-parse@npm:2.7.0"
   checksum: 974386587060b6fc5b1ac06481b2f9dbbb0d63c860cc73dc7533f27835fdb67b0ef08762dbfef25625c15bc0a0c366899e00076cb0d556af06b71e22f1dede4c
@@ -2690,6 +2714,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stream-wormhole@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "stream-wormhole@npm:1.1.0"
+  checksum: cc19e0235c5d031bd530fa83913c807d9525fa4ba33d51691dd822c0726b8b7ef138b34f289d063a3018cddba67d3ba7fd0ecedaa97242a0f1ed2eed3c6a2ab1
+  languageName: node
+  linkType: hard
+
 "string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^4.1.0":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
@@ -2788,6 +2819,13 @@ __metadata:
     mkdirp: "npm:^1.0.3"
     yallist: "npm:^4.0.0"
   checksum: 2042bbb14830b5cd0d584007db0eb0a7e933e66d1397e72a4293768d2332449bc3e312c266a0887ec20156dea388d8965e53b4fc5097f42d78593549016da089
+  languageName: node
+  linkType: hard
+
+"text-decoding@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "text-decoding@npm:1.0.0"
+  checksum: 73c604f285d86d653815a5c32b86ffef9ffe27074bc3e5da3718ac46bba7c04775bb3da7b13c60e3a6525d1acce7cc3442b39e25a3a43f211c866ba9ba414207
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Currently when you send a request to the rest proxy that involves uploading a file it will fail as fastify does not know how to handle the multi-part body that it receives. This pr adds the `@fastify/multipart` package to handle this and a function to build the FormData object to give to `@discordeno/bot`.

This pr also bumps the version of `@discordeno/rest` in the proxy to the latest on npm due to bugs when testing the code

closes #3354