### PR TITLE
fix(bot,gateway): Fix (some) resharding bugs 

### DIFF
--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -88,6 +88,12 @@ export function createBot(options: CreateBotOptions): Bot {
         if (!options.gateway?.lastShardId && !options.gateway?.totalShards) bot.gateway.lastShardId = bot.gateway.connection.shards - 1
       }
 
+      if (!bot.gateway.resharding.getSessionInfo) {
+        bot.gateway.resharding.getSessionInfo = async () => {
+          return await bot.rest.getGatewayBot()
+        }
+      }
+
       await bot.gateway.spawnShards()
     },
 

--- a/packages/gateway/src/manager.ts
+++ b/packages/gateway/src/manager.ts
@@ -61,11 +61,9 @@ export function createGatewayManager(options: CreateGatewayManagerOptions): Gate
       shards: new Collection(),
       pendingShards: new Collection(),
       async getSessionInfo() {
-        gateway.logger.error(
+        throw new Error(
           '[Resharding] was enabled but no getSessionInfo handler was provided. Please set a handler like: gateway.resharding.getSessionInfo = async () => { // insert code here to fetch getSessionInfo from rest process. }',
         )
-
-        return null
       },
       async checkIfReshardingIsNeeded() {
         if (!gateway.resharding.enabled) {
@@ -692,13 +690,8 @@ export interface GatewayManager extends Required<CreateGatewayManagerOptions> {
     shards: Collection<number, Shard>
     /** Holds the pending shards that have been created and are pending all shards finish loading. */
     pendingShards: Collection<number, Shard>
-    /**
-     * Handler to get shard count and other session info.
-     *
-     * @remarks
-     * Should never return null. Returning null will skip the resharding
-     */
-    getSessionInfo: () => Promise<Camelize<DiscordGetGatewayBot> | null>
+    /** Handler to get shard count and other session info. */
+    getSessionInfo: () => Promise<Camelize<DiscordGetGatewayBot>>
     /** Handler to edit the shard id on any cached guilds. */
     updateGuildsShardId: (guildIds: string[], shardId: number) => Promise<void>
     /** Handler to check if resharding is necessary. */

--- a/packages/gateway/src/manager.ts
+++ b/packages/gateway/src/manager.ts
@@ -119,12 +119,6 @@ export function createGatewayManager(options: CreateGatewayManagerOptions): Gate
         if (typeof info.lastShardId === 'number') gateway.lastShardId = info.lastShardId
         gateway.logger.warn(`[Resharding] Starting the reshard process. New Total Shards. ${gateway.totalShards}`)
 
-        if (oldShardNumber === gateway.totalShards) {
-          gateway.logger.warn('[Resharding] Aborting the reshard process. The total number of shards is the same')
-
-          return
-        }
-
         // Resetting buckets
         gateway.buckets.clear()
         // Refilling buckets with new values

--- a/packages/gateway/src/manager.ts
+++ b/packages/gateway/src/manager.ts
@@ -230,10 +230,7 @@ export function createGatewayManager(options: CreateGatewayManagerOptions): Gate
         gateway.logger.warn(`[Resharding] Completed.`)
 
         // Replace old shards
-        gateway.shards.clear()
-        for (const shard of gateway.resharding.shards.values()) {
-          gateway.shards.set(shard.id, shard)
-        }
+        gateway.shards = new Collection(gateway.resharding.shards)
 
         // Clear our collections and keep only one reference to the shards, the one in gateway.shards
         gateway.resharding.shards.clear()

--- a/packages/gateway/src/manager.ts
+++ b/packages/gateway/src/manager.ts
@@ -198,7 +198,7 @@ export function createGatewayManager(options: CreateGatewayManagerOptions): Gate
         gateway.logger.warn(`[Resharding] Shard #${shard.id} is now pending`)
 
         // Check if all shards are now online.
-        if (gateway.resharding.shards.size !== gateway.resharding.pendingShards.size) return
+        if (gateway.lastShardId - gateway.firstShardId >= gateway.resharding.pendingShards.size) return
 
         gateway.logger.warn(`[Resharding] All shards are now online.`)
 

--- a/packages/gateway/src/manager.ts
+++ b/packages/gateway/src/manager.ts
@@ -213,11 +213,14 @@ export function createGatewayManager(options: CreateGatewayManagerOptions): Gate
           const oldHandler = shard.events.message
 
           // Change with spread operator to not affect new shards, as changing anything on shard.events will directly change options.events, which changes new shards' events
-          shard.events.message = async (shard, message) => {
-            // Member checks need to continue but others can stop
-            if (message.t === 'GUILD_MEMBERS_CHUNK') {
-              oldHandler?.(shard, message)
-            }
+          shard.events = {
+            ...shard.events,
+            message: async function (_, message) {
+              // Member checks need to continue but others can stop
+              if (message.t === 'GUILD_MEMBERS_CHUNK') {
+                oldHandler?.(shard, message)
+              }
+            },
           }
         }
 

--- a/packages/gateway/src/manager.ts
+++ b/packages/gateway/src/manager.ts
@@ -325,6 +325,9 @@ export function createGatewayManager(options: CreateGatewayManagerOptions): Gate
 
       // Check and reshard automatically if auto resharding is enabled.
       if (gateway.resharding.enabled && gateway.resharding.checkInterval !== -1) {
+        // It is better to ensure there is always only one
+        clearInterval(gateway.resharding.checkIntervalId)
+
         gateway.resharding.checkIntervalId = setInterval(async () => {
           const reshardingInfo = await gateway.resharding.checkIfReshardingIsNeeded()
 
@@ -665,8 +668,8 @@ export interface GatewayManager extends Required<CreateGatewayManagerOptions> {
      * The % of how full a shard is when resharding should be triggered.
      *
      * @remarks
-     * The value is not accurate. We use discord recommended shard value to get an approximation of the shard full percentage that it then compared with this value.
-     * So the bot may not reshard when exactly at the percentage provided but when the percentage is a bit higher and discord has updated the recommended shard count.
+     * We use discord recommended shard value to get an **approximation** of the shard full percentage to compare with this value so the bot may not reshard at the exact percentage provided but may reshard when it is a bit higher than the provided percentage.
+     * For accurate calculation, you may override the `checkIfReshardingIsNeeded` function
      *
      * @default 80 as in 80%
      */

--- a/packages/gateway/src/manager.ts
+++ b/packages/gateway/src/manager.ts
@@ -663,6 +663,11 @@ export interface GatewayManager extends Required<CreateGatewayManagerOptions> {
     enabled: boolean
     /**
      * The % of how full a shard is when resharding should be triggered.
+     *
+     * @remarks
+     * The value is not accurate. We use discord recommended shard value to get an approximation of the shard full percentage that it then compared with this value.
+     * So the bot may not reshard when exactly at the percentage provided but when the percentage is a bit higher and discord has updated the recommended shard count.
+     *
      * @default 80 as in 80%
      */
     shardsFullPercentage: number

--- a/packages/gateway/src/manager.ts
+++ b/packages/gateway/src/manager.ts
@@ -107,7 +107,6 @@ export function createGatewayManager(options: CreateGatewayManagerOptions): Gate
         return { needed: true, info: sessionInfo }
       },
       async reshard(info) {
-        const oldShardNumber = gateway.totalShards
         gateway.logger.warn(`[Resharding] Starting the reshard process. Previous total shards. ${gateway.totalShards}`)
         // Set values on gateway
         gateway.totalShards = info.shards

--- a/packages/gateway/src/manager.ts
+++ b/packages/gateway/src/manager.ts
@@ -66,19 +66,19 @@ export function createGatewayManager(options: CreateGatewayManagerOptions): Gate
         )
       },
       async checkIfReshardingIsNeeded() {
+        gateway.logger.warn('[Resharding] Checking if resharding is needed.')
+
         if (!gateway.resharding.enabled) {
           gateway.logger.debug('[Resharding] Resharding is disabled.')
 
           return { needed: false }
         }
 
-        gateway.logger.warn('[Resharding] Checking if resharding is needed.')
         gateway.logger.warn('[Resharding] Resharding is enabled.')
 
         const sessionInfo = await gateway.resharding.getSessionInfo()
 
-        gateway.logger.warn('[Resharding] Session info retrieved.')
-        gateway.logger.debug(`[Resharding] Session info details: ${JSON.stringify(sessionInfo)}`)
+        gateway.logger.debug(`[Resharding] Session info retrieved: ${JSON.stringify(sessionInfo)}`)
 
         // Don't have enough identify limits to try resharding
         if (sessionInfo.sessionStartLimit.remaining < sessionInfo.shards) {
@@ -226,6 +226,7 @@ export function createGatewayManager(options: CreateGatewayManagerOptions): Gate
         }
 
         gateway.logger.warn(`[Resharding] Shutting down old shards.`)
+        // Close old shards
         await gateway.shutdown(ShardSocketCloseCodes.Resharded, 'Resharded!', false)
 
         gateway.logger.warn(`[Resharding] Completed.`)

--- a/packages/gateway/src/manager.ts
+++ b/packages/gateway/src/manager.ts
@@ -77,12 +77,6 @@ export function createGatewayManager(options: CreateGatewayManagerOptions): Gate
 
         const sessionInfo = await gateway.resharding.getSessionInfo()
 
-        if (!sessionInfo) {
-          gateway.logger.warn("[Resharding] Resharding is enabled however the session info couldn't be fetched.")
-
-          return { needed: false }
-        }
-
         gateway.logger.warn('[Resharding] Session info retrieved.')
         gateway.logger.debug(`[Resharding] Session info details: ${JSON.stringify(sessionInfo)}`)
 

--- a/packages/gateway/src/manager.ts
+++ b/packages/gateway/src/manager.ts
@@ -89,11 +89,12 @@ export function createGatewayManager(options: CreateGatewayManagerOptions): Gate
 
         gateway.logger.warn('[Resharding] Able to reshard, checking whether necessary now.')
 
-        // FIXME: this calculation is clearly wrong to some degree, using 2 shards and 5000 guilds the % should be 100, but is 250
         // 2500 is the max amount of guilds a single shard can handle
         // 1000 is the amount of guilds discord uses to determine how many shards to recommend.
         // This algo helps check if your bot has grown enough to reshard.
-        const percentage = ((2500 * sessionInfo.shards) / (gateway.totalShards * 1000)) * 100
+        // While this is imprecise as discord changes the recommended number of shard every 1000 guilds it is good enough
+        // The alternative is to store the guild count for each shard and require the Guilds intent for `GUILD_CREATE` and `GUILD_DELETE` events
+        const percentage = (sessionInfo.shards / ((gateway.totalShards * 2500) / 1000)) * 100
 
         // Less than necessary% being used so do nothing
         if (percentage < gateway.resharding.shardsFullPercentage) {


### PR DESCRIPTION
Currently the resharding
- Will throw an error if you don't provide a `getSessionInfo`, while we can provide a fallback value if you use `createBot` from `@discordeno/bot`
- Will attempt to reshard regardless of the % of capacity (the formula is bugged)
- Will make `gateway.resharding.shards` and `gateway.shards` be the same collections, create issues at a later point

TODO:
- [x] Find a way to get the correct capacity% shards

(@AwesomeStickz)