### PR TITLE
feat(types)!: Use BigInt for permission flags

### DIFF
--- a/packages/bot/src/transformers/toggles/Permissions.ts
+++ b/packages/bot/src/transformers/toggles/Permissions.ts
@@ -1,4 +1,4 @@
-import { BitwisePermissionFlags } from '@discordeno/types'
+import { type PermissionStrings, BitwisePermissionFlags } from '@discordeno/types'
 import { ToggleBitfieldBigint } from './ToggleBitfield.js'
 
 export class Permissions extends ToggleBitfieldBigint {
@@ -6,15 +6,15 @@ export class Permissions extends ToggleBitfieldBigint {
     super(BigInt(bits))
   }
 
-  has(permission: keyof typeof BitwisePermissionFlags): boolean {
-    return this.contains(BigInt(BitwisePermissionFlags[permission]))
+  has(permission: PermissionStrings): boolean {
+    return this.contains(BitwisePermissionFlags[permission])
   }
 
-  hasAll(permissions: Array<keyof typeof BitwisePermissionFlags>): boolean {
+  hasAll(permissions: PermissionStrings[]): boolean {
     return permissions.every((key) => this.has(key))
   }
 
-  missing(permissions: Array<keyof typeof BitwisePermissionFlags>): Array<keyof typeof BitwisePermissionFlags> {
+  missing(permissions: PermissionStrings[]): PermissionStrings[] {
     return permissions.filter((key) => !this.has(key))
   }
 }

--- a/packages/types/src/shared.ts
+++ b/packages/types/src/shared.ts
@@ -649,106 +649,106 @@ export enum ApplicationCommandPermissionTypes {
 }
 
 /** https://discord.com/developers/docs/topics/permissions#permissions-bitwise-permission-flags */
-export enum BitwisePermissionFlags {
+export const BitwisePermissionFlags = {
   /** Allows creation of instant invites */
-  CREATE_INSTANT_INVITE = 0x0000000000000001,
+  CREATE_INSTANT_INVITE: 1n << 0n,
   /** Allows kicking members */
-  KICK_MEMBERS = 0x0000000000000002,
+  KICK_MEMBERS: 1n << 1n,
   /** Allows banning members */
-  BAN_MEMBERS = 0x0000000000000004,
+  BAN_MEMBERS: 1n << 2n,
   /** Allows all permissions and bypasses channel permission overwrites */
-  ADMINISTRATOR = 0x0000000000000008,
+  ADMINISTRATOR: 1n << 3n,
   /** Allows management and editing of channels */
-  MANAGE_CHANNELS = 0x0000000000000010,
+  MANAGE_CHANNELS: 1n << 4n,
   /** Allows management and editing of the guild */
-  MANAGE_GUILD = 0x0000000000000020,
+  MANAGE_GUILD: 1n << 5n,
   /** Allows for the addition of reactions to messages */
-  ADD_REACTIONS = 0x0000000000000040,
+  ADD_REACTIONS: 1n << 6n,
   /** Allows for viewing of audit logs */
-  VIEW_AUDIT_LOG = 0x0000000000000080,
+  VIEW_AUDIT_LOG: 1n << 7n,
   /** Allows for using priority speaker in a voice channel */
-  PRIORITY_SPEAKER = 0x0000000000000100,
+  PRIORITY_SPEAKER: 1n << 8n,
   /** Allows the user to go live */
-  STREAM = 0x0000000000000200,
+  STREAM: 1n << 9n,
   /** Allows guild members to view a channel, which includes reading messages in text channels and joining voice channels */
-  VIEW_CHANNEL = 0x0000000000000400,
+  VIEW_CHANNEL: 1n << 10n,
   /** Allows for sending messages in a channel. (does not allow sending messages in threads) */
-  SEND_MESSAGES = 0x0000000000000800,
+  SEND_MESSAGES: 1n << 11n,
   /** Allows for sending of /tts messages */
-  SEND_TTS_MESSAGES = 0x0000000000001000,
+  SEND_TTS_MESSAGES: 1n << 12n,
   /** Allows for deletion of other users messages */
-  MANAGE_MESSAGES = 0x0000000000002000,
+  MANAGE_MESSAGES: 1n << 13n,
   /** Links sent by users with this permission will be auto-embedded */
-  EMBED_LINKS = 0x0000000000004000,
+  EMBED_LINKS: 1n << 14n,
   /** Allows for uploading images and files */
-  ATTACH_FILES = 0x0000000000008000,
+  ATTACH_FILES: 1n << 15n,
   /** Allows for reading of message history */
-  READ_MESSAGE_HISTORY = 0x0000000000010000,
+  READ_MESSAGE_HISTORY: 1n << 16n,
   /** Allows for using the @everyone tag to notify all users in a channel, and the @here tag to notify all online users in a channel */
-  MENTION_EVERYONE = 0x0000000000020000,
+  MENTION_EVERYONE: 1n << 17n,
   /** Allows the usage of custom emojis from other servers */
-  USE_EXTERNAL_EMOJIS = 0x0000000000040000,
+  USE_EXTERNAL_EMOJIS: 1n << 18n,
   /** Allows for viewing guild insights */
-  VIEW_GUILD_INSIGHTS = 0x0000000000080000,
+  VIEW_GUILD_INSIGHTS: 1n << 19n,
   /** Allows for joining of a voice channel */
-  CONNECT = 0x0000000000100000,
+  CONNECT: 1n << 20n,
   /** Allows for speaking in a voice channel */
-  SPEAK = 0x0000000000200000,
+  SPEAK: 1n << 21n,
   /** Allows for muting members in a voice channel */
-  MUTE_MEMBERS = 0x0000000000400000,
+  MUTE_MEMBERS: 1n << 22n,
   /** Allows for deafening of members in a voice channel */
-  DEAFEN_MEMBERS = 0x0000000000800000,
+  DEAFEN_MEMBERS: 1n << 23n,
   /** Allows for moving of members between voice channels */
-  MOVE_MEMBERS = 0x0000000001000000,
+  MOVE_MEMBERS: 1n << 24n,
   /** Allows for using voice-activity-detection in a voice channel */
-  USE_VAD = 0x0000000002000000,
+  USE_VAD: 1n << 25n,
   /** Allows for modification of own nickname */
-  CHANGE_NICKNAME = 0x0000000004000000,
+  CHANGE_NICKNAME: 1n << 26n,
   /** Allows for modification of other users nicknames */
-  MANAGE_NICKNAMES = 0x0000000008000000,
+  MANAGE_NICKNAMES: 1n << 27n,
   /** Allows management and editing of roles */
-  MANAGE_ROLES = 0x0000000010000000,
+  MANAGE_ROLES: 1n << 28n,
   /** Allows management and editing of webhooks */
-  MANAGE_WEBHOOKS = 0x0000000020000000,
+  MANAGE_WEBHOOKS: 1n << 29n,
   /** Allows for editing and deleting emojis, stickers, and soundboard sounds created by all users */
-  MANAGE_GUILD_EXPRESSIONS = 0x0000000040000000,
+  MANAGE_GUILD_EXPRESSIONS: 1n << 30n,
   /** Allows members to use application commands in text channels */
-  USE_SLASH_COMMANDS = 0x0000000080000000,
+  USE_SLASH_COMMANDS: 1n << 31n,
   /** Allows for requesting to speak in stage channels. */
-  REQUEST_TO_SPEAK = 0x0000000100000000,
+  REQUEST_TO_SPEAK: 1n << 32n,
   /** Allows for editing and deleting scheduled events created by all users */
-  MANAGE_EVENTS = 0x0000000200000000,
+  MANAGE_EVENTS: 1n << 33n,
   /** Allows for deleting and archiving threads, and viewing all private threads */
-  MANAGE_THREADS = 0x0000000400000000,
+  MANAGE_THREADS: 1n << 34n,
   /** Allows for creating public and announcement threads */
-  CREATE_PUBLIC_THREADS = 0x0000000800000000,
+  CREATE_PUBLIC_THREADS: 1n << 35n,
   /** Allows for creating private threads */
-  CREATE_PRIVATE_THREADS = 0x0000001000000000,
+  CREATE_PRIVATE_THREADS: 1n << 36n,
   /** Allows the usage of custom stickers from other servers */
-  USE_EXTERNAL_STICKERS = 0x0000002000000000,
+  USE_EXTERNAL_STICKERS: 1n << 37n,
   /** Allows for sending messages in threads */
-  SEND_MESSAGES_IN_THREADS = 0x0000004000000000,
+  SEND_MESSAGES_IN_THREADS: 1n << 38n,
   /** Allows for launching activities (applications with the `EMBEDDED` flag) in a voice channel. */
-  USE_EMBEDDED_ACTIVITIES = 0x0000008000000000,
+  USE_EMBEDDED_ACTIVITIES: 1n << 39n,
   /** Allows for timing out users to prevent them from sending or reacting to messages in chat and threads, and from speaking in voice and stage channels */
-  MODERATE_MEMBERS = 0x0000010000000000,
+  MODERATE_MEMBERS: 1n << 40n,
   /** Allows for viewing role subscription insights. */
-  VIEW_CREATOR_MONETIZATION_ANALYTICS = 0x0000020000000000,
+  VIEW_CREATOR_MONETIZATION_ANALYTICS: 1n << 41n,
   /** Allows for using soundboard in a voice channel. */
-  USE_SOUNDBOARD = 0x0000040000000000,
+  USE_SOUNDBOARD: 1n << 42n,
   /** Allows for creating emojis, stickers, and soundboard sounds, and editing and deleting those created by the current user */
-  CREATE_GUILD_EXPRESSIONS = 0x0000080000000000,
+  CREATE_GUILD_EXPRESSIONS: 1n << 43n,
   /** Allows for creating scheduled events, and editing and deleting those created by the current user */
-  CREATE_EVENTS = 0x0000100000000000,
+  CREATE_EVENTS: 1n << 44n,
   /** Allows the usage of custom soundboards sounds from other servers */
-  USE_EXTERNAL_SOUNDS = 0x0000200000000000,
+  USE_EXTERNAL_SOUNDS: 1n << 45n,
   /** Allows sending voice messages */
-  SEND_VOICE_MESSAGES = 0x0000400000000000,
+  SEND_VOICE_MESSAGES: 1n << 46n,
   /** Allows sending polls */
-  SEND_POLLS = 0x0002000000000000,
+  SEND_POLLS: 1n << 49n,
   /** Allows user-installed apps to send public responses. When disabled, users will still be allowed to use their apps but the responses will be ephemeral. This only applies to apps not also installed to the server. */
-  USE_EXTERNAL_APPS = 0x0004000000000000,
-}
+  USE_EXTERNAL_APPS: 1n << 50n,
+} as const
 
 export type PermissionStrings = keyof typeof BitwisePermissionFlags
 

--- a/packages/utils/src/permissions.ts
+++ b/packages/utils/src/permissions.ts
@@ -7,7 +7,7 @@ export function calculatePermissions(permissionBits: bigint): PermissionStrings[
     // Since Object.keys() not only returns the permission names but also the bit values we need to return false if it is a Number
     if (Number(permission)) return false
     // Check if permissionBits has this permission
-    return permissionBits & BigInt(BitwisePermissionFlags[permission as PermissionStrings])
+    return permissionBits & BitwisePermissionFlags[permission as PermissionStrings]
   }) as PermissionStrings[]
 }
 
@@ -15,7 +15,7 @@ export function calculatePermissions(permissionBits: bigint): PermissionStrings[
 export function calculateBits(permissions: PermissionStrings[]): string {
   return permissions
     .reduce((bits, perm) => {
-      bits |= BigInt(BitwisePermissionFlags[perm])
+      bits |= BitwisePermissionFlags[perm]
       return bits
     }, 0n)
     .toString()


### PR DESCRIPTION
Discord is pretty close to the Number.MAX_SAFE_INTEGER (around 1 << 53, with 1 << 55 it will start truncating numbers), to avoid this we need to change to BigInt.

This pr also removes some BigInt constructor calls that are no longer necessary.

The reason this PR changes the enum to an object is because Typescript does not support bigint keys in objects, and enums are transformed into objects with also the values as keys. There are issues in the typescript repo, however they date back version 2.6

> [!WARNING]
> This is a breaking change for 2 reason:
> 1. BigInt is not compatibile with number, so if you used number it breaks
> 1. Since we needed to convert to an object now if you do `BitwisePermissionFlags[1]` it now gives undefined instead of the name of the permission
