### PR TITLE
feat(types,rest,bot): Support integrationTypesConfig in Application

### DIFF
--- a/packages/bot/src/transformers/application.ts
+++ b/packages/bot/src/transformers/application.ts
@@ -7,6 +7,7 @@ import {
   type Guild,
   type Team,
   type User,
+  type DiscordApplicationIntegrationType,
 } from '../index.js'
 
 export function transformApplication(bot: Bot, payload: { application: DiscordApplication; shardId: number }): Application {
@@ -38,6 +39,7 @@ export function transformApplication(bot: Bot, payload: { application: DiscordAp
     bot: payload.application.bot ? bot.transformers.user(bot, payload.application.bot as DiscordUser) : undefined,
     interactionsEndpointUrl: payload.application.interactions_endpoint_url,
     redirectUris: payload.application.redirect_uris,
+    integrationTypesConfig: payload.application.integration_types_config,
   } as Application
 
   return bot.transformers.customizers.application(bot, payload.application, application)
@@ -66,4 +68,5 @@ export interface Application {
   bot?: User
   redirectUris?: string[]
   interactionsEndpointUrl?: string
+  integrationTypesConfig?: DiscordApplicationIntegrationType
 }

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -972,7 +972,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
     },
 
     async editApplicationInfo(body) {
-      return await rest.patch<DiscordApplication>(rest.routes.oauth2.application(), {
+      return await rest.patch<DiscordApplication>(rest.routes.application(), {
         body,
       })
     },

--- a/packages/rest/src/routes.ts
+++ b/packages/rest/src/routes.ts
@@ -609,6 +609,10 @@ export function createRoutes(): RestRoutes {
       return `/users/${userId}`
     },
 
+    application() {
+      return '/applications/@me'
+    },
+
     currentUser() {
       return '/users/@me'
     },

--- a/packages/rest/src/typings/routes.ts
+++ b/packages/rest/src/typings/routes.ts
@@ -248,7 +248,7 @@ export interface RestRoutes {
     tokenRevoke: () => string
     /** Route to get information about the current authorization. Requires an access token */
     currentAuthorization: () => string
-    /** Route to get information about the current application. Requires an access token */
+    /** Route to get information about the current application. */
     application: () => string
     /** Route to get the connection the user has. Requires the `connections` OAuth2 scope */
     connections: () => string
@@ -266,6 +266,8 @@ export interface RestRoutes {
   }
   /** Get information about the current OAuth2 user / bot user. If used with a OAuth2 token requires the `identify` OAuth2 scope */
   currentUser: () => string
+  /**  Route to get and edit information about the current application. */
+  application: () => string
   /** Route for handling a sticker. */
   sticker: (stickerId: BigString) => string
   /** Route for handling all voice regions. */

--- a/packages/types/src/discord.ts
+++ b/packages/types/src/discord.ts
@@ -373,6 +373,8 @@ export interface DiscordApplication {
   tags?: string[]
   /** settings for the application's default in-app authorization link, if enabled */
   install_params?: DiscordInstallParams
+  /** Default scopes and permissions for each supported installation context.  */
+  integration_types_config?: DiscordApplicationIntegrationType
   /** the application's default custom authorization link, if enabled */
   custom_install_url?: string
   /** the application's role connection verification entry point, which when configured will render the app as a verification method in the guild role verification configuration */
@@ -385,6 +387,13 @@ export interface DiscordApplication {
   redirect_uris?: string[]
   /** Interactions endpoint URL for the app */
   interactions_endpoint_url?: string
+}
+
+export enum DiscordApplicationIntegrationType {
+  /** App is installable to servers */
+  GuildInstall = 0,
+  /** App is installable to users */
+  UserInstall = 1,
 }
 
 export type DiscordTokenExchange = DiscordTokenExchangeAuthorizationCode | DiscordTokenExchangeRefreshToken | DiscordTokenExchangeClientCredentials

--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -4,6 +4,7 @@ import type {
   AutoModerationTriggerTypes,
   DiscordApplicationCommandOption,
   DiscordApplicationCommandOptionChoice,
+  DiscordApplicationIntegrationType,
   DiscordAttachment,
   DiscordAutoModerationRuleTriggerMetadataPresets,
   DiscordChannel,
@@ -1271,6 +1272,8 @@ export interface EditApplication {
   roleConnectionsVerificationUrl?: string
   /** Settings for the app's default in-app authorization link, if enabled */
   installParams?: DiscordInstallParams
+  /** Default scopes and permissions for each supported installation context. */
+  integrationTypesConfig?: DiscordApplicationIntegrationType
   /**
    * App's public flags
    *


### PR DESCRIPTION
Add support for the new integrationTypesConfig option in the application

This also fix an error there was with the `editApplicationInfo` rest method as it was wrongfully using the oauth2 application endpoint

closes #3496