### PR TITLE
fix(rest): Use camelCase for body members

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -954,7 +954,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       await rest.patch(rest.routes.guilds.voice(guildId), {
         body: {
           ...options,
-          request_to_speak_timestamp: options.requestToSpeakTimestamp
+          requestToSpeakTimestamp: options.requestToSpeakTimestamp
             ? new Date(options.requestToSpeakTimestamp).toISOString()
             : options.requestToSpeakTimestamp,
         },
@@ -1018,7 +1018,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
     async followAnnouncement(sourceChannelId, targetChannelId, reason) {
       return await rest.post<DiscordFollowedChannel>(rest.routes.channels.follow(sourceChannelId), {
         body: {
-          webhook_channel_id: targetChannelId,
+          webhookChannelId: targetChannelId,
         },
         reason,
       })
@@ -1154,7 +1154,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
 
     async getDmChannel(userId) {
       return await rest.post<DiscordChannel>(rest.routes.channels.dm(), {
-        body: { recipient_id: userId },
+        body: { recipientId: userId },
       })
     },
 


### PR DESCRIPTION
Some of the methods in the REST manager have a hardcoded object literal with the keys instead of an object as a parameter, this is fine as sometimes we need to adjust the object. However, this creates an issue if the body is in `snake_case` and needs to be edited by `changeToDiscordFormat` since #3825.

This pr changes these objects to use `camelCase` member names so that `changeToDiscordFormat` can do its job