### PR TITLE
feat(types): Add domain connection service type

### DIFF
--- a/packages/types/src/discord.ts
+++ b/packages/types/src/discord.ts
@@ -508,6 +508,7 @@ export interface DiscordConnection {
 export enum DiscordConnectionServiceType {
   BattleNet = 'battlenet',
   Bungie = 'Bungie.net',
+  Domain = 'domain',
   eBay = 'ebay',
   EpicGames = 'epicgames',
   Facebook = 'facebook',


### PR DESCRIPTION
Add domain connection service type to the DiscordConnectionServiceType enum

Upstream: [discord/discord-api-docs#6395](https://github.com/discord/discord-api-docs/pull/6395)
fixes #3585