### PR TITLE
fix(rest): Add the property if it has `_` to the object

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -194,10 +194,13 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
         const newObj: any = {}
 
         for (const key of Object.keys(obj)) {
-          // If the key is already in snake_case we have no reason for the rest of the code to run.
-          if (key.includes('_')) continue
-
           const value = obj[key]
+
+          // If the key is already in snake_case we can assume it is already in the discord format.
+          if (key.includes('_')) {
+            newObj[key] = value
+            continue
+          }
 
           // Some falsy values should be allowed like null or 0
           if (value !== undefined) {


### PR DESCRIPTION
In #3825 an if was added to ignore all fields that had `_` in the key as they were already in snake_case. However, the check simply ignored the key, but we do not mutate the object, we create another one so all keys with `_` provided to rest are ignored.