### PR TITLE
feat(types): Add bungie discord connection

### DIFF
--- a/packages/types/src/discord.ts
+++ b/packages/types/src/discord.ts
@@ -478,6 +478,7 @@ export interface DiscordConnection {
 /** https://discord.com/developers/docs/resources/user#connection-object-services */
 export enum DiscordConnectionServiceType {
   BattleNet = 'battlenet',
+  Bungie = 'Bungie.net',
   eBay = 'ebay',
   EpicGames = 'epicgames',
   Facebook = 'facebook',


### PR DESCRIPTION
Adds the Bungie connection to the `DiscordConnectionServiceType` enum

closes #3524