### PR TITLE
fix(ci): Add env to `test:e2e` turbo task

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -34,7 +34,8 @@
     },
     "test:e2e": {
       "dependsOn": ["^build"],
-      "outputs": ["coverage/**"]
+      "outputs": ["coverage/**"],
+      "env": ["DISCORD_TOKEN", "UNIT_TEST_GUILD_ID"]
     },
     "lint": {
       "dependsOn": ["build:type"],

--- a/turbo.json
+++ b/turbo.json
@@ -35,7 +35,7 @@
     "test:e2e": {
       "dependsOn": ["^build"],
       "outputs": ["coverage/**"],
-      "env": ["DISCORD_TOKEN", "UNIT_TEST_GUILD_ID"]
+      "env": ["DISCORD_TOKEN", "E2E_TEST_GUILD_ID"]
     },
     "lint": {
       "dependsOn": ["build:type"],


### PR DESCRIPTION
Turbo in v2 does not pass down the environment variables unless manually specified (by default), so the E2E run is failing for the missing environment variable for the `DISCORD_TOKEN` and `UNIT_TEST_GUILD_ID`.

> [!NOTE]
> CI has also add the env for `PROXY_REST_SECRET` and `PROXY_REST_URL`, however they are not used, so i didn't add them to the turborepo configuration 