### PR TITLE
feat(ci): Add discordeno to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: ['gateway', 'rest', 'types', 'utils', 'bot']
+        package: ['gateway', 'rest', 'types', 'utils', 'bot', 'discordeno']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Add the `discordeno` package to the release workflow.

Currently we do not publish it, adding it will make it possible to test the CLI without messing with `.tgz` files

> [!NOTE]
> This will make a dev version of discordeno become the latest version.
> 
> When we will release v19 we will need to add `@<tag>` to the npm command after the package name