### PR TITLE
feat(types): Add `USE_EXTERNAL_APPS` permission

### DIFF
--- a/packages/types/src/shared.ts
+++ b/packages/types/src/shared.ts
@@ -688,6 +688,8 @@ export enum BitwisePermissionFlags {
   SEND_VOICE_MESSAGES = 0x0000400000000000,
   /** Allows sending polls */
   SEND_POLLS = 0x0002000000000000,
+  /** Allows user-installed apps to send public responses. When disabled, users will still be allowed to use their apps but the responses will be ephemeral. This only applies to apps not also installed to the server. */
+  USE_EXTERNAL_APPS = 0x0004000000000000,
 }
 
 export type PermissionStrings = keyof typeof BitwisePermissionFlags


### PR DESCRIPTION
Add `USE_EXTERNAL_APPS` permission to `BitwisePermissionFlags`

- Upstream: https://github.com/discord/discord-api-docs/pull/6913
- fixes #3657 