### PR TITLE
fix(types)!: Set `recurrenceRule` as nullable in update guild scheduled event

### DIFF
--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -1126,7 +1126,7 @@ export interface CreateScheduledEvent {
   /** the cover image of the scheduled event */
   image?: string
   /** the definition for how often this event should recur */
-  recurrence_rule?: DiscordScheduledEventRecurrenceRule
+  recurrenceRule?: DiscordScheduledEventRecurrenceRule
 }
 
 export interface EditScheduledEvent {
@@ -1151,7 +1151,7 @@ export interface EditScheduledEvent {
   /** the cover image of the scheduled event */
   image?: string
   /** the definition for how often this event should recur */
-  recurrence_rule?: DiscordScheduledEventRecurrenceRule
+  recurrenceRule?: DiscordScheduledEventRecurrenceRule | null
 }
 
 export interface GetScheduledEvents {


### PR DESCRIPTION
Set `recurrenceRule` as nullable in update guild scheduled event.

- upstream: https://github.com/discord/discord-api-docs/pull/7062 

> [!WARNING]
> This is breaking as the original pr used `snake_case` for `recurrence_rule` in update and create of guild scheduled event. This causes issues of consistency and (potentially) runtime errors such as the ones fixed in #3849 