### PR TITLE
feat(rest,bot): Add get sticker pack endpoint

### DIFF
--- a/packages/bot/src/helpers.ts
+++ b/packages/bot/src/helpers.ts
@@ -405,6 +405,9 @@ export function createBotHelpers(bot: Bot): BotHelpers {
     getMessages: async (channelId, options) => {
       return (await bot.rest.getMessages(channelId, options)).map((res) => bot.transformers.message(bot, snakelize(res)))
     },
+    getStickerPack: async (stickerPackId) => {
+      return bot.transformers.stickerPack(bot, snakelize(await bot.rest.getStickerPack(stickerPackId)))
+    },
     getStickerPacks: async () => {
       return (await bot.rest.getStickerPacks()).map((res) => bot.transformers.stickerPack(bot, snakelize(res)))
     },
@@ -857,6 +860,7 @@ export interface BotHelpers {
   getInvites: (guildId: BigString) => Promise<Invite[]>
   getMessage: (channelId: BigString, messageId: BigString) => Promise<Message>
   getMessages: (channelId: BigString, options?: GetMessagesOptions) => Promise<Message[]>
+  getStickerPack: (stickerPackId: BigString) => Promise<StickerPack>
   getStickerPacks: () => Promise<StickerPack[]>
   getOriginalInteractionResponse: (token: string) => Promise<Message>
   getPinnedMessages: (channelId: BigString) => Promise<Message[]>

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -1256,6 +1256,10 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       return await rest.get<DiscordMessage[]>(rest.routes.channels.messages(channelId, options))
     },
 
+    async getStickerPack(stickerPackId) {
+      return await rest.get<DiscordStickerPack>(rest.routes.stickerPack(stickerPackId))
+    },
+
     async getStickerPacks() {
       return await rest.get<DiscordStickerPack[]>(rest.routes.stickerPacks())
     },

--- a/packages/rest/src/routes.ts
+++ b/packages/rest/src/routes.ts
@@ -620,6 +620,10 @@ export function createRoutes(): RestRoutes {
       return '/gateway/bot'
     },
 
+    stickerPack(stickerPackId) {
+      return `/sticker-packs/${stickerPackId}`
+    },
+
     stickerPacks() {
       return '/sticker-packs'
     },

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -2045,6 +2045,14 @@ export interface RestManager {
    */
   getMessages: (channelId: BigString, options?: GetMessagesOptions) => Promise<CamelizedDiscordMessage[]>
   /**
+   * Returns a sticker pack for the given ID.
+   *
+   * @returns A {@link CamelizedDiscordStickerPack} object.
+   *
+   * @see {@link https://discord.com/developers/docs/resources/sticker#get-sticker-pack}
+   */
+  getStickerPack: (stickerPackId: BigString) => Promise<CamelizedDiscordStickerPack>
+  /**
    * Returns the list of sticker packs available.
    *
    * @returns A collection of {@link CamelizedDiscordStickerPack} objects assorted by sticker ID.

--- a/packages/rest/src/typings/routes.ts
+++ b/packages/rest/src/typings/routes.ts
@@ -21,6 +21,7 @@ export interface RestRoutes {
   gatewayBot: () => string
   // Standard Sticker Packs
   stickerPacks: () => string
+  stickerPack: (stickerPackId: BigString) => string
   /** Routes for webhook related routes. */
   webhooks: {
     /** Route for managing the original message sent by a webhook. */


### PR DESCRIPTION
Add get sticker pack endpoint

- upstream: https://github.com/discord/discord-api-docs/pull/7065
- fixes #3842 