### PR TITLE
feat(types,bot)!: Use flag Enums where possible

### DIFF
--- a/packages/bot/src/transformers/activity.ts
+++ b/packages/bot/src/transformers/activity.ts
@@ -1,4 +1,4 @@
-import type { ActivityTypes, Bot, DiscordActivity } from '../index.js'
+import type { ActivityFlag, ActivityTypes, Bot, DiscordActivity } from '../index.js'
 
 export function transformActivity(bot: Bot, payload: DiscordActivity): Activity {
   const activity = {
@@ -38,7 +38,7 @@ export function transformActivity(bot: Bot, payload: DiscordActivity): Activity 
 
 export interface Activity {
   join?: string
-  flags?: number
+  flags?: ActivityFlag
   applicationId?: bigint
   spectate?: string
   url?: string

--- a/packages/bot/src/transformers/channel.ts
+++ b/packages/bot/src/transformers/channel.ts
@@ -1,5 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
-import type { BigString, ChannelTypes, DiscordChannel, DiscordThreadMember, OverwriteReadable, VideoQualityModes } from '@discordeno/types'
+import type {
+  BigString,
+  ChannelFlags,
+  ChannelTypes,
+  DiscordChannel,
+  DiscordThreadMember,
+  OverwriteReadable,
+  VideoQualityModes,
+} from '@discordeno/types'
 import { calculatePermissions, type Bot } from '../index.js'
 import { Permissions } from './toggles/Permissions.js'
 import { ChannelToggles } from './toggles/channel.js'
@@ -191,7 +199,7 @@ export interface Channel extends BaseChannel {
   /** computed permissions for the invoking user in the channel, including overwrites, only included when part of the resolved data received on a slash command interaction. This does not include implicit permissions, which may need to be checked separately. */
   permissions?: Permissions
   /** The flags of the channel */
-  flags?: number
+  flags?: ChannelFlags
   /**
    * Explicit permission overwrites for members and roles
    * @deprecated Use channel.permissionOverwrites

--- a/packages/bot/src/transformers/interaction.ts
+++ b/packages/bot/src/transformers/interaction.ts
@@ -1,6 +1,7 @@
 import {
   InteractionResponseTypes,
   InteractionTypes,
+  MessageFlag,
   type ApplicationCommandOptionTypes,
   type ApplicationCommandTypes,
   type BigString,
@@ -12,14 +13,14 @@ import {
 } from '@discordeno/types'
 import { Collection } from '@discordeno/utils'
 import {
+  DiscordApplicationIntegrationType,
   type Bot,
   type Channel,
   type Component,
-  DiscordApplicationIntegrationType,
   type DiscordChannel,
   type DiscordInteractionContextType,
 } from '../index.js'
-import { MessageFlags, type DiscordInteractionDataResolved } from '../typings.js'
+import type { DiscordInteractionDataResolved } from '../typings.js'
 import type { Attachment } from './attachment.js'
 import type { Member } from './member.js'
 import type { Message } from './message.js'
@@ -153,7 +154,7 @@ const baseInteraction: Partial<Interaction> & BaseInteraction = {
     // If user provides an object, determine if it should be an autocomplete or a modal response
     if (response.title) type = InteractionResponseTypes.Modal
     if (this.type === InteractionTypes.ApplicationCommandAutocomplete) type = InteractionResponseTypes.ApplicationCommandAutocompleteResult
-    if (type === InteractionResponseTypes.ChannelMessageWithSource && options?.isPrivate) response.flags = MessageFlags.Ephemeral
+    if (type === InteractionResponseTypes.ChannelMessageWithSource && options?.isPrivate) response.flags = MessageFlag.Ephemeral
 
     // Since this has already been given a response, any further responses must be followups.
     if (this.acknowledged) return await this.bot!.helpers.sendFollowupMessage(this.token!, response)
@@ -202,7 +203,7 @@ const baseInteraction: Partial<Interaction> & BaseInteraction = {
     return await this.bot!.helpers.sendInteractionResponse(this.id!, this.token!, {
       type: InteractionResponseTypes.DeferredChannelMessageWithSource,
       data: {
-        flags: isPrivate ? MessageFlags.Ephemeral : undefined,
+        flags: isPrivate ? MessageFlag.Ephemeral : undefined,
       },
     })
   },

--- a/packages/bot/src/transformers/message.ts
+++ b/packages/bot/src/transformers/message.ts
@@ -1,5 +1,6 @@
 import {
   DiscordApplicationIntegrationType,
+  MessageFlag,
   type DiscordMessage,
   type DiscordMessageCall,
   type DiscordMessageInteractionMetadata,
@@ -10,7 +11,6 @@ import {
 } from '@discordeno/types'
 import { CHANNEL_MENTION_REGEX } from '../constants.js'
 import { snowflakeToTimestamp, type Bot, type Poll } from '../index.js'
-import { MessageFlags } from '../typings.js'
 import type { Attachment } from './attachment.js'
 import type { Channel } from './channel.js'
 import type { Component } from './component.js'
@@ -22,52 +22,52 @@ import type { User } from './user.js'
 
 const baseMessage: Partial<Message> & MessageBase = {
   get crossposted() {
-    return this.flags?.contains(MessageFlags.Crossposted) ?? false
+    return this.flags?.contains(MessageFlag.Crossposted) ?? false
   },
   set crossposted(value: boolean) {
     if (!this.flags) return
-    if (value) this.flags.add(MessageFlags.Crossposted)
-    else this.flags.remove(MessageFlags.Crossposted)
+    if (value) this.flags.add(MessageFlag.Crossposted)
+    else this.flags.remove(MessageFlag.Crossposted)
   },
   get ephemeral() {
-    return this.flags?.contains(MessageFlags.Ephemeral) ?? false
+    return this.flags?.contains(MessageFlag.Ephemeral) ?? false
   },
   set ephemeral(value: boolean) {
     if (!this.flags) return
-    if (value) this.flags.add(MessageFlags.Ephemeral)
-    else this.flags.remove(MessageFlags.Ephemeral)
+    if (value) this.flags.add(MessageFlag.Ephemeral)
+    else this.flags.remove(MessageFlag.Ephemeral)
   },
   get failedToMentionSomeRolesInThread() {
-    return this.flags?.contains(MessageFlags.FailedToMentionSomeRolesInThread) ?? false
+    return this.flags?.contains(MessageFlag.FailedToMentionSomeRolesInThread) ?? false
   },
   set failedToMentionSomeRolesInThread(value: boolean) {
     if (!this.flags) return
-    if (value) this.flags.add(MessageFlags.FailedToMentionSomeRolesInThread)
-    else this.flags.remove(MessageFlags.FailedToMentionSomeRolesInThread)
+    if (value) this.flags.add(MessageFlag.FailedToMentionSomeRolesInThread)
+    else this.flags.remove(MessageFlag.FailedToMentionSomeRolesInThread)
   },
   get hasThread() {
-    return this.flags?.contains(MessageFlags.HasThread) ?? false
+    return this.flags?.contains(MessageFlag.HasThread) ?? false
   },
   set hasThread(value: boolean) {
     if (!this.flags) return
-    if (value) this.flags.add(MessageFlags.HasThread)
-    else this.flags.remove(MessageFlags.HasThread)
+    if (value) this.flags.add(MessageFlag.HasThread)
+    else this.flags.remove(MessageFlag.HasThread)
   },
   get isCrosspost() {
-    return this.flags?.contains(MessageFlags.IsCrosspost) ?? false
+    return this.flags?.contains(MessageFlag.IsCrosspost) ?? false
   },
   set isCrosspost(value: boolean) {
     if (!this.flags) return
-    if (value) this.flags.add(MessageFlags.IsCrosspost)
-    else this.flags.remove(MessageFlags.IsCrosspost)
+    if (value) this.flags.add(MessageFlag.IsCrosspost)
+    else this.flags.remove(MessageFlag.IsCrosspost)
   },
   get loading() {
-    return this.flags?.contains(MessageFlags.Loading) ?? false
+    return this.flags?.contains(MessageFlag.Loading) ?? false
   },
   set loading(value: boolean) {
     if (!this.flags) return
-    if (value) this.flags.add(MessageFlags.Loading)
-    else this.flags.remove(MessageFlags.Loading)
+    if (value) this.flags.add(MessageFlag.Loading)
+    else this.flags.remove(MessageFlag.Loading)
   },
   get mentionedUserIds() {
     return this.mentions?.map((user) => user.id) ?? []
@@ -89,28 +89,28 @@ const baseMessage: Partial<Message> & MessageBase = {
     else this.bitfield.remove(3)
   },
   get sourceMessageDeleted() {
-    return this.flags?.contains(MessageFlags.SourceMessageDeleted) ?? false
+    return this.flags?.contains(MessageFlag.SourceMessageDeleted) ?? false
   },
   set sourceMessageDeleted(value: boolean) {
     if (!this.flags) return
-    if (value) this.flags.add(MessageFlags.SourceMessageDeleted)
-    else this.flags.remove(MessageFlags.SourceMessageDeleted)
+    if (value) this.flags.add(MessageFlag.SourceMessageDeleted)
+    else this.flags.remove(MessageFlag.SourceMessageDeleted)
   },
   get suppressEmbeds() {
-    return this.flags?.contains(MessageFlags.SuppressEmbeds) ?? false
+    return this.flags?.contains(MessageFlag.SuppressEmbeds) ?? false
   },
   set suppressEmbeds(value: boolean) {
     if (!this.flags) return
-    if (value) this.flags.add(MessageFlags.SuppressEmbeds)
-    else this.flags.remove(MessageFlags.SuppressEmbeds)
+    if (value) this.flags.add(MessageFlag.SuppressEmbeds)
+    else this.flags.remove(MessageFlag.SuppressEmbeds)
   },
   get suppressNotifications() {
-    return this.flags?.contains(MessageFlags.SuppressNotifications) ?? false
+    return this.flags?.contains(MessageFlag.SuppressNotifications) ?? false
   },
   set suppressNotifications(value: boolean) {
     if (!this.flags) return
-    if (value) this.flags.add(MessageFlags.SuppressNotifications)
-    else this.flags.remove(MessageFlags.SuppressNotifications)
+    if (value) this.flags.add(MessageFlag.SuppressNotifications)
+    else this.flags.remove(MessageFlag.SuppressNotifications)
   },
   get timestamp() {
     return this.id ? snowflakeToTimestamp(this.id) : 0
@@ -124,12 +124,12 @@ const baseMessage: Partial<Message> & MessageBase = {
     else this.bitfield.remove(1)
   },
   get urgent() {
-    return this.flags?.contains(MessageFlags.Urgent) ?? false
+    return this.flags?.contains(MessageFlag.Urgent) ?? false
   },
   set urgent(value: boolean) {
     if (!this.flags) return
-    if (value) this.flags.add(MessageFlags.Urgent)
-    else this.flags.remove(MessageFlags.Urgent)
+    if (value) this.flags.add(MessageFlag.Urgent)
+    else this.flags.remove(MessageFlag.Urgent)
   },
 }
 

--- a/packages/bot/src/transformers/sku.ts
+++ b/packages/bot/src/transformers/sku.ts
@@ -1,4 +1,4 @@
-import type { DiscordSku, DiscordSkuFlag, DiscordSkuType } from '@discordeno/types'
+import type { DiscordSku, DiscordSkuType, SkuFlag } from '@discordeno/types'
 import type { Bot } from '../index.js'
 
 export function transformSku(bot: Bot, payload: DiscordSku): Sku {
@@ -27,5 +27,5 @@ export interface Sku {
   /** System-generated URL slug based on the SKU's name */
   slug: string
   /** SKU flags combined as a bitfield */
-  flags: DiscordSkuFlag
+  flags: SkuFlag
 }

--- a/packages/bot/src/typings.ts
+++ b/packages/bot/src/typings.ts
@@ -19,6 +19,7 @@ import {
   type InteractionResponseTypes,
   type MessageComponentTypes,
   type MessageComponents,
+  type MessageFlag,
   type TextStyles,
 } from '@discordeno/types'
 import type * as handlers from './handlers/index.js'
@@ -37,7 +38,7 @@ export interface DiscordInteractionResponse {
 export interface DiscordInteractionCallbackData {
   tts?: boolean
   title?: string
-  flags?: number
+  flags?: MessageFlag
   content?: string
   choices?: DiscordApplicationCommandOptionChoice[]
   custom_id?: string
@@ -116,7 +117,7 @@ export interface BotInteractionCallbackData {
   /** The components you would like to have sent in this message */
   components?: MessageComponents
   /** Message flags combined as a bit field (only SUPPRESS_EMBEDS and EPHEMERAL can be set) */
-  flags?: number
+  flags?: MessageFlag
   /** Autocomplete choices (max of 25 choices) */
   choices?: ApplicationCommandOptionChoice[]
 }
@@ -209,29 +210,4 @@ export interface BotGatewayHandlerOptions {
   ENTITLEMENT_DELETE: typeof handlers.handleEntitlementDelete
   MESSAGE_POLL_VOTE_ADD: typeof handlers.handleMessagePollVoteAdd
   MESSAGE_POLL_VOTE_REMOVE: typeof handlers.handleMessagePollVoteRemove
-}
-
-export enum MessageFlags {
-  /** Whether this message has been published to subscribed channels (via Channel Following) */
-  Crossposted = 1 << 0,
-  /** Whether this message originated from a message in another channel (via Channel Following) */
-  IsCrosspost = 1 << 1,
-  /** Whether do not include any embeds when serializing this message */
-  SuppressEmbeds = 1 << 2,
-  /** Whether the source message for this crosspost has been deleted (via Channel Following) */
-  SourceMessageDeleted = 1 << 3,
-  /** Whether this message came from the urgent message system */
-  Urgent = 1 << 4,
-  /** Whether this message has an associated thread, with the same id as the message */
-  HasThread = 1 << 5,
-  /** Whether this message is only visible to the user who invoked the Interaction */
-  Ephemeral = 1 << 6,
-  /** Whether this message is an Interaction Response and the bot is "thinking" */
-  Loading = 1 << 7,
-  /** Whether this message failed to mention some roles and add their members to the thread */
-  FailedToMentionSomeRolesInThread = 1 << 8,
-  /** Whether this message will not trigger push and desktop notifications */
-  SuppressNotifications = 1 << 12,
-  /** Whether this message is a voice message */
-  IsVoiceMessage = 1 << 13,
 }

--- a/packages/types/src/discord.ts
+++ b/packages/types/src/discord.ts
@@ -1,4 +1,5 @@
 import type {
+  ActivityFlag,
   ActivityTypes,
   AllowedMentionsTypes,
   ApplicationCommandOptionTypes,
@@ -22,6 +23,7 @@ import type {
   Localization,
   MessageActivityTypes,
   MessageComponentTypes,
+  MessageFlag,
   MessageTypes,
   MfaLevels,
   OverwriteTypes,
@@ -32,6 +34,7 @@ import type {
   ScheduledEventEntityType,
   ScheduledEventPrivacyLevel,
   ScheduledEventStatus,
+  SkuFlag,
   SortOrderTypes,
   StickerFormatTypes,
   StickerTypes,
@@ -39,6 +42,7 @@ import type {
   TargetTypes,
   TeamMembershipStates,
   TextStyles,
+  UserFlags,
   VerificationLevels,
   VideoQualityModes,
   WebhookTypes,
@@ -53,11 +57,11 @@ export interface DiscordUser {
   /** The user's chosen language option */
   locale?: string
   /** The flags on a user's account */
-  flags?: number
+  flags?: UserFlags
   /** The type of Nitro subscription on a user's account */
   premium_type?: PremiumTypes
   /** The public flags on a user's account */
-  public_flags?: number
+  public_flags?: UserFlags
   /** the user's banner color encoded as an integer representation of hexadecimal color code */
   accent_color?: number
   /** The user's id */
@@ -1185,7 +1189,7 @@ export interface DiscordActivity {
   /** Whether or not the activity is an instanced game session */
   instance?: boolean
   /** Activity flags `OR`d together, describes what the payload includes */
-  flags?: number
+  flags?: ActivityFlag
   /** Unix timestamps for start and/or end of the game */
   timestamps?: DiscordActivityTimestamps
   /** Application id for the game */
@@ -1350,7 +1354,7 @@ export interface DiscordMessage {
   /** Data showing the source of a crossposted channel follow add, pin or reply message */
   message_reference?: Omit<DiscordMessageReference, 'failIfNotExists'>
   /** Message flags combined as a bitfield */
-  flags?: DiscordMessageFlag
+  flags?: MessageFlag
   /**
    * The stickers sent with the message (bots currently can only receive messages with stickers, not send)
    * @deprecated
@@ -3178,7 +3182,7 @@ export interface DiscordCreateForumPostWithMessage {
     /** Attachment objects with filename and description. See {@link https://discord.com/developers/docs/reference#uploading-files Uploading Files} */
     attachments?: DiscordAttachment[]
     /** Message flags combined as a bitfield, only SUPPRESS_EMBEDS can be set */
-    flags?: DiscordMessageFlag
+    flags?: MessageFlag
   }
   /** the IDs of the set of tags that have been applied to a thread in a GUILD_FORUM channel */
   applied_tags?: string[]
@@ -3363,7 +3367,7 @@ export interface DiscordSku {
   /** System-generated URL slug based on the SKU's name */
   slug: string
   /** SKU flags combined as a bitfield */
-  flags: DiscordSkuFlag
+  flags: SkuFlag
 }
 
 /** https://discord.com/developers/docs/monetization/skus#sku-object-sku-types */
@@ -3376,42 +3380,6 @@ export enum DiscordSkuType {
   Subscription = 5,
   /** System-generated group for each SUBSCRIPTION SKU created */
   SubscriptionGroup = 6,
-}
-
-/** https://discord.com/developers/docs/monetization/skus#sku-object-sku-flags */
-export enum DiscordSkuFlag {
-  /** SKU is available for purchase */
-  Available = 1 << 2,
-  /** Recurring SKU that can be purchased by a user and applied to a single server. Grants access to every user in that server. */
-  GuildSubscription = 1 << 7,
-  /** Recurring SKU purchased by a user for themselves. Grants access to the purchasing user in every server. */
-  UserSubscription = 1 << 8,
-}
-
-/** https://discord.com/developers/docs/resources/channel#message-object-message-flags */
-export enum DiscordMessageFlag {
-  /** This message has been published to subscribed channels (via Channel Following) */
-  Crossposted = 1 << 0,
-  /** This message originated from a message in another channel (via Channel Following) */
-  IsCrosspost = 1 << 1,
-  /** Do not include any embeds when serializing this message */
-  SuppressEmbeds = 1 << 2,
-  /** The source message for this crosspost has been deleted (via Channel Following) */
-  SourceMessageDeleted = 1 << 3,
-  /** This message came from the urgent message system */
-  Urgent = 1 << 4,
-  /** This message has an associated thread, with the same id as the message */
-  HasThread = 1 << 5,
-  /** This message is only visible to the user who invoked the Interaction */
-  Ephemeral = 1 << 6,
-  /** This message is an Interaction Response and the bot is "thinking" */
-  Loading = 1 << 7,
-  /** This message failed to mention some roles and add their members to the thread */
-  FailedToMentionSomeRolesInThread = 1 << 8,
-  /** This message will not trigger push and desktop notifications */
-  SuppressNotifications = 1 << 12,
-  /** This message is a voice message */
-  IsVoiceMessage = 1 << 13,
 }
 
 /** https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-context-types */

--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -13,7 +13,6 @@ import type {
   DiscordGuildOnboardingPrompt,
   DiscordInstallParams,
   DiscordInteractionContextType,
-  DiscordMessageFlag,
   DiscordPollAnswer,
   DiscordPollLayoutType,
   DiscordPollMedia,
@@ -35,6 +34,7 @@ import type {
   InteractionResponseTypes,
   Localization,
   MessageComponentTypes,
+  MessageFlag,
   OverwriteTypes,
   PermissionStrings,
   ScheduledEventEntityType,
@@ -81,7 +81,7 @@ export interface CreateMessageOptions {
   /** IDs of up to 3 stickers in the server to send in the message */
   stickerIds?: [BigString] | [BigString, BigString] | [BigString, BigString, BigString]
   /** Message flags combined as a bitfield, only SUPPRESS_EMBEDS and SUPPRESS_NOTIFICATIONS can be set */
-  flags?: DiscordMessageFlag
+  flags?: MessageFlag
   /** If true and nonce is present, it will be checked for uniqueness in the past few minutes. If another message was created by the same author with the same nonce, that message will be returned and no new message will be created. */
   enforceNonce?: boolean
   /** A poll object */
@@ -505,7 +505,7 @@ export interface InteractionCallbackData {
   /** The components you would like to have sent in this message */
   components?: MessageComponents
   /** Message flags combined as a bit field (only `SUPPRESS_EMBEDS`, `EPHEMERAL` and `SUPPRESS_NOTIFICATIONS` can be set) */
-  flags?: number
+  flags?: MessageFlag
   /** Autocomplete choices (max of 25 choices) */
   choices?: Camelize<DiscordApplicationCommandOptionChoice[]>
 }
@@ -796,7 +796,7 @@ export interface CreateForumPostWithMessage {
     /** IDs of up to 3 stickers in the server to send in the message */
     stickerIds?: BigString[]
     /** Message flags combined as a bitfield, only SUPPRESS_EMBEDS and SUPPRESS_NOTIFICATIONS can be set */
-    flags?: DiscordMessageFlag
+    flags?: MessageFlag
   }
   /** The IDs of the set of tags that have been applied to a thread in a GUILD_FORUM or a GUILD_MEDIA channel */
   appliedTags?: BigString[]
@@ -987,7 +987,7 @@ export interface EditMessage {
   /** Embedded `rich` content (up to 6000 characters) */
   embeds?: Array<Camelize<DiscordEmbed>> | null
   /** Edit the flags of the message (only `SUPPRESS_EMBEDS` can currently be set/unset) */
-  flags?: DiscordMessageFlag | null
+  flags?: MessageFlag | null
   /** The contents of the files being sent/edited */
   files?: FileContent[]
   /** Allowed mentions for the message */

--- a/packages/types/src/shared.ts
+++ b/packages/types/src/shared.ts
@@ -58,6 +58,55 @@ export enum AttachmentFlags {
   IsRemix = 1 << 2,
 }
 
+/** https://discord.com/developers/docs/resources/channel#message-object-message-flags */
+export enum MessageFlag {
+  /** This message has been published to subscribed channels (via Channel Following) */
+  Crossposted = 1 << 0,
+  /** This message originated from a message in another channel (via Channel Following) */
+  IsCrosspost = 1 << 1,
+  /** Do not include any embeds when serializing this message */
+  SuppressEmbeds = 1 << 2,
+  /** The source message for this crosspost has been deleted (via Channel Following) */
+  SourceMessageDeleted = 1 << 3,
+  /** This message came from the urgent message system */
+  Urgent = 1 << 4,
+  /** This message has an associated thread, with the same id as the message */
+  HasThread = 1 << 5,
+  /** This message is only visible to the user who invoked the Interaction */
+  Ephemeral = 1 << 6,
+  /** This message is an Interaction Response and the bot is "thinking" */
+  Loading = 1 << 7,
+  /** This message failed to mention some roles and add their members to the thread */
+  FailedToMentionSomeRolesInThread = 1 << 8,
+  /** This message will not trigger push and desktop notifications */
+  SuppressNotifications = 1 << 12,
+  /** This message is a voice message */
+  IsVoiceMessage = 1 << 13,
+}
+
+/** https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-flags */
+export enum ActivityFlag {
+  Instance = 1 << 0,
+  Join = 1 << 1,
+  Spectate = 1 << 2,
+  JoinRequest = 1 << 3,
+  Sync = 1 << 4,
+  Play = 1 << 5,
+  PartyPrivacyFriends = 1 << 6,
+  PartyPrivacyVoiceChannel = 1 << 7,
+  Embedded = 1 << 8,
+}
+
+/** https://discord.com/developers/docs/monetization/skus#sku-object-sku-flags */
+export enum SkuFlag {
+  /** SKU is available for purchase */
+  Available = 1 << 2,
+  /** Recurring SKU that can be purchased by a user and applied to a single server. Grants access to every user in that server. */
+  GuildSubscription = 1 << 7,
+  /** Recurring SKU purchased by a user for themselves. Grants access to the purchasing user in every server. */
+  UserSubscription = 1 << 8,
+}
+
 /** https://discord.com/developers/docs/resources/guild#integration-object-integration-expire-behaviors */
 export enum IntegrationExpireBehaviors {
   RemoveRole,


### PR DESCRIPTION
This PR replaces some `number` type usage and replaces them with the proper enum. This means adding the `ActivityFlag` enum.

> [!IMPORTANT]
> This does NOT include the `MemberFlag` enum, that is included in #3617.

### Questions:
1. Since Enums should be singular, as it doesn't make sense that the enum is plural if it is a number effectively, it would be the same as saying `numbers` instead of `number`[^enumTSHandbook]. Should we rename the other flag enums to make them singular?
This is the case in other enums as well, like the `<Name>Types` enum(s) (or even entire types I think), those as well should be renamed based on what we decide but they are out of the scope of this PR since they are not flags, it will need a separate PR.
1. In the PR I have renamed some existing flag enums to remove the `Discord` prefix since some do not have it (eg. `ChannelFlags` and `UserFlags`). Should we keep it instead? It is somewhat inconsistent that (almost) everything out of `@discordeno/types` has the `Discord` prefix however flag enums are an exception to this.

---

Part of #3612.

> [!NOTE]
> This pull request currently contains some breaking changes, beside the type change which is a breaking change in itself:
> - Rename `DiscordSkuFlag` to `SkuFlag` for constistency[^enumsNames].
> - Rename `DiscordMessageFlag` to `MessageFlag` for constistency[^enumsNames].
> - Remove `MessageFlags` from `@discordeno/bot`, leave only the one in `@discordeno/types`

[^enumsNames]: See the questions above for more informations.
[^enumTSHandbook]: The typescript handbook itself on the enum docs uses signular names (eg. `Direction`). [TS Handbook link](https://www.typescriptlang.org/docs/handbook/enums.html)