### PR TITLE
fix(utils): Use media.discordapp.net for gif stickers

### DIFF
--- a/packages/types/src/shared.ts
+++ b/packages/types/src/shared.ts
@@ -394,6 +394,7 @@ export enum StickerFormatTypes {
   Png = 1,
   APng,
   Lottie,
+  Gif,
 }
 
 /** https://discord.com/developers/docs/interactions/slash-commands#interaction-interactiontype */

--- a/packages/utils/src/images.ts
+++ b/packages/utils/src/images.ts
@@ -357,7 +357,7 @@ export function stickerUrl(
     type?: StickerFormatTypes
   },
 ): string | undefined {
-  if (!stickerId) return undefined
+  if (!stickerId) return
 
   const url =
     options?.type === StickerFormatTypes.Gif

--- a/packages/utils/src/images.ts
+++ b/packages/utils/src/images.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
-import type { BigString, GetGuildWidgetImageQuery, ImageFormat, ImageSize } from '@discordeno/types'
+import { type BigString, type GetGuildWidgetImageQuery, type ImageFormat, type ImageSize, StickerFormatTypes } from '@discordeno/types'
 import { iconBigintToHash } from './hash.js'
 
 /** Help format an image url. */
@@ -354,9 +354,17 @@ export function stickerUrl(
   options?: {
     size?: ImageSize
     format?: ImageFormat
+    type?: StickerFormatTypes
   },
 ): string | undefined {
-  return stickerId ? formatImageUrl(`https://cdn.discordapp.com/stickers/${stickerId}`, options?.size ?? 128, options?.format) : undefined
+  if (!stickerId) return undefined
+
+  const url =
+    options?.type === StickerFormatTypes.Gif
+      ? `https://media.discordapp.net/stickers/${stickerId}`
+      : `https://cdn.discordapp.com/stickers/${stickerId}`
+
+  return formatImageUrl(url, options?.size ?? 128, options?.format)
 }
 
 /**


### PR DESCRIPTION
Use media.discordapp.net for gif stickers, cdn.discordapp.com returns a 404 for gif stickers
Add Gif to StickerFromatTypes as it was missing

Upstream: [discord/discord-api-docs#6831](https://github.com/discord/discord-api-docs/pull/6831)
fixes #3576