### PR TITLE
feat(types)!: Add flags enums

### DIFF
--- a/packages/bot/src/transformers/interaction.ts
+++ b/packages/bot/src/transformers/interaction.ts
@@ -1,6 +1,7 @@
 import {
   InteractionResponseTypes,
   InteractionTypes,
+  MessageFlags,
   type ApplicationCommandOptionTypes,
   type ApplicationCommandTypes,
   type BigString,
@@ -19,7 +20,7 @@ import {
   type DiscordChannel,
   type DiscordInteractionContextType,
 } from '../index.js'
-import { MessageFlags, type DiscordInteractionDataResolved } from '../typings.js'
+import type { DiscordInteractionDataResolved } from '../typings.js'
 import type { Attachment } from './attachment.js'
 import type { Member } from './member.js'
 import type { Message } from './message.js'

--- a/packages/bot/src/transformers/message.ts
+++ b/packages/bot/src/transformers/message.ts
@@ -1,5 +1,6 @@
 import {
   DiscordApplicationIntegrationType,
+  MessageFlags,
   type DiscordMessage,
   type DiscordMessageCall,
   type DiscordMessageInteractionMetadata,
@@ -10,7 +11,6 @@ import {
 } from '@discordeno/types'
 import { CHANNEL_MENTION_REGEX } from '../constants.js'
 import { snowflakeToTimestamp, type Bot, type Poll } from '../index.js'
-import { MessageFlags } from '../typings.js'
 import type { Attachment } from './attachment.js'
 import type { Channel } from './channel.js'
 import type { Component } from './component.js'

--- a/packages/bot/src/transformers/sku.ts
+++ b/packages/bot/src/transformers/sku.ts
@@ -1,4 +1,4 @@
-import type { DiscordSku, DiscordSkuFlag, DiscordSkuType } from '@discordeno/types'
+import type { DiscordSku, DiscordSkuType, SkuFlags } from '@discordeno/types'
 import type { Bot } from '../index.js'
 
 export function transformSku(bot: Bot, payload: DiscordSku): Sku {
@@ -27,5 +27,5 @@ export interface Sku {
   /** System-generated URL slug based on the SKU's name */
   slug: string
   /** SKU flags combined as a bitfield */
-  flags: DiscordSkuFlag
+  flags: SkuFlags
 }

--- a/packages/bot/src/transformers/sku.ts
+++ b/packages/bot/src/transformers/sku.ts
@@ -1,4 +1,4 @@
-import type { DiscordSku, DiscordSkuType } from '@discordeno/types'
+import type { DiscordSku, DiscordSkuFlag, DiscordSkuType } from '@discordeno/types'
 import type { Bot } from '../index.js'
 
 export function transformSku(bot: Bot, payload: DiscordSku): Sku {
@@ -27,5 +27,5 @@ export interface Sku {
   /** System-generated URL slug based on the SKU's name */
   slug: string
   /** SKU flags combined as a bitfield */
-  flags: number
+  flags: DiscordSkuFlag
 }

--- a/packages/bot/src/transformers/sku.ts
+++ b/packages/bot/src/transformers/sku.ts
@@ -1,4 +1,4 @@
-import type { DiscordSku, DiscordSkuFlag, DiscordSkuType } from '@discordeno/types'
+import type { DiscordSku, DiscordSkuType } from '@discordeno/types'
 import type { Bot } from '../index.js'
 
 export function transformSku(bot: Bot, payload: DiscordSku): Sku {
@@ -27,5 +27,5 @@ export interface Sku {
   /** System-generated URL slug based on the SKU's name */
   slug: string
   /** SKU flags combined as a bitfield */
-  flags: DiscordSkuFlag
+  flags: number
 }

--- a/packages/bot/src/typings.ts
+++ b/packages/bot/src/typings.ts
@@ -210,28 +210,3 @@ export interface BotGatewayHandlerOptions {
   MESSAGE_POLL_VOTE_ADD: typeof handlers.handleMessagePollVoteAdd
   MESSAGE_POLL_VOTE_REMOVE: typeof handlers.handleMessagePollVoteRemove
 }
-
-export enum MessageFlags {
-  /** Whether this message has been published to subscribed channels (via Channel Following) */
-  Crossposted = 1 << 0,
-  /** Whether this message originated from a message in another channel (via Channel Following) */
-  IsCrosspost = 1 << 1,
-  /** Whether do not include any embeds when serializing this message */
-  SuppressEmbeds = 1 << 2,
-  /** Whether the source message for this crosspost has been deleted (via Channel Following) */
-  SourceMessageDeleted = 1 << 3,
-  /** Whether this message came from the urgent message system */
-  Urgent = 1 << 4,
-  /** Whether this message has an associated thread, with the same id as the message */
-  HasThread = 1 << 5,
-  /** Whether this message is only visible to the user who invoked the Interaction */
-  Ephemeral = 1 << 6,
-  /** Whether this message is an Interaction Response and the bot is "thinking" */
-  Loading = 1 << 7,
-  /** Whether this message failed to mention some roles and add their members to the thread */
-  FailedToMentionSomeRolesInThread = 1 << 8,
-  /** Whether this message will not trigger push and desktop notifications */
-  SuppressNotifications = 1 << 12,
-  /** Whether this message is a voice message */
-  IsVoiceMessage = 1 << 13,
-}

--- a/packages/types/src/discord.ts
+++ b/packages/types/src/discord.ts
@@ -22,6 +22,7 @@ import {
   type Localization,
   type MessageActivityTypes,
   type MessageComponentTypes,
+  type MessageFlags,
   type MessageTypes,
   type MfaLevels,
   type OverwriteTypes,
@@ -32,6 +33,7 @@ import {
   type ScheduledEventEntityType,
   type ScheduledEventPrivacyLevel,
   type ScheduledEventStatus,
+  type SkuFlags,
   type SortOrderTypes,
   type StickerFormatTypes,
   type StickerTypes,
@@ -1352,7 +1354,7 @@ export interface DiscordMessage {
   /** Data showing the source of a crossposted channel follow add, pin or reply message */
   message_reference?: Omit<DiscordMessageReference, 'failIfNotExists'>
   /** Message flags combined as a bitfield */
-  flags?: DiscordMessageFlag
+  flags?: MessageFlags
   /**
    * The stickers sent with the message (bots currently can only receive messages with stickers, not send)
    * @deprecated
@@ -3218,7 +3220,7 @@ export interface DiscordCreateForumPostWithMessage {
     /** Attachment objects with filename and description. See {@link https://discord.com/developers/docs/reference#uploading-files Uploading Files} */
     attachments?: DiscordAttachment[]
     /** Message flags combined as a bitfield, only SUPPRESS_EMBEDS can be set */
-    flags?: DiscordMessageFlag
+    flags?: MessageFlags
   }
   /** the IDs of the set of tags that have been applied to a thread in a GUILD_FORUM channel */
   applied_tags?: string[]
@@ -3403,7 +3405,7 @@ export interface DiscordSku {
   /** System-generated URL slug based on the SKU's name */
   slug: string
   /** SKU flags combined as a bitfield */
-  flags: DiscordSkuFlag
+  flags: SkuFlags
 }
 
 /** https://discord.com/developers/docs/monetization/skus#sku-object-sku-types */
@@ -3416,42 +3418,6 @@ export enum DiscordSkuType {
   Subscription = 5,
   /** System-generated group for each SUBSCRIPTION SKU created */
   SubscriptionGroup = 6,
-}
-
-/** https://discord.com/developers/docs/monetization/skus#sku-object-sku-flags */
-export enum DiscordSkuFlag {
-  /** SKU is available for purchase */
-  Available = 1 << 2,
-  /** Recurring SKU that can be purchased by a user and applied to a single server. Grants access to every user in that server. */
-  GuildSubscription = 1 << 7,
-  /** Recurring SKU purchased by a user for themselves. Grants access to the purchasing user in every server. */
-  UserSubscription = 1 << 8,
-}
-
-/** https://discord.com/developers/docs/resources/channel#message-object-message-flags */
-export enum DiscordMessageFlag {
-  /** This message has been published to subscribed channels (via Channel Following) */
-  Crossposted = 1 << 0,
-  /** This message originated from a message in another channel (via Channel Following) */
-  IsCrosspost = 1 << 1,
-  /** Do not include any embeds when serializing this message */
-  SuppressEmbeds = 1 << 2,
-  /** The source message for this crosspost has been deleted (via Channel Following) */
-  SourceMessageDeleted = 1 << 3,
-  /** This message came from the urgent message system */
-  Urgent = 1 << 4,
-  /** This message has an associated thread, with the same id as the message */
-  HasThread = 1 << 5,
-  /** This message is only visible to the user who invoked the Interaction */
-  Ephemeral = 1 << 6,
-  /** This message is an Interaction Response and the bot is "thinking" */
-  Loading = 1 << 7,
-  /** This message failed to mention some roles and add their members to the thread */
-  FailedToMentionSomeRolesInThread = 1 << 8,
-  /** This message will not trigger push and desktop notifications */
-  SuppressNotifications = 1 << 12,
-  /** This message is a voice message */
-  IsVoiceMessage = 1 << 13,
 }
 
 /** https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-context-types */

--- a/packages/types/src/discord.ts
+++ b/packages/types/src/discord.ts
@@ -22,7 +22,6 @@ import {
   type Localization,
   type MessageActivityTypes,
   type MessageComponentTypes,
-  type MessageFlags,
   type MessageTypes,
   type MfaLevels,
   type OverwriteTypes,
@@ -33,7 +32,6 @@ import {
   type ScheduledEventEntityType,
   type ScheduledEventPrivacyLevel,
   type ScheduledEventStatus,
-  type SkuFlags,
   type SortOrderTypes,
   type StickerFormatTypes,
   type StickerTypes,
@@ -1354,7 +1352,7 @@ export interface DiscordMessage {
   /** Data showing the source of a crossposted channel follow add, pin or reply message */
   message_reference?: Omit<DiscordMessageReference, 'failIfNotExists'>
   /** Message flags combined as a bitfield */
-  flags?: MessageFlags
+  flags?: number
   /**
    * The stickers sent with the message (bots currently can only receive messages with stickers, not send)
    * @deprecated
@@ -3220,7 +3218,7 @@ export interface DiscordCreateForumPostWithMessage {
     /** Attachment objects with filename and description. See {@link https://discord.com/developers/docs/reference#uploading-files Uploading Files} */
     attachments?: DiscordAttachment[]
     /** Message flags combined as a bitfield, only SUPPRESS_EMBEDS can be set */
-    flags?: MessageFlags
+    flags?: number
   }
   /** the IDs of the set of tags that have been applied to a thread in a GUILD_FORUM channel */
   applied_tags?: string[]
@@ -3405,7 +3403,7 @@ export interface DiscordSku {
   /** System-generated URL slug based on the SKU's name */
   slug: string
   /** SKU flags combined as a bitfield */
-  flags: SkuFlags
+  flags: number
 }
 
 /** https://discord.com/developers/docs/monetization/skus#sku-object-sku-types */

--- a/packages/types/src/discord.ts
+++ b/packages/types/src/discord.ts
@@ -22,6 +22,7 @@ import {
   type Localization,
   type MessageActivityTypes,
   type MessageComponentTypes,
+  type MessageFlags,
   type MessageTypes,
   type MfaLevels,
   type OverwriteTypes,
@@ -32,6 +33,7 @@ import {
   type ScheduledEventEntityType,
   type ScheduledEventPrivacyLevel,
   type ScheduledEventStatus,
+  type SkuFlags,
   type SortOrderTypes,
   type StickerFormatTypes,
   type StickerTypes,
@@ -1352,7 +1354,7 @@ export interface DiscordMessage {
   /** Data showing the source of a crossposted channel follow add, pin or reply message */
   message_reference?: Omit<DiscordMessageReference, 'failIfNotExists'>
   /** Message flags combined as a bitfield */
-  flags?: number
+  flags?: MessageFlags
   /**
    * The stickers sent with the message (bots currently can only receive messages with stickers, not send)
    * @deprecated
@@ -3218,7 +3220,7 @@ export interface DiscordCreateForumPostWithMessage {
     /** Attachment objects with filename and description. See {@link https://discord.com/developers/docs/reference#uploading-files Uploading Files} */
     attachments?: DiscordAttachment[]
     /** Message flags combined as a bitfield, only SUPPRESS_EMBEDS can be set */
-    flags?: number
+    flags?: MessageFlags
   }
   /** the IDs of the set of tags that have been applied to a thread in a GUILD_FORUM channel */
   applied_tags?: string[]
@@ -3403,7 +3405,7 @@ export interface DiscordSku {
   /** System-generated URL slug based on the SKU's name */
   slug: string
   /** SKU flags combined as a bitfield */
-  flags: number
+  flags: SkuFlags
 }
 
 /** https://discord.com/developers/docs/monetization/skus#sku-object-sku-types */

--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -34,6 +34,7 @@ import type {
   InteractionResponseTypes,
   Localization,
   MessageComponentTypes,
+  MessageFlags,
   OverwriteTypes,
   PermissionStrings,
   ScheduledEventEntityType,
@@ -80,7 +81,7 @@ export interface CreateMessageOptions {
   /** IDs of up to 3 stickers in the server to send in the message */
   stickerIds?: [BigString] | [BigString, BigString] | [BigString, BigString, BigString]
   /** Message flags combined as a bitfield, only SUPPRESS_EMBEDS and SUPPRESS_NOTIFICATIONS can be set */
-  flags?: number
+  flags?: MessageFlags
   /** If true and nonce is present, it will be checked for uniqueness in the past few minutes. If another message was created by the same author with the same nonce, that message will be returned and no new message will be created. */
   enforceNonce?: boolean
   /** A poll object */
@@ -795,7 +796,7 @@ export interface CreateForumPostWithMessage {
     /** IDs of up to 3 stickers in the server to send in the message */
     stickerIds?: BigString[]
     /** Message flags combined as a bitfield, only SUPPRESS_EMBEDS and SUPPRESS_NOTIFICATIONS can be set */
-    flags?: number
+    flags?: MessageFlags
   }
   /** The IDs of the set of tags that have been applied to a thread in a GUILD_FORUM or a GUILD_MEDIA channel */
   appliedTags?: BigString[]
@@ -986,7 +987,7 @@ export interface EditMessage {
   /** Embedded `rich` content (up to 6000 characters) */
   embeds?: Array<Camelize<DiscordEmbed>> | null
   /** Edit the flags of the message (only `SUPPRESS_EMBEDS` can currently be set/unset) */
-  flags?: number | null
+  flags?: MessageFlags | null
   /** The contents of the files being sent/edited */
   files?: FileContent[]
   /** Allowed mentions for the message */

--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -34,7 +34,6 @@ import type {
   InteractionResponseTypes,
   Localization,
   MessageComponentTypes,
-  MessageFlags,
   OverwriteTypes,
   PermissionStrings,
   ScheduledEventEntityType,
@@ -81,7 +80,7 @@ export interface CreateMessageOptions {
   /** IDs of up to 3 stickers in the server to send in the message */
   stickerIds?: [BigString] | [BigString, BigString] | [BigString, BigString, BigString]
   /** Message flags combined as a bitfield, only SUPPRESS_EMBEDS and SUPPRESS_NOTIFICATIONS can be set */
-  flags?: MessageFlags
+  flags?: number
   /** If true and nonce is present, it will be checked for uniqueness in the past few minutes. If another message was created by the same author with the same nonce, that message will be returned and no new message will be created. */
   enforceNonce?: boolean
   /** A poll object */
@@ -796,7 +795,7 @@ export interface CreateForumPostWithMessage {
     /** IDs of up to 3 stickers in the server to send in the message */
     stickerIds?: BigString[]
     /** Message flags combined as a bitfield, only SUPPRESS_EMBEDS and SUPPRESS_NOTIFICATIONS can be set */
-    flags?: MessageFlags
+    flags?: number
   }
   /** The IDs of the set of tags that have been applied to a thread in a GUILD_FORUM or a GUILD_MEDIA channel */
   appliedTags?: BigString[]
@@ -987,7 +986,7 @@ export interface EditMessage {
   /** Embedded `rich` content (up to 6000 characters) */
   embeds?: Array<Camelize<DiscordEmbed>> | null
   /** Edit the flags of the message (only `SUPPRESS_EMBEDS` can currently be set/unset) */
-  flags?: MessageFlags | null
+  flags?: number | null
   /** The contents of the files being sent/edited */
   files?: FileContent[]
   /** Allowed mentions for the message */

--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -13,7 +13,6 @@ import type {
   DiscordGuildOnboardingPrompt,
   DiscordInstallParams,
   DiscordInteractionContextType,
-  DiscordMessageFlag,
   DiscordPollAnswer,
   DiscordPollLayoutType,
   DiscordPollMedia,
@@ -35,6 +34,7 @@ import type {
   InteractionResponseTypes,
   Localization,
   MessageComponentTypes,
+  MessageFlags,
   OverwriteTypes,
   PermissionStrings,
   ScheduledEventEntityType,
@@ -81,7 +81,7 @@ export interface CreateMessageOptions {
   /** IDs of up to 3 stickers in the server to send in the message */
   stickerIds?: [BigString] | [BigString, BigString] | [BigString, BigString, BigString]
   /** Message flags combined as a bitfield, only SUPPRESS_EMBEDS and SUPPRESS_NOTIFICATIONS can be set */
-  flags?: DiscordMessageFlag
+  flags?: MessageFlags
   /** If true and nonce is present, it will be checked for uniqueness in the past few minutes. If another message was created by the same author with the same nonce, that message will be returned and no new message will be created. */
   enforceNonce?: boolean
   /** A poll object */
@@ -796,7 +796,7 @@ export interface CreateForumPostWithMessage {
     /** IDs of up to 3 stickers in the server to send in the message */
     stickerIds?: BigString[]
     /** Message flags combined as a bitfield, only SUPPRESS_EMBEDS and SUPPRESS_NOTIFICATIONS can be set */
-    flags?: DiscordMessageFlag
+    flags?: MessageFlags
   }
   /** The IDs of the set of tags that have been applied to a thread in a GUILD_FORUM or a GUILD_MEDIA channel */
   appliedTags?: BigString[]
@@ -987,7 +987,7 @@ export interface EditMessage {
   /** Embedded `rich` content (up to 6000 characters) */
   embeds?: Array<Camelize<DiscordEmbed>> | null
   /** Edit the flags of the message (only `SUPPRESS_EMBEDS` can currently be set/unset) */
-  flags?: DiscordMessageFlag | null
+  flags?: MessageFlags | null
   /** The contents of the files being sent/edited */
   files?: FileContent[]
   /** Allowed mentions for the message */

--- a/packages/types/src/shared.ts
+++ b/packages/types/src/shared.ts
@@ -58,6 +58,55 @@ export enum AttachmentFlags {
   IsRemix = 1 << 2,
 }
 
+/** https://discord.com/developers/docs/monetization/skus#sku-object-sku-flags */
+export enum SkuFlags {
+  /** SKU is available for purchase */
+  Available = 1 << 2,
+  /** Recurring SKU that can be purchased by a user and applied to a single server. Grants access to every user in that server. */
+  GuildSubscription = 1 << 7,
+  /** Recurring SKU purchased by a user for themselves. Grants access to the purchasing user in every server. */
+  UserSubscription = 1 << 8,
+}
+
+/** https://discord.com/developers/docs/resources/channel#message-object-message-flags */
+export enum MessageFlags {
+  /** This message has been published to subscribed channels (via Channel Following) */
+  Crossposted = 1 << 0,
+  /** This message originated from a message in another channel (via Channel Following) */
+  IsCrosspost = 1 << 1,
+  /** Do not include any embeds when serializing this message */
+  SuppressEmbeds = 1 << 2,
+  /** The source message for this crosspost has been deleted (via Channel Following) */
+  SourceMessageDeleted = 1 << 3,
+  /** This message came from the urgent message system */
+  Urgent = 1 << 4,
+  /** This message has an associated thread, with the same id as the message */
+  HasThread = 1 << 5,
+  /** This message is only visible to the user who invoked the Interaction */
+  Ephemeral = 1 << 6,
+  /** This message is an Interaction Response and the bot is "thinking" */
+  Loading = 1 << 7,
+  /** This message failed to mention some roles and add their members to the thread */
+  FailedToMentionSomeRolesInThread = 1 << 8,
+  /** This message will not trigger push and desktop notifications */
+  SuppressNotifications = 1 << 12,
+  /** This message is a voice message */
+  IsVoiceMessage = 1 << 13,
+}
+
+/** https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-flags */
+export enum ActivityFlags {
+  Instance = 1 << 0,
+  Join = 1 << 1,
+  Spectate = 1 << 2,
+  JoinRequest = 1 << 3,
+  Sync = 1 << 4,
+  Play = 1 << 5,
+  PartyPrivacyFriends = 1 << 6,
+  PartyPrivacyVoiceChannel = 1 << 7,
+  Embedded = 1 << 8,
+}
+
 /** https://discord.com/developers/docs/resources/guild#integration-object-integration-expire-behaviors */
 export enum IntegrationExpireBehaviors {
   RemoveRole,


### PR DESCRIPTION
Add the enum for `ActivityTypes`. Rename and move enums for `MessageFlags` and `SkuFlags`

> [!NOTE]
> This pr does not remove these types from the objects. Currently some object still use `MessageFlags` and `SkuFlags`

> [!WARNING]
> This is a breaking change as before `MessageFlags` was called `DiscordMessageFlag` and `SkuFlags` was called `DiscordSkuFlag`.
> The prefix `Discord` was dropped for consistency with other flag enums (`ChannelFlags`, `RoleFlags`, `UserFlags`, ...)