### PR TITLE
fix(discordeno)!: Fix some errors in `DiscordenoConfig`

### DIFF
--- a/examples/advanced/src/bot.ts
+++ b/examples/advanced/src/bot.ts
@@ -23,7 +23,7 @@ export const bot = createProxyCache(
 // By default, bot.logger will use an instance of the logger from @discordeno/bot, this logger supports depth and we need to change it, so we need to say to TS that we know what we are doing with as
 ;(bot.logger as typeof discordenoLogger).setDepth(LogDepth.Full)
 
-// Setup desired proprieties
+// Setup desired properties
 bot.transformers.desiredProperties.interaction.id = true
 bot.transformers.desiredProperties.interaction.type = true
 bot.transformers.desiredProperties.interaction.data = true

--- a/examples/beginner/src/bot.ts
+++ b/examples/beginner/src/bot.ts
@@ -18,7 +18,7 @@ export const bot = createProxyCache(
   },
 )
 
-// Setup desired proprieties
+// Setup desired properties
 bot.transformers.desiredProperties.interaction.id = true
 bot.transformers.desiredProperties.interaction.type = true
 bot.transformers.desiredProperties.interaction.data = true

--- a/examples/bigbot/src/bot/bot.ts
+++ b/examples/bigbot/src/bot/bot.ts
@@ -19,7 +19,7 @@ export const bot = createCustomBot(
 
 overrideGatewayImplementations(bot)
 
-// TEMPLATE-SETUP: Add/Remove the desired proprieties that you don't need
+// TEMPLATE-SETUP: Add/Remove the desired properties that you don't need
 const props = bot.transformers.desiredProperties
 
 props.interaction.id = true
@@ -32,7 +32,7 @@ props.interaction.guildId = true
 props.user.id = true
 props.user.username = true
 
-// TEMPLATE-SETUP: If you want/need to add any custom proprieties on the Bot type, you can do it in this function and the `CustomBot` type below. Make sure to do it in both or else you will get an error by TypeScript
+// TEMPLATE-SETUP: If you want/need to add any custom properties on the Bot type, you can do it in this function and the `CustomBot` type below. Make sure to do it in both or else you will get an error by TypeScript
 function createCustomBot<TBot extends Bot = Bot>(rawBot: TBot): CustomBot<TBot> {
   const bot = rawBot as CustomBot<TBot>
 

--- a/examples/minimal/src/bot.ts
+++ b/examples/minimal/src/bot.ts
@@ -7,7 +7,7 @@ const rawBot = createBot({
   intents: Intents.Guilds,
 })
 
-// Setup desired proprieties
+// Setup desired properties
 rawBot.transformers.desiredProperties.interaction.id = true
 rawBot.transformers.desiredProperties.interaction.type = true
 rawBot.transformers.desiredProperties.interaction.data = true

--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -6,7 +6,7 @@ import type { BigString, DiscordGatewayPayload, DiscordReady, GatewayIntents, Re
 import { type Collection, createLogger, getBotIdFromToken, type logger } from '@discordeno/utils'
 import { createBotGatewayHandlers } from './handlers.js'
 import { type BotHelpers, createBotHelpers } from './helpers.js'
-import { type Transformers, type TransformersDesiredProprieties, createTransformers } from './transformers.js'
+import { type Transformers, type TransformersDesiredProperties, createTransformers } from './transformers.js'
 import type {
   AuditLogEntry,
   AutoModerationActionExecution,
@@ -135,11 +135,11 @@ export interface CreateBotOptions {
    */
   defaultDesiredPropertiesValue?: boolean
   /**
-   * Set the desired proprieties for the bot
+   * Set the desired properties for the bot
    *
    * @default {}
    */
-  desiredProperties?: RecursivePartial<TransformersDesiredProprieties>
+  desiredProperties?: RecursivePartial<TransformersDesiredProperties>
   /**
    * This factory will be invoked to create the logger for gateway, rest and bot
    *

--- a/packages/bot/src/transformers.ts
+++ b/packages/bot/src/transformers.ts
@@ -243,7 +243,7 @@ export interface Transformers {
     pollMedia: (bot: Bot, payload: DiscordPollMedia, pollMedia: PollMedia) => any
     avatarDecorationData: (bot: Bot, payload: DiscordAvatarDecorationData, avatarDecorationData: AvatarDecorationData) => any
   }
-  desiredProperties: TransformersDesiredProprieties
+  desiredProperties: TransformersDesiredProperties
   reverse: {
     allowedMentions: (bot: Bot, payload: AllowedMentions) => DiscordAllowedMentions
     embed: (bot: Bot, payload: Embed) => DiscordEmbed
@@ -316,7 +316,7 @@ export interface Transformers {
   avatarDecorationData: (bot: Bot, payload: DiscordAvatarDecorationData) => AvatarDecorationData
 }
 
-export interface TransformersDesiredProprieties {
+export interface TransformersDesiredProperties {
   attachment: {
     id: boolean
     filename: boolean
@@ -805,7 +805,7 @@ export function createTransformers(options: RecursivePartial<Transformers>, opts
       pollMedia: options.customizers?.pollMedia ?? defaultCustomizer,
       avatarDecorationData: options.customizers?.avatarDecorationData ?? defaultCustomizer,
     },
-    desiredProperties: createDesiredProprietiesObject(options.desiredProperties ?? {}, opts?.defaultDesiredPropertiesValue ?? false),
+    desiredProperties: createDesiredPropertiesObject(options.desiredProperties ?? {}, opts?.defaultDesiredPropertiesValue ?? false),
     reverse: {
       allowedMentions: options.reverse?.allowedMentions ?? transformAllowedMentionsToDiscordAllowedMentions,
       embed: options.reverse?.embed ?? transformEmbedToDiscordEmbed,
@@ -879,10 +879,10 @@ export function createTransformers(options: RecursivePartial<Transformers>, opts
   }
 }
 
-export function createDesiredProprietiesObject(
-  desiredProperties: RecursivePartial<TransformersDesiredProprieties>,
+export function createDesiredPropertiesObject(
+  desiredProperties: RecursivePartial<TransformersDesiredProperties>,
   defaultValue = false,
-): TransformersDesiredProprieties {
+): TransformersDesiredProperties {
   return {
     attachment: {
       id: defaultValue,

--- a/packages/discordeno/src/bin/config.ts
+++ b/packages/discordeno/src/bin/config.ts
@@ -1,7 +1,7 @@
 import { unlink, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import { pathToFileURL } from 'node:url'
-import { type TransformersDesiredProprieties, createDesiredProprietiesObject, gray } from '@discordeno/bot'
+import { type TransformersDesiredProperties, createDesiredPropertiesObject, gray } from '@discordeno/bot'
 import type { RecursivePartial } from '@discordeno/types'
 import { findUp } from 'find-up'
 import ts from 'typescript'
@@ -24,7 +24,7 @@ export function defineConfig(config: RecursivePartial<DiscordenoConfig>): Discor
   return {
     desiredProperties: {
       behavior: config.desiredProperties?.behavior ?? DesiredPropertiesBehavior.TypeAsNever,
-      properties: createDesiredProprietiesObject(config.desiredProperties?.properties ?? {}),
+      properties: createDesiredPropertiesObject(config.desiredProperties?.properties ?? {}),
     },
   }
 }
@@ -83,6 +83,6 @@ function buildConfig(path: string) {
 export interface DiscordenoConfig {
   desiredProperties: {
     behavior: DesiredPropertiesBehavior
-    properties: TransformersDesiredProprieties
+    properties: TransformersDesiredProperties
   }
 }

--- a/packages/discordeno/src/bin/config.ts
+++ b/packages/discordeno/src/bin/config.ts
@@ -6,7 +6,7 @@ import type { RecursivePartial } from '@discordeno/types'
 import { findUp } from 'find-up'
 import ts from 'typescript'
 
-export enum DesiredProprietiesBehavior {
+export enum DesiredPropertiesBehavior {
   Remove,
   TypeAsNever,
 }
@@ -23,7 +23,7 @@ export const typescriptOptions: ts.CompilerOptions = {
 export function defineConfig(config: RecursivePartial<DiscordenoConfig>): DiscordenoConfig {
   return {
     desiredProperties: {
-      behavior: config.desiredProperties?.behavior ?? DesiredProprietiesBehavior.TypeAsNever,
+      behavior: config.desiredProperties?.behavior ?? DesiredPropertiesBehavior.TypeAsNever,
       properties: createDesiredProprietiesObject(config.desiredProperties?.properties ?? {}),
     },
   }
@@ -82,7 +82,7 @@ function buildConfig(path: string) {
 
 export interface DiscordenoConfig {
   desiredProperties: {
-    behavior: DesiredProprietiesBehavior
-    properties: RecursivePartial<TransformersDesiredProprieties>
+    behavior: DesiredPropertiesBehavior
+    properties: TransformersDesiredProprieties
   }
 }

--- a/packages/discordeno/src/bin/generate/desiredProperty.ts
+++ b/packages/discordeno/src/bin/generate/desiredProperty.ts
@@ -1,7 +1,7 @@
 import type { DiscordenoConfig } from '../config.js'
 
 /** Mapping to all the dependencies a specific getter has */
-const computedDesiredProprieties = {
+const computedDesiredProperties = {
   channel: {
     archived: ['toggles'],
     invitable: ['toggles'],
@@ -73,9 +73,9 @@ export function isPropertyDesired(config: DiscordenoConfig, interfaceName: strin
   const name = pascalCaseToCamelCase(interfaceName)
 
   const interfaceProps = desiredProperties[name as keyof typeof desiredProperties]
-  const computedProps = computedDesiredProprieties[name as keyof typeof computedDesiredProprieties]
+  const computedProps = computedDesiredProperties[name as keyof typeof computedDesiredProperties]
 
-  // This interface does not support desired proprieties, so we include them
+  // This interface does not support desired properties, so we include them
   if (!interfaceProps) {
     return true
   }
@@ -101,7 +101,7 @@ export function isPropertyDesired(config: DiscordenoConfig, interfaceName: strin
 
 export function getPropertyDependencies(interfaceName: string, memberName: string): string[] | undefined {
   const name = pascalCaseToCamelCase(interfaceName)
-  const computedProps = computedDesiredProprieties[name as keyof typeof computedDesiredProprieties]
+  const computedProps = computedDesiredProperties[name as keyof typeof computedDesiredProperties]
 
   if (!computedProps) return undefined
 

--- a/packages/discordeno/src/bin/generate/typescript.ts
+++ b/packages/discordeno/src/bin/generate/typescript.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert'
 import { type WriteStream, createWriteStream } from 'node:fs'
 import ts from 'typescript'
-import { DesiredProprietiesBehavior, type DiscordenoConfig, typescriptOptions } from '../config.js'
+import { DesiredPropertiesBehavior, type DiscordenoConfig, typescriptOptions } from '../config.js'
 import { getPropertyDependencies, isPropertyDesired } from './desiredProperty.js'
 import { writeInterfaceMember, writeJSDoc } from './emitter.js'
 
@@ -102,7 +102,7 @@ function handleUndesiredProperty(
   typeText: string,
   isOptional: boolean,
 ) {
-  if (config.desiredProperties.behavior === DesiredProprietiesBehavior.Remove) return
+  if (config.desiredProperties.behavior === DesiredPropertiesBehavior.Remove) return
 
   const dependencies = getPropertyDependencies(interfaceName, memberName)
 

--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -1183,7 +1183,7 @@ export interface EditMessage {
   components?: MessageComponents
 }
 
-/** Additional proprieties for https://discord.com/developers/docs/interactions/application-commands#get-guild-application-command-permissions and https://discord.com/developers/docs/interactions/application-commands#get-guild-application-command-permissions */
+/** Additional properties for https://discord.com/developers/docs/interactions/application-commands#get-guild-application-command-permissions and https://discord.com/developers/docs/interactions/application-commands#get-guild-application-command-permissions */
 export interface GetApplicationCommandPermissionOptions {
   /** Access token of the user. Requires the `applications.commands.permissions.update` scope */
   accessToken: string


### PR DESCRIPTION
1. Fix typo in DesiredProp**rie**tiesBehavior
2. Remove the RecursivePartial<T> from `DiscordenoConfig.desiredProperies.properties` as it makes the object just harder to work with, as it is "lying" since the object should always be constructed with all the props

> [!WARNING]
> This is breaking since it is renaming a type