### PR TITLE
fix(utils): Use '%20' instead of ' ' for joining scopes

### DIFF
--- a/packages/utils/src/oauth2.ts
+++ b/packages/utils/src/oauth2.ts
@@ -2,7 +2,7 @@ import type { BigString, DiscordApplicationIntegrationType, OAuth2Scope, Permiss
 import { calculateBits } from './permissions.js'
 
 export function createOAuth2Link(options: CreateOAuth2LinkOptions): string {
-  const joinedScopeString = options.scope.join(' ')
+  const joinedScopeString = options.scope.join('%20')
 
   let url = `https://discord.com/oauth2/authorize?client_id=${options.clientId}&scope=${joinedScopeString}`
 


### PR DESCRIPTION
Currently the `createOAuth2Link` function uses a space character to join the scopes provided, this does work, however it creates an issue where if you don't pass the resulting URL in something like the `URL` constructor the space can give issues when using. For example, it makes discord error when used as the url for a link button