### PR TITLE
docs(types): Update some documentation of the options for slash commands

### DIFF
--- a/packages/types/src/discord.ts
+++ b/packages/types/src/discord.ts
@@ -2361,10 +2361,15 @@ export interface DiscordApplicationCommandOption {
   type: ApplicationCommandOptionTypes
   /**
    * Name of command, 1-32 characters.
-   * `ApplicationCommandTypes.ChatInput` command names must match the following regex `^[-_\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}$` with the unicode flag set.
+   *
+   * @remarks
+   * This value should be unique within an array of {@link DiscordApplicationCommandOption}
+   *
+   * {@link ApplicationCommandTypes.ChatInput | ChatInput} command names must match the following regex `^[-_\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}$` with the unicode flag set.
    * If there is a lowercase variant of any letters used, you must use those.
    * Characters with no lowercase variants and/or uncased letters are still allowed.
-   * ApplicationCommandTypes.User` and `ApplicationCommandTypes.Message` commands may be mixed case and can include spaces.
+   *
+   * {@link ApplicationCommandTypes.User | User} and {@link ApplicationCommandTypes.Message | Message} commands may be mixed case and can include spaces.
    */
   name: string
   /** Localization object for the `name` field. Values follow the same restrictions as `name` */
@@ -2386,7 +2391,7 @@ export interface DiscordApplicationCommandOption {
    * @remarks
    * Only valid in options of type {@link ApplicationCommandOptionTypes.String | String}, {@link ApplicationCommandOptionTypes.Integer | Integer}, or {@link ApplicationCommandOptionTypes.Number | Number}
    *
-   * If you provide there options, they will be the ONLY accepted values for this option
+   * If you provide an array of choices, they will be the ONLY accepted values for this option
    */
   choices?: DiscordApplicationCommandOptionChoice[]
   /**
@@ -2401,6 +2406,8 @@ export interface DiscordApplicationCommandOption {
    *
    * @remarks
    * Only valid in options of type {@link ApplicationCommandOptionTypes.String | String}, {@link ApplicationCommandOptionTypes.Integer | Integer}, or {@link ApplicationCommandOptionTypes.Number | Number}
+   *
+   * When {@link DiscordApplicationCommandOption.choices | choices} are provided, this may not be set to true
    */
   autocomplete?: boolean
   /**

--- a/packages/types/src/discord.ts
+++ b/packages/types/src/discord.ts
@@ -2373,27 +2373,70 @@ export interface DiscordApplicationCommandOption {
   description: string
   /** Localization object for the `description` field. Values follow the same restrictions as `description` */
   description_localizations?: Localization | null
-  /** If the parameter is required or optional--default `false` */
+  /**
+   * If the parameter is required or optional. default `false`
+   *
+   * @remarks
+   * Valid in all option types except {@link ApplicationCommandOptionTypes.SubCommand | SubCommand} and {@link ApplicationCommandOptionTypes.SubCommandGroup | SubCommandGroup}
+   */
   required?: boolean
-  /** Choices for the option types `ApplicationCommandOptionTypes.String`, `ApplicationCommandOptionTypes.Integer`, and `ApplicationCommandOptionTypes.Number`, from which the user can choose, max 25 */
+  /**
+   * Choices for the option from which the user can choose, max 25
+   *
+   * @remarks
+   * Only valid in options of type {@link ApplicationCommandOptionTypes.String | String}, {@link ApplicationCommandOptionTypes.Integer | Integer}, or {@link ApplicationCommandOptionTypes.Number | Number}
+   *
+   * If you provide there options, they will be the ONLY accepted values for this option
+   */
   choices?: DiscordApplicationCommandOptionChoice[]
-  /** If the option is a subcommand or subcommand group type, these nested options will be the parameters */
+  /**
+   * If the option is a subcommand or subcommand group type, these nested options will be the parameters
+   *
+   * @remarks
+   * Only valid in option of type {@link ApplicationCommandOptionTypes.SubCommand | SubCommand} or {@link ApplicationCommandOptionTypes.SubCommandGroup | SubCommandGroup}
+   */
   options?: DiscordApplicationCommandOption[]
   /**
    * If autocomplete interactions are enabled for this option.
    *
-   * Only available for `ApplicationCommandOptionTypes.String`, `ApplicationCommandOptionTypes.Integer` and `ApplicationCommandOptionTypes.Number` option types
+   * @remarks
+   * Only valid in options of type {@link ApplicationCommandOptionTypes.String | String}, {@link ApplicationCommandOptionTypes.Integer | Integer}, or {@link ApplicationCommandOptionTypes.Number | Number}
    */
   autocomplete?: boolean
-  /** If the option is a channel type, the channels shown will be restricted to these types */
+  /**
+   * The channels shown will be restricted to these types
+   *
+   * @remarks
+   * Only valid in option of type {@link ApplicationCommandOptionTypes.Channel | Channel}
+   */
   channel_types?: ChannelTypes[]
-  /** If the option type is `ApplicationCommandOptionTypes.Integer` or `ApplicationCommandOptionTypes.Number`, the minimum permitted value */
+  /**
+   * The minimum permitted value
+   *
+   * @remarks
+   * Only valid in options of type {@link ApplicationCommandOptionTypes.Integer | Integer} or {@link ApplicationCommandOptionTypes.Number | Number}
+   */
   min_value?: number
-  /** If the option type is `ApplicationCommandOptionTypes.Integer` or `ApplicationCommandOptionTypes.Number`, the maximum permitted value */
+  /**
+   * The maximum permitted value
+   *
+   * @remarks
+   * Only valid in options of type {@link ApplicationCommandOptionTypes.Integer | Integer} or {@link ApplicationCommandOptionTypes.Number | Number}
+   */
   max_value?: number
-  /** If the option type is `ApplicationCommandOptionTypes.String`, the minimum permitted length */
+  /**
+   * The minimum permitted length, should be in the range of from 0 to 600
+   *
+   * @remarks
+   * Only valid in options of type {@link ApplicationCommandOptionTypes.String | String}
+   */
   min_length?: number
-  /** If the option type is `ApplicationCommandOptionTypes.String`, the maximum permitted length  */
+  /**
+   * The maximum permitted length, should be in the range of from 0 to 600
+   *
+   * @remarks
+   * Only valid in options of type {@link ApplicationCommandOptionTypes.String | String}
+   */
   max_length?: number
 }
 

--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -457,7 +457,12 @@ export interface CreateSlashApplicationCommand {
   descriptionLocalizations?: Localization
   /** Type of command, defaults `ApplicationCommandTypes.ChatInput` if not set  */
   type?: ApplicationCommandTypes
-  /** Parameters for the command */
+  /**
+   * Parameters for the command
+   *
+   * @remarks
+   * This is only valid in commands of type {@link ApplicationCommandTypes.ChatInput | ChatInput}
+   */
   options?: Camelize<DiscordApplicationCommandOption[]>
   /** Set of permissions represented as a bit set */
   defaultMemberPermissions?: PermissionStrings[]


### PR DESCRIPTION
Update and clarify when the options for options are valid given the type of the command/option

Upstream: [discord/discord-api-docs#6177](https://github.com/discord/discord-api-docs/pull/6177)
fixes #3599