### PR TITLE
fix(rest): ignore snakelized properties in `changeToDiscordFormat`

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -204,12 +204,15 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
               case 'deny':
                 newObj[key] = typeof value === 'string' ? value : calculateBits(value)
                 continue
+              case 'default_member_permissions':
               case 'defaultMemberPermissions':
                 newObj.default_member_permissions = typeof value === 'string' ? value : calculateBits(value)
                 continue
+              case 'name_localizations':
               case 'nameLocalizations':
                 newObj.name_localizations = value
                 continue
+              case 'name_localizations':
               case 'descriptionLocalizations':
                 newObj.description_localizations = value
                 continue

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -212,7 +212,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
               case 'nameLocalizations':
                 newObj.name_localizations = value
                 continue
-              case 'name_localizations':
+              case 'description_localizations':
               case 'descriptionLocalizations':
                 newObj.description_localizations = value
                 continue


### PR DESCRIPTION
Currently for `nameLocalizations`, `descriptionLocalizations` and some others, we have a special behavior. In the specific case of `nameLocalizations` and `descriptionLocalizations` that will skip the snakelization as that would break the format discord expects.

However, when the rest receives the objects already in the snake_case form (eg in a proxy) it will actually fail the check for `nameLocalizations` and `descriptionLocalizations` breaking the format that discord expects resulting in an error on the request

fixes #3666