### PR TITLE
fix(build): Fix CJS extension script to avoid replacing .json

### DIFF
--- a/scripts/fixCjsExtension.js
+++ b/scripts/fixCjsExtension.js
@@ -10,7 +10,7 @@ for await (const dir of dirs) {
       }
       const content = await fs.promises.readFile(`dist/cjs${dir}/${file}`, 'utf-8')
       await fs.promises.rm(`dist/cjs${dir}/${file}`)
-      fs.promises.writeFile(`dist/cjs${dir}/${file.slice(0, -3)}.cjs`, content.replace(/\.js/g, '.cjs'))
+      fs.promises.writeFile(`dist/cjs${dir}/${file.slice(0, -3)}.cjs`, content.replace(/\.js(?!on)/g, '.cjs'))
     }),
   )
 }


### PR DESCRIPTION
Currently the script uses a RegExP to change all the `.js` references to `.cjs` to avoid runtime errors as since we have `"type": "module"` in our package.json all the `.js` files are getting interpreted as ESModules and we need to use the `.cjs` extension for CommonJS. The script just checked for the presence of `.js` anywhere in the code and replaced with `.cjs` but this caused errors in the REST package as the `Response` object that `fetch()` returns has a `.json` method to get the JSON body but `.json` starting with `.js` was being matched by the RegExP and was creating unexpected runtime errors. This pr adds a RegEx Negative LookAhead to make sure we aren't replacing any `.json` instance.