### PR TITLE
feat(types): Add banner to `DiscordPartialGuild`

### DIFF
--- a/packages/types/src/discord.ts
+++ b/packages/types/src/discord.ts
@@ -913,6 +913,8 @@ export interface DiscordPartialGuild {
   id: string
   /** Icon hash */
   icon: string | null
+  /** Banner hash */
+  banner: string | null
   /** true if the user is the owner of the guild */
   owner: boolean
   /** Total permissions for the user in the guild (excludes overwrites and implicit permissions) */


### PR DESCRIPTION
Add banner to `DiscordPartialGuild`

On a side note: Why do we even have this type? wouldn't it be the same as using `Partial<DiscordGuild>`? It would also be a better idea to do so because it doesn't seem that discord documents explicitly what are the props that this method will return

- upstream: https://github.com/discord/discord-api-docs/pull/6982
- fixes #3755 