### PR TITLE
test(rest:e2e): Increase timeout for send a direct message e2e test

### DIFF
--- a/packages/rest/tests/e2e/member.spec.ts
+++ b/packages/rest/tests/e2e/member.spec.ts
@@ -54,7 +54,9 @@ describe('Member tests', () => {
     expect(member2.nick).to.null
   })
 
-  it('Send a direct message', async () => {
+  it('Send a direct message', async function () {
+    this.timeout(60000)
+
     // DM test only on dd unit testing bot
     if (rest.applicationId.toString() !== '770381961553510451') return
     // Itoh Alt ID


### PR DESCRIPTION
Currently the "Send a Direct Message" E2E test fails due to the 30s timeout. This increases it to 60s hoping this is long enough to make it pass