### PR TITLE
fix(examples): Add commands dir import to examples register commands script

### DIFF
--- a/examples/advanced/src/register-commands.ts
+++ b/examples/advanced/src/register-commands.ts
@@ -1,7 +1,16 @@
 import 'dotenv/config'
 
 import { bot } from './bot.js'
+import importDirectory from './utils/loader.js'
 import { updateApplicationCommands } from './utils/updateCommands.js'
+
+bot.logger.info('Loading commands...')
+await importDirectory('./dist/commands')
 
 bot.logger.info('Updating commands...')
 await updateApplicationCommands()
+
+bot.logger.info('Done!')
+
+// We need to manually exit as the REST Manager has timeouts that will keep NodeJS alive
+process.exit()

--- a/examples/beginner/src/register-commands.ts
+++ b/examples/beginner/src/register-commands.ts
@@ -2,6 +2,15 @@ import 'dotenv/config'
 
 import { bot } from './bot.js'
 import { updateCommands } from './utils/helpers.js'
+import importDirectory from './utils/loader.js'
+
+bot.logger.info('Loading commands...')
+await importDirectory('./dist/commands')
 
 bot.logger.info('Updating commands...')
 await updateCommands()
+
+bot.logger.info('Done!')
+
+// We need to manually exit as the REST Manager has timeouts that will keep NodeJS alive
+process.exit()

--- a/examples/bigbot/src/bot/register-commands.ts
+++ b/examples/bigbot/src/bot/register-commands.ts
@@ -1,5 +1,19 @@
 import 'dotenv/config'
 
+import { join as joinPath } from 'node:path'
+import { getDirnameFromFileUrl } from '../util.js'
+import { bot } from './bot.js'
+import importDirectory from './utils/loader.js'
 import { updateCommands } from './utils/updateCommands.js'
 
+// The importDirectory function uses 'readdir' that requires either a relative path compared to the process CWD or an absolute one, so to get one relative we need to use import.meta.url
+const currentDirectory = getDirnameFromFileUrl(import.meta.url)
+
+await importDirectory(joinPath(currentDirectory, './commands'))
+
 await updateCommands()
+
+bot.logger.info('Done!')
+
+// We need to manually exit as the REST Manager has timeouts that will keep NodeJS alive
+process.exit()

--- a/examples/minimal/src/register-commands.ts
+++ b/examples/minimal/src/register-commands.ts
@@ -1,7 +1,16 @@
 import 'dotenv/config'
 
+import importDirectory from './utils/loader.js'
 import logger from './utils/logger.js'
 import { updateApplicationCommands } from './utils/updateCommands.js'
 
+logger.info('Loading commands...')
+await importDirectory('./dist/commands')
+
 logger.info('Updating commands...')
 await updateApplicationCommands()
+
+logger.info('Done!')
+
+// We need to manually exit as the REST Manager has timeouts that will keep NodeJS alive
+process.exit()


### PR DESCRIPTION
Currently we do not load the commands before registering them to discord, this makes so it always sends an empty array