### PR TITLE
feat(rest): Update comment for permissions needed when pruning members

### DIFF
--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -2062,7 +2062,7 @@ export interface RestManager {
    * @returns A number indicating the number of members that would be kicked.
    *
    * @remarks
-   * Requires the `KICK_MEMBERS` permission.
+   * Requires the `MANAGE_GUILD` and `KICK_MEMBERS` permissions.
    *
    * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-prune-count}
    */
@@ -2751,7 +2751,7 @@ export interface RestManager {
    * @returns A number indicating how many members were pruned.
    *
    * @remarks
-   * Requires the `KICK_MEMBERS` permission.
+   * Requires the `MANAGE_GUILD` and `KICK_MEMBERS` permissions.
    *
    * ❗ Requests to this endpoint will time out for large guilds. To prevent this from happening, set the {@link BeginGuildPrune.computePruneCount} property of the {@link options} object parameter to `false`. This will begin the process of pruning, and immediately return `undefined`, rather than wait for the process to complete before returning the actual count of members that have been kicked.
    *


### PR DESCRIPTION
This updates the comment with the updated required permissions needed when pruning the members in a guild. This now takes the `MANAGE_GUILD` permissions other then the `KICK_MEMBERS` according to new commits in discord/discord-api-docs (#3497)

closes #3497