### PR TITLE
feat(bot,types): Add `approximate_user_install_count` to `DiscordApplication`

### DIFF
--- a/packages/bot/src/transformers/application.ts
+++ b/packages/bot/src/transformers/application.ts
@@ -30,12 +30,22 @@ export function transformApplication(bot: Bot, payload: { application: DiscordAp
       : undefined,
     team: payload.application.team ? bot.transformers.team(bot, payload.application.team) : undefined,
     guildId: payload.application.guild_id ? bot.transformers.snowflake(payload.application.guild_id) : undefined,
+    customInstallUrl: payload.application.custom_install_url,
     // @ts-expect-error the partial here wont break anything
     guild: payload.application.guild ? bot.transformers.guild(bot, { guild: payload.application.guild, shardId: payload.shardId }) : undefined,
     approximateGuildCount: payload.application.approximate_guild_count,
+    approximateUserInstallCount: payload.application.approximate_user_install_count,
     bot: payload.application.bot ? bot.transformers.user(bot, payload.application.bot as DiscordUser) : undefined,
     interactionsEndpointUrl: payload.application.interactions_endpoint_url,
     redirectUris: payload.application.redirect_uris,
+    roleConnectionsVerificationUrl: payload.application.role_connections_verification_url,
+    tags: payload.application.tags,
+    installParams: payload.application.install_params
+      ? {
+          scopes: payload.application.install_params.scopes,
+          permissions: bot.transformers.snowflake(payload.application.install_params.permissions),
+        }
+      : undefined,
     integrationTypesConfig: payload.application.integration_types_config
       ? {
           [DiscordApplicationIntegrationType.GuildInstall]: payload.application.integration_types_config['0']?.oauth2_install_params

--- a/packages/bot/src/transformers/reverse/application.ts
+++ b/packages/bot/src/transformers/reverse/application.ts
@@ -14,6 +14,7 @@ export function transformApplicationToDiscordApplication(bot: Bot, payload: Appl
     slug: payload.slug,
     cover_image: payload.coverImage ? iconBigintToHash(payload.coverImage) : undefined,
     flags: payload.flags,
+    approximate_user_install_count: payload.approximateUserInstallCount,
 
     id: payload.id.toString(),
     icon: payload.icon ? iconBigintToHash(payload.icon) : null,

--- a/packages/bot/src/transformers/types.ts
+++ b/packages/bot/src/transformers/types.ts
@@ -132,11 +132,16 @@ export interface Application {
   botPublic: boolean
   botRequireCodeGrant: boolean
   verifyKey: string
+  customInstallUrl?: string
   approximateGuildCount?: number
+  approximateUserInstallCount?: number
+  installParams?: ApplicationInstallParams
   bot?: User
   redirectUris?: string[]
   interactionsEndpointUrl?: string
   integrationTypesConfig?: Partial<Record<DiscordApplicationIntegrationType, ApplicationIntegrationTypeConfiguration>>
+  roleConnectionsVerificationUrl: string
+  tags: string[]
 }
 
 export interface ApplicationIntegrationTypeConfiguration {

--- a/packages/types/src/discord.ts
+++ b/packages/types/src/discord.ts
@@ -395,6 +395,8 @@ export interface DiscordApplication {
   role_connections_verification_url?: string
   /** An approximate count of the app's guild membership. */
   approximate_guild_count?: number
+  /** Approximate count of users that have installed the app. */
+  approximate_user_install_count?: number
   /** Partial user object for the bot user associated with the app */
   bot?: Partial<DiscordUser>
   /** Array of redirect URIs for the app */
@@ -410,12 +412,7 @@ export interface DiscordApplicationIntegrationTypeConfiguration {
    *
    * https://discord.com/developers/docs/resources/application#install-params-object-install-params-structure
    */
-  oauth2_install_params?: {
-    /** Scopes to add the application to the server with */
-    scopes: OAuth2Scope[]
-    /** Permissions to request for the bot role */
-    permissions: string
-  }
+  oauth2_install_params?: DiscordInstallParams
 }
 
 export enum DiscordApplicationIntegrationType {


### PR DESCRIPTION
Add the `approximate_user_install_count` member to `DiscordApplication` and the `approximateUserInstallCount` memebr to `Application`

This pr also adds a few missing values from `Application` that were declared in `DiscordApplication`

> [!NOTE]
> `approximate_user_install_count` was added to the reverse transformers, however a bunch more proprieties are missing from it. However, since some reverse transformers that are needed are missing this pr does not add the missing members. 

- upstream: https://github.com/discord/discord-api-docs/pull/7070
- fixes: #3843 