### PR TITLE
fix(bot)!: Use `bot.transformers.emoji` in `handleGuildEmojisUpdate`

### DIFF
--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -2,7 +2,7 @@ import type { CreateGatewayManagerOptions, GatewayManager } from '@discordeno/ga
 import { ShardSocketCloseCodes, createGatewayManager } from '@discordeno/gateway'
 import type { CreateRestManagerOptions, RestManager } from '@discordeno/rest'
 import { createRestManager } from '@discordeno/rest'
-import type { BigString, DiscordEmoji, DiscordGatewayPayload, DiscordReady, GatewayIntents } from '@discordeno/types'
+import type { BigString, DiscordGatewayPayload, DiscordReady, GatewayIntents } from '@discordeno/types'
 import { createLogger, getBotIdFromToken, type Collection, type logger } from '@discordeno/utils'
 import { createBotGatewayHandlers } from './handlers.js'
 import { createBotHelpers, type BotHelpers } from './helpers.js'
@@ -230,7 +230,7 @@ export interface EventHandlers {
   stageInstanceCreate: (data: { id: bigint; guildId: bigint; channelId: bigint; topic: string }) => unknown
   stageInstanceDelete: (data: { id: bigint; guildId: bigint; channelId: bigint; topic: string }) => unknown
   stageInstanceUpdate: (data: { id: bigint; guildId: bigint; channelId: bigint; topic: string }) => unknown
-  guildEmojisUpdate: (payload: { guildId: bigint; emojis: Collection<bigint, DiscordEmoji> }) => unknown
+  guildEmojisUpdate: (payload: { guildId: bigint; emojis: Collection<bigint, Emoji> }) => unknown
   guildBanAdd: (user: User, guildId: bigint) => unknown
   guildBanRemove: (user: User, guildId: bigint) => unknown
   guildCreate: (guild: Guild) => unknown

--- a/packages/bot/src/handlers/emojis/GUILD_EMOJIS_UPDATE.ts
+++ b/packages/bot/src/handlers/emojis/GUILD_EMOJIS_UPDATE.ts
@@ -9,6 +9,6 @@ export async function handleGuildEmojisUpdate(bot: Bot, data: DiscordGatewayPayl
 
   bot.events.guildEmojisUpdate({
     guildId: bot.transformers.snowflake(payload.guild_id),
-    emojis: new Collection(payload.emojis.map((emoji) => [bot.transformers.snowflake(emoji.id!), emoji])),
+    emojis: new Collection(payload.emojis.map((emoji) => [bot.transformers.snowflake(emoji.id!), bot.transformers.emoji(bot, emoji)])),
   })
 }


### PR DESCRIPTION
Currently we use `Collection<bigint, DiscordEmoji>` for the `guildEmojisUpdate` event, however there is not reason (afaik) to use `DiscordEmoji` instead of the transformed object `Emoji`

Fixes: #3703 

> [!WARNING]
> This is breaking because the `DiscordEmoji` and the `Emoji` type are incompatible, this may result in Typescript type errors