### PR TITLE
fix(docker): prevent snyk null in severity scores for unassigned CVEs

### DIFF
--- a/.github/workflows/docker-app-rest-passthrough.yml
+++ b/.github/workflows/docker-app-rest-passthrough.yml
@@ -136,11 +136,12 @@ jobs:
         with:
           image: 'discordeno/app-rest-passthrough:latest'
           args: --file=docker-apps/rest-passthrough/Dockerfile
-      # See https://github.com/github/codeql-action/issues/2187#issuecomment-2043220400 for for info
-      - name: Replace security-severity undefined for license-related findings
+      # Snyk will use a security-severify of "null" when the CVE didn't get an assigned score
+      - name: Replace security-severity null for non assigned CVE scores
         if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
         run: |
-          sed -i 's/"security-severity": "undefined"/"security-severity": "0"/g' snyk.sarif
+          sed -i 's/"security-severity": "null"/"security-severity": "0"/g' snyk.sarif
+          sed -i 's/"cvssv3_baseScore": null/"cvssv3_baseScore": 0/g' snyk.sarif
       - name: Upload snyk scan results to GitHub Security tab
         if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
         uses: github/codeql-action/upload-sarif@v3

--- a/docker-apps/rest-passthrough/Dockerfile
+++ b/docker-apps/rest-passthrough/Dockerfile
@@ -9,7 +9,7 @@
 #   the final image, with only the dependencies and compiled files
 
 # build only with the platform of the host machine, since it only uses for dev purposes
-FROM --platform=$BUILDPLATFORM node:18.19.0-alpine3.19 AS deps
+FROM --platform=$BUILDPLATFORM node:20.15.1-alpine3.20 AS deps
 WORKDIR /app
 # copy necessary for install dependencies
 COPY package.json yarn.lock .yarnrc.yml ./
@@ -18,7 +18,7 @@ COPY ./.yarn/releases  ./.yarn/releases
 RUN yarn install --immutable
 
 # build only with the platform of the host machine, since we just need its files
-FROM --platform=$BUILDPLATFORM node:18.19.0-alpine3.19 AS builder
+FROM --platform=$BUILDPLATFORM node:20.15.1-alpine3.20 AS builder
 # copy the dependencies (node_modules) from the deps image
 COPY --from=deps /app /app
 WORKDIR /app
@@ -29,7 +29,7 @@ COPY .swcrc ./
 # compile the files
 RUN yarn build
 
-FROM node:18.19.0-alpine3.19 AS runner
+FROM node:20.15.1-alpine3.20 AS runner
 # copy the compiled files from the builder image
 COPY --from=builder /app/dist /app/dist
 # copy the dependencies from the deps image

--- a/docker-apps/rest-passthrough/Dockerfile
+++ b/docker-apps/rest-passthrough/Dockerfile
@@ -9,7 +9,7 @@
 #   the final image, with only the dependencies and compiled files
 
 # build only with the platform of the host machine, since it only uses for dev purposes
-FROM --platform=$BUILDPLATFORM node:20.15.1-alpine3.20 AS deps
+FROM --platform=$BUILDPLATFORM node:18.20.4-alpine3.20 AS deps
 WORKDIR /app
 # copy necessary for install dependencies
 COPY package.json yarn.lock .yarnrc.yml ./
@@ -18,7 +18,7 @@ COPY ./.yarn/releases  ./.yarn/releases
 RUN yarn install --immutable
 
 # build only with the platform of the host machine, since we just need its files
-FROM --platform=$BUILDPLATFORM node:20.15.1-alpine3.20 AS builder
+FROM --platform=$BUILDPLATFORM node:18.20.4-alpine3.20 AS builder
 # copy the dependencies (node_modules) from the deps image
 COPY --from=deps /app /app
 WORKDIR /app
@@ -29,7 +29,7 @@ COPY .swcrc ./
 # compile the files
 RUN yarn build
 
-FROM node:20.15.1-alpine3.20 AS runner
+FROM node:18.20.4-alpine3.20 AS runner
 # copy the compiled files from the builder image
 COPY --from=builder /app/dist /app/dist
 # copy the dependencies from the deps image


### PR DESCRIPTION
Snyk uses `null` in the severity score when the CVE doesn't have an assigned score yet. This makes the codeql/upload-sarif action fail as `null` is not a valid number

This pr also bumps the base image for the docker image from alpine 3.19 to alpine 3.20