### PR TITLE
fix(rest): Fix followups from getting stuck in queue

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -332,7 +332,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       const bucketId = headers.get(RATE_LIMIT_BUCKET_HEADER) ?? undefined
       const limit = headers.get(RATE_LIMIT_LIMIT_HEADER)
 
-      // If this queue doesn't have an identifier, fallback to the bot token
+      // If we didn't received the identifier, fallback to the bot token
       identifier ??= `Bot ${rest.token}`
 
       rest.queues.get(`${identifier}${url}`)?.handleCompletedRequest({
@@ -503,7 +503,6 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       }
 
       // If we the request has a token, use it
-      // If the quest has a custom queue identifier, use it
       // Else fallback to prefix with the bot token
       const queueIdentifier = request.requestBodyOptions?.headers?.authorization ?? `Bot ${rest.token}`
 
@@ -525,16 +524,13 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
 
     async makeRequest(method, route, options) {
       if (rest.isProxied) {
-        options ??= {}
-        options.headers ??= {}
-
         if (rest.authorization !== undefined) {
+          options ??= {}
+          options.headers ??= {}
           options.headers[rest.authorizationHeader] = rest.authorization
         }
 
-        const fetchOptions = rest.createRequestBody(method, options)
-
-        const result = await fetch(`${rest.baseUrl}/v${rest.version}${route}`, fetchOptions)
+        const result = await fetch(`${rest.baseUrl}/v${rest.version}${route}`, rest.createRequestBody(method, options))
 
         if (!result.ok) {
           const err = (await result.json().catch(() => {})) as Record<string, any>

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -505,7 +505,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       // If we the request has a token, use it
       // If the quest has a custom queue identifier, use it
       // Else fallback to prefix with the bot token
-      const queueIdentifier = request.requestBodyOptions?.headers?.authorization ?? request.queueIdentifier ?? `Bot ${rest.token}`
+      const queueIdentifier = request.requestBodyOptions?.headers?.authorization ?? `Bot ${rest.token}`
 
       const queue = rest.queues.get(`${queueIdentifier}${url}`)
 
@@ -525,13 +525,16 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
 
     async makeRequest(method, route, options) {
       if (rest.isProxied) {
+        options ??= {}
+        options.headers ??= {}
+
         if (rest.authorization !== undefined) {
-          options ??= {}
-          options.headers ??= {}
           options.headers[rest.authorizationHeader] = rest.authorization
         }
 
-        const result = await fetch(`${rest.baseUrl}/v${rest.version}${route}`, rest.createRequestBody(method, options))
+        const fetchOptions = rest.createRequestBody(method, options)
+
+        const result = await fetch(`${rest.baseUrl}/v${rest.version}${route}`, fetchOptions)
 
         if (!result.ok) {
           const err = (await result.json().catch(() => {})) as Record<string, any>
@@ -564,7 +567,6 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
             reject(error)
           },
           runThroughQueue: options?.runThroughQueue,
-          queueIdentifier: options?.queueIdentifier,
         }
 
         await rest.processRequest(payload)
@@ -829,7 +831,6 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
 
     async deleteWebhookWithToken(webhookId, token) {
       await rest.delete(rest.routes.webhooks.webhook(webhookId, token), {
-        queueIdentifier: `Webhook ${webhookId}:${token}`,
         unauthorized: true,
       })
     },
@@ -931,7 +932,6 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
           data: options,
         },
         files: options.files,
-        queueIdentifier: `Webhook ${webhookId}:${token}`,
         unauthorized: true,
       })
     },
@@ -975,7 +975,6 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       return await rest.patch<DiscordMessage>(rest.routes.webhooks.message(webhookId, token, messageId, options), {
         body: options,
         files: options.files,
-        queueIdentifier: `Webhook ${webhookId}:${token}`,
         unauthorized: true,
       })
     },
@@ -983,7 +982,6 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
     async editWebhookWithToken(webhookId, token, body) {
       return await rest.patch<DiscordWebhook>(rest.routes.webhooks.webhook(webhookId, token), {
         body,
-        queueIdentifier: `Webhook ${webhookId}:${token}`,
         unauthorized: true,
       })
     },
@@ -999,7 +997,6 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
     async executeWebhook(webhookId, token, options) {
       return await rest.post<DiscordMessage>(rest.routes.webhooks.webhook(webhookId, token, options), {
         body: options,
-        queueIdentifier: `Webhook ${webhookId}:${token}`,
         unauthorized: true,
       })
     },
@@ -1359,14 +1356,12 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
 
     async getWebhookMessage(webhookId, token, messageId, options) {
       return await rest.get<DiscordMessage>(rest.routes.webhooks.message(webhookId, token, messageId, options), {
-        queueIdentifier: `Webhook ${webhookId}:${token}`,
         unauthorized: true,
       })
     },
 
     async getWebhookWithToken(webhookId, token) {
       return await rest.get<DiscordWebhook>(rest.routes.webhooks.webhook(webhookId, token), {
-        queueIdentifier: `Webhook ${webhookId}:${token}`,
         unauthorized: true,
       })
     },
@@ -1415,7 +1410,6 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       return await rest.post(rest.routes.webhooks.webhook(rest.applicationId, token), {
         body: options,
         files: options.files,
-        queueIdentifier: `Webhook ${rest.applicationId}:${token}`,
         unauthorized: true,
       })
     },

--- a/packages/rest/src/queue.ts
+++ b/packages/rest/src/queue.ts
@@ -31,17 +31,17 @@ export class Queue {
   /** The timeout for the deletion of this queue */
   deleteQueueTimeout?: NodeJS.Timeout
   /**
-   * The authorization being used for the requests in this queue
+   * The identifier for this request, may be the request authorization, a custom identifier or fallback to the bot auth
    *
    * @remarks
-   * This is also used to get the key this queue is stored as in the queue mapping of the rest manager
+   * This is used to get the identify this queue from the queue mapping of the rest manager
    */
-  requestAuthorization: string
+  identifier: string
 
   constructor(rest: RestManager, options: QueueOptions) {
     this.rest = rest
     this.url = options.url
-    this.requestAuthorization = options.requestAuthorization
+    this.identifier = options.identifier
 
     if (options.interval) this.interval = options.interval
     if (options.max) this.max = options.max
@@ -77,7 +77,7 @@ export class Queue {
     this.processing = true
 
     while (this.waiting.length > 0) {
-      this.rest.logger.debug(`[Queue] ${this.getQueueType()} ${this.url} process waiting while loop ran.`)
+      this.rest.logger.debug(`[Queue] ${this.queueType} ${this.url} process waiting while loop ran.`)
       if (this.isRequestAllowed()) {
         // Resolve the next item in the queue
         this.waiting.shift()?.()
@@ -99,7 +99,7 @@ export class Queue {
     this.processingPending = true
 
     while (this.pending.length > 0) {
-      this.rest.logger.debug(`Queue ${this.getQueueType()} ${this.url} process pending while loop ran with ${this.pending.length}.`)
+      this.rest.logger.debug(`Queue ${this.queueType} ${this.url} process pending while loop ran with ${this.pending.length}.`)
       if (!this.firstRequest && !this.isRequestAllowed()) {
         const now = Date.now()
         const future = this.frozenAt + this.interval
@@ -112,11 +112,11 @@ export class Queue {
         const basicURL = this.rest.simplifyUrl(request.route, request.method)
 
         // If this url is still rate limited, try again
-        const urlResetIn = this.rest.checkRateLimits(basicURL, this.requestAuthorization)
+        const urlResetIn = this.rest.checkRateLimits(basicURL, this.identifier)
         if (urlResetIn) await delay(urlResetIn)
 
         // IF A BUCKET EXISTS, CHECK THE BUCKET'S RATE LIMITS
-        const bucketResetIn = request.bucketId ? this.rest.checkRateLimits(request.bucketId, this.requestAuthorization) : false
+        const bucketResetIn = request.bucketId ? this.rest.checkRateLimits(request.bucketId, this.identifier) : false
         if (bucketResetIn) await delay(bucketResetIn)
 
         this.firstRequest = false
@@ -134,8 +134,6 @@ export class Queue {
         // Check if this request is able to be made globally
         await this.rest.invalidBucket.waitUntilRequestAvailable()
 
-        if (request.requestBodyOptions?.headers?.authorization) request.requestBodyOptions.headers.authorization = this.requestAuthorization
-
         await this.rest
           .sendRequest(request)
           // Should be handled in sendRequest, this catch just prevents bots from dying
@@ -143,7 +141,7 @@ export class Queue {
       }
     }
 
-    this.rest.logger.debug(`Queue ${this.getQueueType()} ${this.url} process pending while loop exited with ${this.pending.length}.`)
+    this.rest.logger.debug(`Queue ${this.queueType} ${this.url} process pending while loop exited with ${this.pending.length}.`)
 
     // Mark as false so next pending request can be triggered by new loop.
     this.processingPending = false
@@ -182,26 +180,26 @@ export class Queue {
       return
     }
 
-    this.rest.logger.debug(`[Queue] ${this.getQueueType()} ${this.url}. Delaying delete for ${this.deleteQueueDelay}ms`)
+    this.rest.logger.debug(`[Queue] ${this.queueType} ${this.url}. Delaying delete for ${this.deleteQueueDelay}ms`)
 
     // Delete in a minute giving a bit of time to allow new requests that may reuse this queue
     clearTimeout(this.deleteQueueTimeout)
     this.deleteQueueTimeout = setTimeout(() => {
       if (!this.isQueueClearable()) {
-        this.rest.logger.debug(`[Queue] ${this.getQueueType()} ${this.url}. is not clearable. Restarting processing of queue.`)
+        this.rest.logger.debug(`[Queue] ${this.queueType} ${this.url}. is not clearable. Restarting processing of queue.`)
         this.processPending()
         return
       }
 
-      this.rest.logger.debug(`[Queue] ${this.getQueueType()} ${this.url}. Deleting`)
+      this.rest.logger.debug(`[Queue] ${this.queueType} ${this.url}. Deleting`)
 
       if (this.timeoutId) clearTimeout(this.timeoutId)
 
       // No requests have been requested for this queue so we nuke this queue
-      this.rest.queues.delete(`${this.requestAuthorization}${this.url}`)
+      this.rest.queues.delete(`${this.identifier}${this.url}`)
       this.rest.logger.debug(
-        `[Queue] ${this.getQueueType()} ${this.url}. Deleted! Remaining: (${this.rest.queues.size})`,
-        [...this.rest.queues.values()].map((queue) => `${queue.getQueueType()}${queue.url}`),
+        `[Queue] ${this.queueType} ${this.url}. Deleted! Remaining: (${this.rest.queues.size})`,
+        [...this.rest.queues.values()].map((queue) => `${queue.queueType}${queue.url}`),
       )
     }, this.deleteQueueDelay)
   }
@@ -217,8 +215,8 @@ export class Queue {
     return true
   }
 
-  getQueueType(): string {
-    return this.requestAuthorization.split(' ')[0]
+  get queueType(): string {
+    return this.identifier.slice(0, this.identifier.indexOf(' '))
   }
 }
 
@@ -236,5 +234,5 @@ export interface QueueOptions {
   /** The time in milliseconds to wait before deleting this queue if it is empty. Defaults to 60000(one minute). */
   deleteQueueDelay?: number
   /** The base key that identifies this queue in the rest manager */
-  requestAuthorization: string
+  identifier: string
 }

--- a/packages/rest/src/queue.ts
+++ b/packages/rest/src/queue.ts
@@ -31,7 +31,7 @@ export class Queue {
   /** The timeout for the deletion of this queue */
   deleteQueueTimeout?: NodeJS.Timeout
   /**
-   * The identifier for this request, may be the request authorization, a custom identifier or fallback to the bot auth
+   * The identifier for this request, may be the request authorization or fallback to the bot auth
    *
    * @remarks
    * This is used to get the identify this queue from the queue mapping of the rest manager

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -235,7 +235,7 @@ export interface RestManager {
   /** Whether or not the rest manager should keep objects in raw snake case from discord. */
   preferSnakeCase: (enabled: boolean) => RestManager
   /** Check the rate limits for a url or a bucket. */
-  checkRateLimits: (url: string, requestAuthorization: string) => number | false
+  checkRateLimits: (url: string, identifier: string) => number | false
   /* Update the queues and ratelimit information to adapt to the new token */
   updateTokenQueues: (oldToken: string, newToken: string) => Promise<void>
   /** Reshapes and modifies the obj as needed to make it ready for discords api. */
@@ -245,7 +245,7 @@ export interface RestManager {
   /** This will create a infinite loop running in 1 seconds using tail recursion to keep rate limits clean. When a rate limit resets, this will remove it so the queue can proceed. */
   processRateLimitedPaths: () => void
   /** Processes the rate limit headers and determines if it needs to be rate limited and returns the bucket id if available */
-  processHeaders: (url: string, headers: Headers, requestAuthorization: string) => string | undefined
+  processHeaders: (url: string, headers: Headers, identifier: string) => string | undefined
   /** Sends a request to the api. */
   sendRequest: (options: SendRequestOptions) => Promise<void>
   /** Split a url to separate rate limit buckets based on major/minor parameters. */
@@ -2945,7 +2945,7 @@ export interface CreateRequestBodyOptions {
   files?: FileContent[]
 }
 
-export type MakeRequestOptions = Omit<CreateRequestBodyOptions, 'method'> & Pick<SendRequestOptions, 'runThroughQueue'>
+export type MakeRequestOptions = Omit<CreateRequestBodyOptions, 'method'> & Pick<SendRequestOptions, 'runThroughQueue' | 'queueIdentifier'>
 
 export interface RequestBody {
   headers: Record<string, string>
@@ -2975,6 +2975,11 @@ export interface SendRequestOptions {
    * Useful for routes which do not have any rate limits.
    */
   runThroughQueue?: boolean
+  /**
+   * The identifier for the queue.
+   * Useful when the route does not use the traditional authentication approach (using the Authentication header)
+   */
+  queueIdentifier?: string
 }
 
 export interface RestRateLimitedPath {

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -2945,7 +2945,7 @@ export interface CreateRequestBodyOptions {
   files?: FileContent[]
 }
 
-export type MakeRequestOptions = Omit<CreateRequestBodyOptions, 'method'> & Pick<SendRequestOptions, 'runThroughQueue' | 'queueIdentifier'>
+export type MakeRequestOptions = Omit<CreateRequestBodyOptions, 'method'> & Pick<SendRequestOptions, 'runThroughQueue'>
 
 export interface RequestBody {
   headers: Record<string, string>
@@ -2975,11 +2975,6 @@ export interface SendRequestOptions {
    * Useful for routes which do not have any rate limits.
    */
   runThroughQueue?: boolean
-  /**
-   * The identifier for the queue.
-   * Useful when the route does not use the traditional authentication approach (using the Authentication header)
-   */
-  queueIdentifier?: string
 }
 
 export interface RestRateLimitedPath {


### PR DESCRIPTION
Currently it is possibile for the followups to get stuck in an dead queue (that will never refresh) because of the omission of both the header and the token in the url (due to how the ratelimit buckets work)