### PR TITLE
fix(gateway): Remove bot token from the shard debug logs

### DIFF
--- a/packages/gateway/src/Shard.ts
+++ b/packages/gateway/src/Shard.ts
@@ -216,7 +216,7 @@ export class DiscordenoShard {
     await this.connect()
     this.logger.debug(
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      `[Gateway] Resuming Shard #${this.id}, after connecting. ${this.gatewayConfig.token} | ${this.sessionId} | ${this.previousSequenceNumber}`,
+      `[Gateway] Resuming Shard #${this.id}, after connecting. ${this.sessionId} | ${this.previousSequenceNumber}`,
     )
 
     this.send(


### PR DESCRIPTION
Currently we add to the debug logs for the shards the bot token when resume is called. In the rest package we do censor it with "tokenhere" while still showing the HTTP header, however in this situation there isn't the need to show what token is in use and it is better to not leak the bot token in a log file or something like that