### PR TITLE
faet(bot): Type `commandOptionsParser`, remove any

### DIFF
--- a/packages/bot/src/commandOptionsParser.ts
+++ b/packages/bot/src/commandOptionsParser.ts
@@ -1,11 +1,11 @@
 import { ApplicationCommandOptionTypes } from '@discordeno/types'
-import type { Interaction, InteractionDataOption } from './index.js'
+import type { Attachment, Channel, Interaction, InteractionDataOption, Member, Role, User } from './index.js'
 
-export function commandOptionsParser(interaction: Interaction, options?: InteractionDataOption[]): Record<string, any> {
+export function commandOptionsParser(interaction: Interaction, options?: InteractionDataOption[]): ParsedInteractionOption {
   if (!interaction.data) return {}
   if (!options) options = interaction.data.options ?? []
 
-  const args: Record<string, any> = {}
+  const args: ParsedInteractionOption = {}
 
   for (const option of options) {
     switch (option.type) {
@@ -14,31 +14,44 @@ export function commandOptionsParser(interaction: Interaction, options?: Interac
         args[option.name] = commandOptionsParser(interaction, option.options)
         break
       case ApplicationCommandOptionTypes.Channel:
-        args[option.name] = interaction.data.resolved?.channels?.get(BigInt(option.value!))
+        args[option.name] = interaction.data.resolved?.channels?.get(BigInt(option.value!)) as InteractionResolvedChannel
         break
       case ApplicationCommandOptionTypes.Role:
-        args[option.name] = interaction.data.resolved?.roles?.get(BigInt(option.value!))
+        args[option.name] = interaction.data.resolved?.roles?.get(BigInt(option.value!)) as Role
         break
       case ApplicationCommandOptionTypes.User:
         args[option.name] = {
-          user: interaction.data.resolved?.users?.get(BigInt(option.value!)),
-          member: interaction.data.resolved?.members?.get(BigInt(option.value!)),
+          user: interaction.data.resolved?.users?.get(BigInt(option.value!)) as User,
+          member: interaction.data.resolved?.members?.get(BigInt(option.value!)) as InteractionResolvedMember,
         }
         break
       case ApplicationCommandOptionTypes.Attachment:
-        args[option.name] = interaction.data.resolved?.attachments?.get(BigInt(option.value!))
+        args[option.name] = interaction.data.resolved?.attachments?.get(BigInt(option.value!)) as Attachment
         break
       case ApplicationCommandOptionTypes.Mentionable:
         // Mentionable are roles or users
-        args[option.name] = interaction.data.resolved?.roles?.get(BigInt(option.value!)) ?? {
-          user: interaction.data.resolved?.users?.get(BigInt(option.value!)),
-          member: interaction.data.resolved?.members?.get(BigInt(option.value!)),
+        args[option.name] = (interaction.data.resolved?.roles?.get(BigInt(option.value!)) as Role) ?? {
+          user: interaction.data.resolved?.users?.get(BigInt(option.value!)) as User,
+          member: interaction.data.resolved?.members?.get(BigInt(option.value!)) as InteractionResolvedMember,
         }
         break
       default:
-        args[option.name] = option.value
+        args[option.name] = option.value as ParsedInteractionOption[string]
     }
   }
 
   return args
 }
+
+export interface ParsedInteractionOption {
+  [key: string]: string | number | boolean | InteractionResolvedUser | InteractionResolvedChannel | Role | Attachment | ParsedInteractionOption
+}
+
+export interface InteractionResolvedUser {
+  user: User
+  member: InteractionResolvedMember
+}
+
+export type InteractionResolvedChannel = Pick<Channel, 'id' | 'name' | 'type' | 'permissions' | 'threadMetadata' | 'parentId'>
+
+export type InteractionResolvedMember = Omit<Member, 'user' | 'deaf' | 'mute'>

--- a/packages/bot/src/transformers/types.ts
+++ b/packages/bot/src/transformers/types.ts
@@ -66,6 +66,8 @@ import type {
   EmojiToggles,
   GuildFeatureKeys,
   GuildToggles,
+  InteractionResolvedChannel,
+  InteractionResolvedMember,
   MemberToggles,
   Permissions,
   RoleToggles,
@@ -932,9 +934,9 @@ export interface InteractionData {
 export interface InteractionDataResolved {
   messages?: Collection<bigint, Message>
   users?: Collection<bigint, User>
-  members?: Collection<bigint, Member>
+  members?: Collection<bigint, InteractionResolvedMember>
   roles?: Collection<bigint, Role>
-  channels?: Collection<bigint, { id: bigint; name: string; type: ChannelTypes; permissions: bigint }>
+  channels?: Collection<bigint, InteractionResolvedChannel>
   attachments?: Collection<bigint, Attachment>
 }
 


### PR DESCRIPTION
Currently we return `Record<string, any>` from `commandOptionsParser`, this can be problematic as it is not obvious that for `ApplicationCommandOptionTypes.User` and for `ApplicationCommandOptionTypes.Mentionable` (when a user is provided) we return `{ user: User, member: Member }`, this now changes the type to make it more clear.

This fixes the types for the `InteractionDataResolved.channels` and `InteractionDataResolved.members` are they were incorrect