### PR TITLE
fix(bot)!: Add `guildId` to `guildStickersUpdate` event

### DIFF
--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -201,7 +201,7 @@ export interface EventHandlers {
   guildMemberAdd: (member: Member, user: User) => unknown
   guildMemberRemove: (user: User, guildId: bigint) => unknown
   guildMemberUpdate: (member: Member, user: User) => unknown
-  guildStickersUpdate: (stickers: Sticker[]) => unknown
+  guildStickersUpdate: (payload: { guildId: bigint; stickers: Sticker[] }) => unknown
   messageCreate: (message: Message) => unknown
   messageDelete: (payload: { id: bigint; channelId: bigint; guildId?: bigint }, message?: Message) => unknown
   messageDeleteBulk: (payload: { ids: bigint[]; channelId: bigint; guildId?: bigint }) => unknown

--- a/packages/bot/src/handlers/guilds/GUILD_STICKERS_UPDATE.ts
+++ b/packages/bot/src/handlers/guilds/GUILD_STICKERS_UPDATE.ts
@@ -5,10 +5,11 @@ export async function handleGuildStickersUpdate(bot: Bot, data: DiscordGatewayPa
 
   const payload = data.d as DiscordGuildStickersUpdate
 
-  bot.events.guildStickersUpdate(
-    payload.stickers.map((sticker) => {
+  bot.events.guildStickersUpdate({
+    guildId: bot.transformers.snowflake(payload.guild_id),
+    stickers: payload.stickers.map((sticker) => {
       sticker.guild_id = payload.guild_id
       return bot.transformers.sticker(bot, sticker)
     }),
-  )
+  })
 }


### PR DESCRIPTION
Currently there is no way to access the `guildId` on the `guildStickersUpdate` event if the events sends an empty array of stickers

Fixes: #3702 

> [!WARNING]
> This is a breaking change since it changes the argument to `guildStickersUpdate` to be a payload object with the `guildId` and the stickers as proprieties on it