### PR TITLE
fix: adapt biome formatting of package.json files to match the yarn one

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -41,16 +41,10 @@
       "allowTrailingCommas": true
     }
   },
-  "overrides": [
-    {
-      "include": ["package.json"],
-      "formatter": {
-        "lineWidth": 1
-      }
-    }
-  ],
   "files": {
     "ignore": [
+      // Ignore the package.json and leave yarn to format it
+      "package.json",
       "node_modules",
       // Ignore turbo and docusaurus cache/stuff
       ".docusaurus",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -41,6 +41,14 @@
       "allowTrailingCommas": true
     }
   },
+  "overrides": [
+    {
+      "include": ["package.json"],
+      "formatter": {
+        "lineWidth": 1
+      }
+    }
+  ],
   "files": {
     "ignore": [
       "node_modules",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "19.0.0-alpha.1",
   "private": true,
   "type": "module",
-  "workspaces": ["packages/*"],
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
     "build": "turbo run build --no-daemon",
     "build:watch": "echo \"Starting build in watch mode...\" && chokidar \"packages/**/*.ts\" --ignore \"packages/**/dist/**/*.d.ts\"  -c \"yarn run build && yarn run build:type\"",

--- a/packages/bot/src/transformers/toggles/member.ts
+++ b/packages/bot/src/transformers/toggles/member.ts
@@ -1,4 +1,4 @@
-import { MemberFlags, type DiscordMember } from '@discordeno/types'
+import { type DiscordMember, MemberFlags } from '@discordeno/types'
 import { ToggleBitfield } from './ToggleBitfield.js'
 
 const memberFlags = ['didRejoin', 'startedOnboarding', 'bypassesVerification', 'completedOnboarding'] as const

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -2,5 +2,8 @@
   "name": "tsconfig",
   "version": "0.0.0",
   "private": true,
-  "files": ["base.json", "test.json"]
+  "files": [
+    "base.json",
+    "test.json"
+  ]
 }

--- a/website/package.json
+++ b/website/package.json
@@ -45,8 +45,16 @@
     "webpack": "^5.89.0"
   },
   "browserslist": {
-    "production": [">0.5%", "not dead", "not op_mini all"],
-    "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
+    "production": [
+      ">0.5%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   },
   "engines": {
     "node": ">=18.0"


### PR DESCRIPTION
Currently yarn and biome fight every time you install the dependencies/run the formatter.

The PRs adds the package.json to the ignore list for biome.

> [!NOTE]
> This PR includes a change to the import sorting for the member toggles as #3617 got merged while using ESLint and it didn't get updated to use biome 