### PR TITLE
fix(bot)!: Remove old unprovided params from event params

### DIFF
--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -221,7 +221,7 @@ export interface EventHandlers {
   messageCreate: (message: Message) => unknown
   messageDelete: (payload: { id: bigint; channelId: bigint; guildId?: bigint }, message?: Message) => unknown
   messageDeleteBulk: (payload: { ids: bigint[]; channelId: bigint; guildId?: bigint }) => unknown
-  messageUpdate: (message: Message, oldMessage?: Message) => unknown
+  messageUpdate: (message: Message) => unknown
   reactionAdd: (payload: {
     userId: bigint
     channelId: bigint

--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -237,7 +237,7 @@ export interface EventHandlers {
   reactionRemove: (payload: { userId: bigint; channelId: bigint; messageId: bigint; guildId?: bigint; emoji: Emoji; burst: boolean }) => unknown
   reactionRemoveEmoji: (payload: { channelId: bigint; messageId: bigint; guildId?: bigint; emoji: Emoji }) => unknown
   reactionRemoveAll: (payload: { channelId: bigint; messageId: bigint; guildId?: bigint }) => unknown
-  presenceUpdate: (presence: PresenceUpdate, oldPresence?: PresenceUpdate) => unknown
+  presenceUpdate: (presence: PresenceUpdate) => unknown
   voiceServerUpdate: (payload: { token: string; endpoint?: string; guildId: bigint }) => unknown
   voiceStateUpdate: (voiceState: VoiceState) => unknown
   channelCreate: (channel: Channel) => unknown


### PR DESCRIPTION
Currently our `bot.events.messageUpdate` and `bot.events.presenceUpdate` accepts 2 parameters, the updated message/presence and the old message/presence, however discord doesn't give the old message/presence, so this removes it as it is never called with that second parameter set to something

> [!WARNING]
> This is breaking because it is changing the `messageUpdate` and `presenceUpdate` events function signature