### PR TITLE
feat(types): `PurchaseNotification` message type

### DIFF
--- a/packages/types/src/shared.ts
+++ b/packages/types/src/shared.ts
@@ -371,6 +371,7 @@ export enum MessageTypes {
   StageSpeaker,
   StageTopic = 31,
   GuildApplicationPremiumSubscription,
+  PurchaseNotification = 44,
 }
 
 /** https://discord.com/developers/docs/resources/channel#message-object-message-activity-types */


### PR DESCRIPTION
Add `PurchaseNotification` (44) on `MessageTypes`

- Upstream: https://github.com/discord/discord-api-docs/pull/6927
- fixes #3654 