### PR TITLE
fix(gateway): Make heartbeat logging clearer

### DIFF
--- a/packages/gateway/src/Shard.ts
+++ b/packages/gateway/src/Shard.ts
@@ -226,7 +226,7 @@ export class DiscordenoShard {
       },
       true,
     )
-    this.logger.debug(`[Gateway] Resuming Shard #${this.id} after send resume`)
+    this.logger.debug(`[Shard] Resuming Shard #${this.id} after send resume`)
 
     return await new Promise((resolve) => {
       this.resolves.set('RESUMED', () => resolve())


### PR DESCRIPTION
Currently our debug logs in `startHeartbeating` consists of `[Gateway] Start Heartbeating Shard #<id>` and then a letter based on the order of the log call.

This pr replaces these logs with more clearer versions of these logs to help with the understanding of these logs without having a direct reference on the code on the side as remembering what each letter means is really difficult.

Also, this removes a few log calls as they were right before/after another one with no real use for both of them