### PR TITLE
feat(rest): Add reason to followAnnouncement

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -24,6 +24,7 @@ import {
   type DiscordEmoji,
   type DiscordEntitlement,
   type DiscordFollowedChannel,
+  type DiscordGetAnswerVotesResponse,
   type DiscordGetGatewayBot,
   type DiscordGuild,
   type DiscordGuildApplicationCommandPermissions,
@@ -40,7 +41,6 @@ import {
   type DiscordMemberWithUser,
   type DiscordMessage,
   type DiscordPartialGuild,
-  type DiscordGetAnswerVotesResponse,
   type DiscordPrunedCount,
   type DiscordRole,
   type DiscordScheduledEvent,
@@ -925,11 +925,12 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       return await rest.post<DiscordMessage>(rest.routes.webhooks.webhook(webhookId, token, options), { body: options })
     },
 
-    async followAnnouncement(sourceChannelId, targetChannelId) {
+    async followAnnouncement(sourceChannelId, targetChannelId, reason) {
       return await rest.post<DiscordFollowedChannel>(rest.routes.channels.follow(sourceChannelId), {
         body: {
           webhook_channel_id: targetChannelId,
         },
+        reason,
       })
     },
 

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -21,6 +21,7 @@ import type {
   CamelizedDiscordEmoji,
   CamelizedDiscordEntitlement,
   CamelizedDiscordFollowedChannel,
+  CamelizedDiscordGetAnswerVotesResponse,
   CamelizedDiscordGetGatewayBot,
   CamelizedDiscordGuild,
   CamelizedDiscordGuildApplicationCommandPermissions,
@@ -36,7 +37,6 @@ import type {
   CamelizedDiscordMessage,
   CamelizedDiscordModifyGuildWelcomeScreen,
   CamelizedDiscordPartialGuild,
-  CamelizedDiscordGetAnswerVotesResponse,
   CamelizedDiscordPrunedCount,
   CamelizedDiscordRole,
   CamelizedDiscordScheduledEvent,
@@ -1502,6 +1502,7 @@ export interface RestManager {
    *
    * @param sourceChannelId - The ID of the announcement channel to follow.
    * @param targetChannelId - The ID of the target channel - the channel to cross-post to.
+   * @param {string} [reason] - An optional reason for the action, to be included in the audit log.
    * @returns An instance of {@link CamelizedDiscordFollowedChannel}.
    *
    * @remarks
@@ -1511,7 +1512,7 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/channel#follow-announcement-channel}
    */
-  followAnnouncement: (sourceChannelId: BigString, targetChannelId: BigString) => Promise<CamelizedDiscordFollowedChannel>
+  followAnnouncement: (sourceChannelId: BigString, targetChannelId: BigString, reason?: string) => Promise<CamelizedDiscordFollowedChannel>
   /**
    * Gets the list of all active threads for a guild.
    *


### PR DESCRIPTION
Add a reason param to followAnnouncement, this will specify the X-Audit-Log-Reason header and it will be logged in the Discord Audit log

Upstream: [discord/discord-api-docs#6559](https://github.com/discord/discord-api-docs/pull/6559)
fixes #3587