### PR TITLE
fix(utils): Use `atob` instead of `node:buffer` for `getBotIdFromToken`

### DIFF
--- a/packages/rest/tests/constants.ts
+++ b/packages/rest/tests/constants.ts
@@ -1,3 +1,3 @@
 import { Buffer } from 'node:buffer'
 
-export const fakeToken = `${Buffer.from('1033452747380494366', 'base64').toString()}.zawsxedcrftvgybhu`
+export const fakeToken = `${Buffer.from('1033452747380494366').toString('base64')}.zawsxedcrftvgybhu`

--- a/packages/utils/src/token.ts
+++ b/packages/utils/src/token.ts
@@ -1,5 +1,3 @@
-import { Buffer } from 'node:buffer'
-
 const validTokenPrefixes = ['Bot', 'Bearer']
 
 /** Removes the Bot/Bearer before the token. */
@@ -19,5 +17,5 @@ export function removeTokenPrefix(token?: string, type: 'GATEWAY' | 'REST' = 'RE
 
 /** Get the bot id from the bot token. WARNING: Discord staff has mentioned this may not be stable forever. Use at your own risk. However, note for over 5 years this has never broken. */
 export function getBotIdFromToken(token: string): bigint {
-  return BigInt(Buffer.from(token.split('.')[0], 'base64').toString())
+  return BigInt(atob(token.split('.')[0]))
 }


### PR DESCRIPTION
This replaces the usage of `Buffer` from `node:buffer` with `atob` for `getBotIdFromToken`.

While node calls it "legacy" (stability 3 in the docs) and suggests using `Buffer`, using `atob` has the following advantages:
- It does not make [Vite](https://vitejs.dev) error at build time (`@discordeno/utils` does not have a reason to not being able to be used in a web page, for example the `createOAuth2Link` can be used)
- It throws on invalid characters. This uncovered that the REST unit tests used a token with invalid UTF characters