### PR TITLE
fix(bot)!: Guild features type

### DIFF
--- a/packages/bot/src/transformers.ts
+++ b/packages/bot/src/transformers.ts
@@ -267,7 +267,6 @@ export interface Transformers {
       stickers: boolean
       threads: boolean
       voiceStates: boolean
-      features: boolean
       large: boolean
       owner: boolean
       widgetEnabled: boolean
@@ -876,7 +875,6 @@ export function createTransformers(options: Partial<Transformers>, opts?: Create
         name: opts?.defaultDesiredPropertiesValue ?? false,
         channels: opts?.defaultDesiredPropertiesValue ?? false,
         emojis: opts?.defaultDesiredPropertiesValue ?? false,
-        features: opts?.defaultDesiredPropertiesValue ?? false,
         iconHash: opts?.defaultDesiredPropertiesValue ?? false,
         large: opts?.defaultDesiredPropertiesValue ?? false,
         members: opts?.defaultDesiredPropertiesValue ?? false,

--- a/packages/bot/src/transformers/toggles/guild.ts
+++ b/packages/bot/src/transformers/toggles/guild.ts
@@ -24,7 +24,7 @@ const featureNames = [
   'autoModeration',
   'invitesDisabled',
   'animatedBanner',
-]
+] as const
 
 export const GuildToggle = {
   /** Whether the bot is the owner of the guild */
@@ -143,7 +143,7 @@ export class GuildToggles extends ToggleBitfieldBigint {
   get features(): GuildFeatureKeys[] {
     const features: GuildFeatureKeys[] = []
     for (const key of Object.keys(GuildToggle)) {
-      if (!featureNames.includes(key)) continue
+      if (!featureNames.includes(key as GuildFeatureKeys)) continue
       if (!super.contains(GuildToggle[key as GuildToggleKeys])) continue
 
       features.push(key as GuildFeatureKeys)
@@ -307,4 +307,4 @@ export class GuildToggles extends ToggleBitfieldBigint {
 
 export type GuildToggleKeys = keyof typeof GuildToggle
 
-export type GuildFeatureKeys = keyof typeof featureNames
+export type GuildFeatureKeys = (typeof featureNames)[number]

--- a/packages/bot/src/transformers/toggles/guild.ts
+++ b/packages/bot/src/transformers/toggles/guild.ts
@@ -2,28 +2,33 @@ import { GuildFeatures, type DiscordGuild } from '@discordeno/types'
 import { ToggleBitfieldBigint } from './ToggleBitfield.js'
 
 const featureNames = [
-  'inviteSplash',
-  'vipRegions',
-  'vanityUrl',
-  'verified',
-  'partnered',
+  'animatedBanner',
+  'animatedIcon',
+  'applicationCommandPermissionsV2',
+  'autoModeration',
+  'banner',
   'community',
+  'creatorMonetizableProvisional',
+  'creatorStorePage',
   'developerSupportServer',
-  'news',
   'discoverable',
   'featurable',
-  'animatedIcon',
-  'banner',
-  'welcomeScreenEnabled',
-  'memberVerificationGateEnabled',
-  'previewEnabled',
-  'ticketedEventsEnabled',
-  'monetizationEnabled',
-  'moreStickers',
-  'roleIcons',
-  'autoModeration',
   'invitesDisabled',
-  'animatedBanner',
+  'inviteSplash',
+  'memberVerificationGateEnabled',
+  'moreStickers',
+  'news',
+  'partnered',
+  'previewEnabled',
+  'raidAlertsDisabled',
+  'roleIcons',
+  'roleSubscriptionsAvailableForPurchase',
+  'roleSubscriptionsEnabled',
+  'ticketedEventsEnabled',
+  'vanityUrl',
+  'verified',
+  'vipRegions',
+  'welcomeScreenEnabled',
 ] as const
 
 export const GuildToggle = {
@@ -39,59 +44,62 @@ export const GuildToggle = {
   premiumProgressBarEnabled: 1n << 4n,
 
   // GUILD FEATURES ARE BELOW THIS
+  // MISSING VALUES IN THE BITFIELD: 24, 25, 26
 
-  /** Whether the guild has access to set an invite splash background */
-  inviteSplash: 1n << 5n,
-  /** Whether the guild has access to set 384 kbps bitrate in voice (previously VIP voice servers) */
-  vipRegions: 1n << 6n,
-  /** Whether the guild has access to set a vanity URL */
-  vanityUrl: 1n << 7n,
-  /** Whether the guild is verified */
-  verified: 1n << 8n,
-  /** Whether the guild is partnered */
-  partnered: 1n << 9n,
+  /** Whether the guild has access to set an animated guild banner image */
+  animatedBanner: 1n << 11n,
+  /** Whether the guild has access to set an animated guild icon */
+  animatedIcon: 1n << 16n,
+  /** Whether the guild is using the old permissions configuration behavior */
+  applicationCommandPermissionsV2: 1n << 14n,
+  /** Whether the guild has set up auto moderation rules */
+  autoModeration: 1n << 28n,
+  /** Whether the guild has access to set a guild banner image */
+  banner: 1n << 17n,
   /** Whether the guild can enable welcome screen, Membership Screening, stage channels and discovery, and receives community updates */
   community: 1n << 10n,
   /** Whether the guild has enabled monetization. */
   creatorMonetizableProvisional: 1n << 31n,
   /** Whether the guild has enabled the role subscription promo page. */
   creatorStorePage: 1n << 32n,
-  /** Whether the guild has access to set an animated guild banner image */
-  animatedBanner: 1n << 11n,
-  /** Whether the guild has access to create news channels */
-  news: 1n << 12n,
+  /** Whether the guild has been set as a support server on the App Directory */
+  developerSupportServer: 1n << 30n,
   /** Whether the guild is able to be discovered in the directory */
   discoverable: 1n << 13n,
   /** Whether the guild is able to be featured in the directory */
   featurable: 1n << 15n,
-  /** Whether the guild has access to set an animated guild icon */
-  animatedIcon: 1n << 16n,
-  /** Whether the guild has access to set a guild banner image */
-  banner: 1n << 17n,
-  /** Whether the guild has enabled the welcome screen */
-  welcomeScreenEnabled: 1n << 18n,
+  /** Whether the guild has paused invites, preventing new users from joining */
+  invitesDisabled: 1n << 29n,
+  /** Whether the guild has access to set an invite splash background */
+  inviteSplash: 1n << 5n,
   /** Whether the guild has enabled [Membership Screening](https://discord.com/developers/docs/resources/guild#membership-screening-object) */
   memberVerificationGateEnabled: 1n << 19n,
-  /** Whether the guild can be previewed before joining via Membership Screening or the directory */
-  previewEnabled: 1n << 20n,
-  /** Whether the guild has enabled ticketed events */
-  ticketedEventsEnabled: 1n << 21n,
-  /** Whether the guild has enabled monetization */
-  monetizationEnabled: 1n << 22n,
   /** Whether the guild has increased custom sticker slots */
   moreStickers: 1n << 23n,
+  /** Whether the guild has access to create news channels */
+  news: 1n << 12n,
+  /** Whether the guild is partnered */
+  partnered: 1n << 9n,
+  /** Whether the guild can be previewed before joining via Membership Screening or the directory */
+  previewEnabled: 1n << 20n,
+  /** Whether the guild has disabled alerts for join raids in the configured safety alerts channel */
+  raidAlertsDisabled: 1n << 22n,
   /** Whether the guild is able to set role icons */
   roleIcons: 1n << 27n,
   /** Whether the guild has role subscriptions that can be purchased. */
   roleSubscriptionsAvailableForPurchase: 1n << 33n,
   /** Whether the guild has enabled role subscriptions. */
   roleSubscriptionsEnabled: 1n << 34n,
-  /** Whether the guild has set up auto moderation rules */
-  autoModeration: 1n << 28n,
-  /** Whether the guild has paused invites, preventing new users from joining */
-  invitesDisabled: 1n << 29n,
-  /** Whether the guild has been set as a support server on the App Directory */
-  developerSupportServer: 1n << 30n,
+  /** Whether the guild has enabled ticketed events */
+  ticketedEventsEnabled: 1n << 21n,
+  /** Whether the guild has access to set a vanity URL */
+  vanityUrl: 1n << 7n,
+  /** Whether the guild is verified */
+  verified: 1n << 8n,
+  /** Whether the guild has access to set 384 kbps bitrate in voice (previously VIP voice servers) */
+  vipRegions: 1n << 6n,
+  /** Whether the guild has enabled the welcome screen */
+  welcomeScreenEnabled: 1n << 18n,
 }
 
 export class GuildToggles extends ToggleBitfieldBigint {
@@ -110,33 +118,33 @@ export class GuildToggles extends ToggleBitfieldBigint {
       if (guild.unavailable) this.add(GuildToggle.unavailable)
       if (guild.premium_progress_bar_enabled) this.add(GuildToggle.premiumProgressBarEnabled)
 
-      if (guild.features.includes(GuildFeatures.InviteSplash)) this.add(GuildToggle.inviteSplash)
-      if (guild.features.includes(GuildFeatures.VipRegions)) this.add(GuildToggle.vipRegions)
-      if (guild.features.includes(GuildFeatures.VanityUrl)) this.add(GuildToggle.vanityUrl)
-      if (guild.features.includes(GuildFeatures.Verified)) this.add(GuildToggle.verified)
-      if (guild.features.includes(GuildFeatures.Partnered)) this.add(GuildToggle.partnered)
+      if (guild.features.includes(GuildFeatures.AnimatedBanner)) this.add(GuildToggle.animatedBanner)
+      if (guild.features.includes(GuildFeatures.AnimatedIcon)) this.add(GuildToggle.animatedIcon)
+      if (guild.features.includes(GuildFeatures.ApplicationCommandPermissionsV2)) this.add(GuildToggle.applicationCommandPermissionsV2)
+      if (guild.features.includes(GuildFeatures.AutoModeration)) this.add(GuildToggle.autoModeration)
+      if (guild.features.includes(GuildFeatures.Banner)) this.add(GuildToggle.banner)
       if (guild.features.includes(GuildFeatures.Community)) this.add(GuildToggle.community)
       if (guild.features.includes(GuildFeatures.CreatorMonetizableProvisional)) this.add(GuildToggle.creatorMonetizableProvisional)
       if (guild.features.includes(GuildFeatures.CreatorStorePage)) this.add(GuildToggle.creatorStorePage)
       if (guild.features.includes(GuildFeatures.DeveloperSupportServer)) this.add(GuildToggle.developerSupportServer)
-      if (guild.features.includes(GuildFeatures.AnimatedBanner)) this.add(GuildToggle.animatedBanner)
-      if (guild.features.includes(GuildFeatures.News)) this.add(GuildToggle.news)
       if (guild.features.includes(GuildFeatures.Discoverable)) this.add(GuildToggle.discoverable)
       if (guild.features.includes(GuildFeatures.Featurable)) this.add(GuildToggle.featurable)
-      if (guild.features.includes(GuildFeatures.AnimatedIcon)) this.add(GuildToggle.animatedIcon)
-      if (guild.features.includes(GuildFeatures.Banner)) this.add(GuildToggle.banner)
-      if (guild.features.includes(GuildFeatures.WelcomeScreenEnabled)) this.add(GuildToggle.welcomeScreenEnabled)
-      if (guild.features.includes(GuildFeatures.MemberVerificationGateEnabled)) {
-        this.add(GuildToggle.memberVerificationGateEnabled)
-      }
-      if (guild.features.includes(GuildFeatures.PreviewEnabled)) this.add(GuildToggle.previewEnabled)
-      if (guild.features.includes(GuildFeatures.TicketedEventsEnabled)) this.add(GuildToggle.ticketedEventsEnabled)
+      if (guild.features.includes(GuildFeatures.InvitesDisabled)) this.add(GuildToggle.invitesDisabled)
+      if (guild.features.includes(GuildFeatures.InviteSplash)) this.add(GuildToggle.inviteSplash)
+      if (guild.features.includes(GuildFeatures.MemberVerificationGateEnabled)) this.add(GuildToggle.memberVerificationGateEnabled)
       if (guild.features.includes(GuildFeatures.MoreStickers)) this.add(GuildToggle.moreStickers)
+      if (guild.features.includes(GuildFeatures.News)) this.add(GuildToggle.news)
+      if (guild.features.includes(GuildFeatures.Partnered)) this.add(GuildToggle.partnered)
+      if (guild.features.includes(GuildFeatures.PreviewEnabled)) this.add(GuildToggle.previewEnabled)
+      if (guild.features.includes(GuildFeatures.RaidAlertsDisabled)) this.add(GuildToggle.raidAlertsDisabled)
       if (guild.features.includes(GuildFeatures.RoleIcons)) this.add(GuildToggle.roleIcons)
       if (guild.features.includes(GuildFeatures.RoleSubscriptionsAvailableForPurchase)) this.add(GuildToggle.roleSubscriptionsAvailableForPurchase)
       if (guild.features.includes(GuildFeatures.RoleSubscriptionsEnabled)) this.add(GuildToggle.roleSubscriptionsEnabled)
-      if (guild.features.includes(GuildFeatures.AutoModeration)) this.add(GuildToggle.autoModeration)
-      if (guild.features.includes(GuildFeatures.InvitesDisabled)) this.add(GuildToggle.invitesDisabled)
+      if (guild.features.includes(GuildFeatures.TicketedEventsEnabled)) this.add(GuildToggle.ticketedEventsEnabled)
+      if (guild.features.includes(GuildFeatures.VanityUrl)) this.add(GuildToggle.vanityUrl)
+      if (guild.features.includes(GuildFeatures.Verified)) this.add(GuildToggle.verified)
+      if (guild.features.includes(GuildFeatures.VipRegions)) this.add(GuildToggle.vipRegions)
+      if (guild.features.includes(GuildFeatures.WelcomeScreenEnabled)) this.add(GuildToggle.welcomeScreenEnabled)
     }
   }
 
@@ -262,11 +270,6 @@ export class GuildToggles extends ToggleBitfieldBigint {
     return this.has('ticketedEventsEnabled')
   }
 
-  /** Whether the guild has enabled monetization */
-  get monetizationEnabled(): boolean {
-    return this.has('monetizationEnabled')
-  }
-
   /** Whether the guild has increased custom sticker slots */
   get moreStickers(): boolean {
     return this.has('moreStickers')
@@ -285,6 +288,36 @@ export class GuildToggles extends ToggleBitfieldBigint {
   /** Whether the guild has paused invites, preventing new users from joining */
   get invitesDisabled(): boolean {
     return this.has('invitesDisabled')
+  }
+
+  /** Whether the guild is using the old permissions configuration behavior */
+  get applicationCommandPermissionsV2(): boolean {
+    return this.has('applicationCommandPermissionsV2')
+  }
+
+  /** Whether the guild has enabled monetization. */
+  get creatorMonetizableProvisional(): boolean {
+    return this.has('creatorMonetizableProvisional')
+  }
+
+  /** Whether the guild has enabled the role subscription promo page. */
+  get creatorStorePage(): boolean {
+    return this.has('creatorStorePage')
+  }
+
+  /** Whether the guild has disabled alerts for join raids in the configured safety alerts channel */
+  get raidAlertsDisabled(): boolean {
+    return this.has('raidAlertsDisabled')
+  }
+
+  /** Whether the guild has role subscriptions that can be purchased. */
+  get roleSubscriptionsAvailableForPurchase(): boolean {
+    return this.has('roleSubscriptionsAvailableForPurchase')
+  }
+
+  /** Whether the guild has enabled role subscriptions. */
+  get roleSubscriptionsEnabled(): boolean {
+    return this.has('roleSubscriptionsEnabled')
   }
 
   /** Checks whether or not the permissions exist in this */

--- a/packages/types/src/shared.ts
+++ b/packages/types/src/shared.ts
@@ -295,6 +295,8 @@ export enum GuildFeatures {
   AnimatedBanner = 'ANIMATED_BANNER',
   /** Guild has disabled alerts for join raids in the configured safety alerts channel */
   RaidAlertsDisabled = 'RAID_ALERTS_DISABLED',
+  /** Guild is using the old permissions configuration behavior */
+  ApplicationCommandPermissionsV2 = 'APPLICATION_COMMAND_PERMISSIONS_V2',
 }
 
 /** https://discord.com/developers/docs/resources/guild#guild-object-mfa-level */


### PR DESCRIPTION
Followup to #3705, turns out i got VERY wrong the type (i put a `keyof` instead of `[number]`).

Also i have checked all the features we have and some where missing so they got added

> [!WARNING]
> This is breaking for 2 reasons:
> 1. I have removed the `features` desired propreities as it was useless
> 1. the `monetizationEnabled` toggle was renamed to the actual name of the feature (`creatorMonetizableProvisional`)