### PR TITLE
feat(gateway): Expose `makePresence` from `GatewayManager`

### DIFF
--- a/packages/gateway/src/Shard.ts
+++ b/packages/gateway/src/Shard.ts
@@ -58,6 +58,7 @@ export class DiscordenoShard {
 
     if (options.requestIdentify) this.requestIdentify = options.requestIdentify
     if (options.shardIsReady) this.shardIsReady = options.shardIsReady
+    if (options.makePresence) this.makePresence = options.makePresence
 
     this.bucket = new LeakyBucket({
       max: this.calculateSafeRequests(),
@@ -611,6 +612,8 @@ export interface ShardCreateOptions {
   requestIdentify?: () => Promise<void>
   /** The handler to alert the gateway manager that this shard has received a READY event. */
   shardIsReady?: () => Promise<void>
+  /** Function to create the bot status to send on Identify requests */
+  makePresence?: () => Promise<BotStatusUpdate | undefined>
 }
 
 export default DiscordenoShard

--- a/packages/gateway/src/manager.ts
+++ b/packages/gateway/src/manager.ts
@@ -177,6 +177,7 @@ export function createGatewayManager(options: CreateGatewayManagerOptions): Gate
             gateway.logger.debug(`[Shard] Resolving shard identify request`)
             gateway.buckets.get(shardId % gateway.connection.sessionStartLimit.maxConcurrency)!.identifyRequests.shift()?.()
           },
+          makePresence: gateway.makePresence,
         })
 
         if (gateway.preferSnakeCase) {
@@ -392,7 +393,7 @@ export function createGatewayManager(options: CreateGatewayManagerOptions): Gate
             gateway.logger.debug(`[Shard] Resolving shard identify request`)
             gateway.buckets.get(shardId % gateway.connection.sessionStartLimit.maxConcurrency)!.identifyRequests.shift()?.()
           },
-          makePresence: this.makePresence,
+          makePresence: gateway.makePresence,
         })
 
         if (this.preferSnakeCase) {
@@ -652,7 +653,12 @@ export interface CreateGatewayManagerOptions {
    * @default logger // The logger exported by `@discordeno/utils`
    */
   logger?: Pick<typeof logger, 'debug' | 'info' | 'warn' | 'error' | 'fatal'>
-  /** Make the presence for when the bot connects to the gateway */
+  /**
+   * Make the presence for when the bot connects to the gateway
+   *
+   * @remarks
+   * This function will be called each time a Shard is going to identify
+   */
   makePresence?: () => Promise<BotStatusUpdate | undefined>
 }
 

--- a/packages/gateway/src/manager.ts
+++ b/packages/gateway/src/manager.ts
@@ -32,8 +32,6 @@ export function createGatewayManager(options: CreateGatewayManagerOptions): Gate
     },
   }
 
-  const makePresence = options.makePresence ?? (() => Promise.resolve(undefined))
-
   const gateway: GatewayManager = {
     events: options.events ?? {},
     compress: options.compress ?? false,
@@ -63,7 +61,7 @@ export function createGatewayManager(options: CreateGatewayManagerOptions): Gate
       },
     },
     logger: options.logger ?? logger,
-    makePresence,
+    makePresence: options.makePresence ?? (() => Promise.resolve(undefined)),
     resharding: {
       enabled: true,
       shardsFullPercentage: 80,


### PR DESCRIPTION
Currently the only way to make a shard have a presence is editing it after the shard is connected, however the `DiscordenoShard` class has a `makePresence` that unless it is used manually it cannot be used as the `GatewayManager` does not accept this method.

This pr adds the `makePresence` method to the `GatewayManager` and passes it down when creating a shard