### PR TITLE
feat(types)!: Rename `Game` activity type to `Playing`

### DIFF
--- a/packages/types/src/shared.ts
+++ b/packages/types/src/shared.ts
@@ -409,7 +409,7 @@ export enum VideoQualityModes {
 
 /** https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-types */
 export enum ActivityTypes {
-  Game = 0,
+  Playing = 0,
   Streaming = 1,
   Listening = 2,
   Watching = 3,


### PR DESCRIPTION
Rename the `Game` activity type to `Playing`

- upstream: https://github.com/discord/discord-api-docs/pull/7033
- fixes #3804 