### PR TITLE
fix: bump script ignoring some `@discordeno` deps

### DIFF
--- a/scripts/bumpVersionByCommit.js
+++ b/scripts/bumpVersionByCommit.js
@@ -11,12 +11,17 @@ if (!packageName) {
 const commitHash = childProcess.execSync('git rev-parse HEAD').toString().trim().slice(0, 7)
 
 const file = JSON.parse(await fs.readFile(`packages/${packageName}/package.json`, 'utf-8'))
+
 const oldVersion = file.version
 file.version = `${oldVersion.split('-')[0]}-next.${commitHash}`
-if (file.dependencies)
+
+if (file.dependencies) {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   Object.keys(file.dependencies).forEach((dependency) => {
-    if (file.dependencies[dependency] === oldVersion) file.dependencies[dependency] = file.version
+    if (dependency.startsWith('@discordeno/')) file.dependencies[dependency] = file.version
   })
+}
+
 await fs.writeFile(`packages/${packageName}/package.json`, JSON.stringify(file, null, 2))
 
 console.log(`Bumped ${packageName} to ${file.version.split('-')[0]}-next.${commitHash}`)


### PR DESCRIPTION
Currently the /scripts/bumpVersionByCommit.js when it needs to bump the dependencies of a package to publish it checks that the dependency version is the same as the package version. This now creates an issue because some packages are classified as beta while other as alpha making the NPM release impossibile to install (see https://github.com/discordeno/discordeno/issues/3519#issuecomment-2082112108).

This pr changes the script to instead use the `@discordeno` npm scope to check if it needs to update the version for the package dependency.