### PR TITLE
feat(bot,types): Add attachment titles

### DIFF
--- a/packages/bot/src/transformers.ts
+++ b/packages/bot/src/transformers.ts
@@ -190,6 +190,7 @@ export interface Transformers {
     attachment: {
       id: boolean
       filename: boolean
+      title: boolean
       contentType: boolean
       size: boolean
       url: boolean
@@ -808,6 +809,7 @@ export function createTransformers(options: Partial<Transformers>, opts?: Create
       attachment: {
         id: opts?.defaultDesiredPropertiesValue ?? false,
         filename: opts?.defaultDesiredPropertiesValue ?? false,
+        title: opts?.defaultDesiredPropertiesValue ?? false,
         contentType: opts?.defaultDesiredPropertiesValue ?? false,
         size: opts?.defaultDesiredPropertiesValue ?? false,
         url: opts?.defaultDesiredPropertiesValue ?? false,

--- a/packages/bot/src/transformers/attachment.ts
+++ b/packages/bot/src/transformers/attachment.ts
@@ -7,6 +7,7 @@ export function transformAttachment(bot: Bot, payload: DiscordAttachment): Attac
 
   if (props.id && payload.id) attachment.id = bot.transformers.snowflake(payload.id)
   if (props.filename && payload.filename) attachment.filename = payload.filename
+  if (props.title && payload.title) attachment.title = payload.title
   if (props.contentType && payload.content_type) attachment.contentType = payload.content_type
   if (props.size) attachment.size = payload.size
   if (props.url && payload.url) attachment.url = payload.url
@@ -25,6 +26,8 @@ export function transformAttachment(bot: Bot, payload: DiscordAttachment): Attac
 export interface Attachment {
   /** Name of file attached */
   filename: string
+  /** The title of the file */
+  title?: string
   /** The attachment's [media type](https://en.wikipedia.org/wiki/Media_type) */
   contentType?: string
   /** Size of file in bytes */

--- a/packages/types/src/discord.ts
+++ b/packages/types/src/discord.ts
@@ -712,6 +712,8 @@ export interface DiscordEmbedVideo {
 export interface DiscordAttachment {
   /** Name of file attached */
   filename: string
+  /** The title of the file */
+  title?: string
   /** The attachment's [media type](https://en.wikipedia.org/wiki/Media_type) */
   content_type?: string
   /** Size of file in bytes */


### PR DESCRIPTION
Add attachment titles

- Upstream: https://github.com/discord/discord-api-docs/pull/6945
- fixes #3688