### PR TITLE
feat(types): Add roblox connection

### DIFF
--- a/packages/types/src/discord.ts
+++ b/packages/types/src/discord.ts
@@ -528,6 +528,7 @@ export enum DiscordConnectionServiceType {
   PlayStationNetwork = 'playstation',
   Reddit = 'reddit',
   RiotGames = 'riotgames',
+  Roblox = 'roblox',
   Spotify = 'spotify',
   Skype = 'skype',
   Steam = 'steam',


### PR DESCRIPTION
Add the roblox connection to the `DiscordConnectionServiceType` enum

* upstream: https://github.com/discord/discord-api-docs/pull/6995
* fixes #3753