### PR TITLE
feat(types)!: Remove `DiscordPartialGuild`, use `Partial<DiscordGuild>`

### DIFF
--- a/packages/bot/src/helpers.ts
+++ b/packages/bot/src/helpers.ts
@@ -20,7 +20,6 @@ import type {
   CamelizedDiscordInvite,
   CamelizedDiscordInviteMetadata,
   CamelizedDiscordModifyGuildWelcomeScreen,
-  CamelizedDiscordPartialGuild,
   CamelizedDiscordPrunedCount,
   CamelizedDiscordTokenExchange,
   CamelizedDiscordTokenRevocation,
@@ -340,7 +339,8 @@ export function createBotHelpers(bot: Bot): BotHelpers {
       return bot.transformers.guild(bot, { guild: snakelize(await bot.rest.getGuild(guildId, options)), shardId: 0 })
     },
     getGuilds: async (bearerToken, options) => {
-      return await bot.rest.getGuilds(bearerToken, options)
+      // @ts-expect-error getGuilds returns partial guilds
+      return (await bot.rest.getGuilds(bearerToken, options)).map((res) => bot.transformers.guild(bot, { guild: snakelize(res), shardId: 0 }))
     },
     getGuildApplicationCommand: async (commandId, guildId) => {
       return bot.transformers.applicationCommand(bot, snakelize(await bot.rest.getGuildApplicationCommand(commandId, guildId)))
@@ -812,7 +812,7 @@ export interface BotHelpers {
   getGlobalApplicationCommand: (commandId: BigString) => Promise<ApplicationCommand>
   getGlobalApplicationCommands: () => Promise<ApplicationCommand[]>
   getGuild: (guildId: BigString, options?: { counts?: boolean }) => Promise<Guild>
-  getGuilds: (bearerToken: string, options?: GetUserGuilds) => Promise<CamelizedDiscordPartialGuild[]>
+  getGuilds: (bearerToken: string, options?: GetUserGuilds) => Promise<Partial<Guild>[]>
   getGuildApplicationCommand: (commandId: BigString, guildId: BigString) => Promise<ApplicationCommand>
   getGuildApplicationCommands: (guildId: BigString) => Promise<ApplicationCommand[]>
   getGuildPreview: (guildId: BigString) => Promise<CamelizedDiscordGuildPreview>

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -32,7 +32,6 @@ import {
   type DiscordMember,
   type DiscordMemberWithUser,
   type DiscordMessage,
-  type DiscordPartialGuild,
   type DiscordPrunedCount,
   type DiscordRole,
   type DiscordScheduledEvent,
@@ -1169,7 +1168,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
           }
         : undefined
 
-      return await rest.get<DiscordPartialGuild[]>(rest.routes.guilds.userGuilds(options), makeRequestOptions)
+      return await rest.get<Partial<DiscordGuild>[]>(rest.routes.guilds.userGuilds(options), makeRequestOptions)
     },
 
     async getGuildApplicationCommand(commandId, guildId) {

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -36,7 +36,6 @@ import type {
   CamelizedDiscordMemberWithUser,
   CamelizedDiscordMessage,
   CamelizedDiscordModifyGuildWelcomeScreen,
-  CamelizedDiscordPartialGuild,
   CamelizedDiscordPrunedCount,
   CamelizedDiscordRole,
   CamelizedDiscordScheduledEvent,
@@ -1829,14 +1828,14 @@ export interface RestManager {
    *
    * @param bearerToken - The access token of the user, if unspecified the bot token is used instead
    * @param options - The parameters for the fetching of the guild.
-   * @returns An instance of {@link CamelizedDiscordGuild}.
+   * @returns An array of partial {@link CamelizedDiscordGuild}.
    *
    * @remarks
    * If used with an access token, the token needs to have the `guilds` scope
    *
    * @see {@link https://discord.com/developers/docs/resources/user#get-current-user-guilds}
    */
-  getGuilds: (bearerToken?: string, options?: GetUserGuilds) => Promise<CamelizedDiscordPartialGuild[]>
+  getGuilds: (bearerToken?: string, options?: GetUserGuilds) => Promise<Partial<CamelizedDiscordGuild>[]>
   /**
    * Gets a guild application command by its ID.
    *

--- a/packages/types/src/camel.ts
+++ b/packages/types/src/camel.ts
@@ -119,7 +119,6 @@ import type {
   DiscordModifyGuildWelcomeScreen,
   DiscordOptionalAuditEntryInfo,
   DiscordOverwrite,
-  DiscordPartialGuild,
   DiscordPoll,
   DiscordPollAnswer,
   DiscordPollAnswerCount,
@@ -208,7 +207,6 @@ export type CamelizedDiscordWebhook = Camelize<DiscordWebhook>
 export interface CamelizedDiscordIncomingWebhook extends Camelize<DiscordIncomingWebhook> {}
 export interface CamelizedDiscordApplicationWebhook extends Camelize<DiscordApplicationWebhook> {}
 export interface CamelizedDiscordGuild extends Camelize<DiscordGuild> {}
-export interface CamelizedDiscordPartialGuild extends Camelize<DiscordPartialGuild> {}
 export interface CamelizedDiscordRole extends Camelize<DiscordRole> {}
 export interface CamelizedDiscordRoleTags extends Camelize<DiscordRoleTags> {}
 export interface CamelizedDiscordEmoji extends Camelize<DiscordEmoji> {}

--- a/packages/types/src/discord.ts
+++ b/packages/types/src/discord.ts
@@ -906,25 +906,6 @@ export interface DiscordGuild {
   safety_alerts_channel_id: string | null
 }
 
-export interface DiscordPartialGuild {
-  /** Guild name (2-100 characters, excluding trailing and leading whitespace) */
-  name: string
-  /** Guild id */
-  id: string
-  /** Icon hash */
-  icon: string | null
-  /** true if the user is the owner of the guild */
-  owner: boolean
-  /** Total permissions for the user in the guild (excludes overwrites and implicit permissions) */
-  permissions: string
-  /** Enabled guild features */
-  features: GuildFeatures[]
-  /** Approximate number of members in this guild, returned from the GET /guilds/id endpoint when with_counts is true */
-  approximate_member_count?: number
-  /** Approximate number of non-offline members in this guild, returned from the GET /guilds/id endpoint when with_counts is true */
-  approximate_presence_count?: number
-}
-
 /** https://discord.com/developers/docs/topics/permissions#role-object-role-structure */
 export interface DiscordRole {
   /** Role id */


### PR DESCRIPTION
The `DiscordPartialGuild` was introduced with #3114, however discord does not document explicitly what are the expected proprieties someone should expect, and generically say "Partial Guild object". So, this pr uses the `Partial<DiscordGuild>` instead.

- fixes #3755 