### PR TITLE
fix(discordeno): Add shebang

### DIFF
--- a/packages/discordeno/bin/discordeno.js
+++ b/packages/discordeno/bin/discordeno.js
@@ -1,1 +1,2 @@
+#!/usr/bin/env node
 import('../dist/esm/bin/index.js')


### PR DESCRIPTION
Currently when packaging the `discordeno` package, npm at install will not run the .js file with node but will attempt to directly run the file causing weird behavior 