### PR TITLE
feat(bot, rest): Add get guild role endpoint

### DIFF
--- a/packages/bot/src/helpers.ts
+++ b/packages/bot/src/helpers.ts
@@ -437,6 +437,9 @@ export function createBotHelpers(bot: Bot): BotHelpers {
     getRoles: async (guildId) => {
       return snakelize(await bot.rest.getRoles(guildId)).map((role) => bot.transformers.role(bot, { role, guildId }))
     },
+    getRole: async (guildId, roleId) => {
+      return bot.transformers.role(bot, { role: snakelize(await bot.rest.getRole(guildId, roleId)), guildId })
+    },
     getScheduledEvent: async (guildId, eventId, options) => {
       return bot.transformers.scheduledEvent(bot, snakelize(await bot.rest.getScheduledEvent(guildId, eventId, options)))
     },
@@ -876,6 +879,7 @@ export interface BotHelpers {
   getPruneCount: (guildId: BigString, options?: GetGuildPruneCountQuery) => Promise<CamelizedDiscordPrunedCount>
   getPublicArchivedThreads: (channelId: BigString, options?: ListArchivedThreads) => Promise<CamelizedDiscordArchivedThreads>
   getRoles: (guildId: BigString) => Promise<Role[]>
+  getRole: (guildId: BigString, roleId: BigString) => Promise<Role>
   getScheduledEvent: (guildId: BigString, eventId: BigString, options?: { withUserCount?: boolean }) => Promise<ScheduledEvent>
   getScheduledEvents: (guildId: BigString, options?: GetScheduledEvents) => Promise<ScheduledEvent[]>
   getScheduledEventUsers: (

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -1293,6 +1293,10 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       return await rest.get<DiscordRole[]>(rest.routes.guilds.roles.all(guildId))
     },
 
+    async getRole(guildId, roleId) {
+      return await rest.get<DiscordRole>(rest.routes.guilds.roles.one(guildId, roleId))
+    },
+
     async getScheduledEvent(guildId, eventId, options) {
       return await rest.get<DiscordScheduledEvent>(rest.routes.guilds.events.event(guildId, eventId, options?.withUserCount))
     },

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -2171,6 +2171,16 @@ export interface RestManager {
    */
   getRoles: (guildId: BigString) => Promise<CamelizedDiscordRole[]>
   /**
+   * Gets a role by id for a guild.
+   *
+   * @param guildId - The ID of the guild to get role for.
+   * @param roleID - The ID of the role.
+   * @returns A {@link CamelizedDiscordRole} object.
+   *
+   * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-role}
+   */
+  getRole: (guildId: BigString, roleId: BigString) => Promise<CamelizedDiscordRole>
+  /**
    * Gets a scheduled event by its ID.
    *
    * @param guildId - The ID of the guild to get the scheduled event from.


### PR DESCRIPTION
Add the Get Guild Role endpoint

- upstream: https://github.com/discord/discord-api-docs/pull/7074
- fixes #3860 