### PR TITLE
feat(types)!: Action rows are not always the top-level

### DIFF
--- a/packages/types/src/discord.ts
+++ b/packages/types/src/discord.ts
@@ -1645,19 +1645,25 @@ export interface DiscordMessageInteractionMetadata {
   triggering_interaction_metadata?: DiscordMessageInteractionMetadata
 }
 
-export type DiscordMessageComponents = DiscordActionRow[]
+export type DiscordMessageComponents = DiscordMessageComponent[]
+export type DiscordMessageComponent = DiscordActionRow | DiscordSelectMenuComponent | DiscordButtonComponent | DiscordInputTextComponent
 
 /** https://discord.com/developers/docs/interactions/message-components#actionrow */
 export interface DiscordActionRow {
   /** Action rows are a group of buttons. */
-  type: 1
+  type: MessageComponentTypes.ActionRow
   /** The components in this row */
-  components: Array<DiscordSelectMenuComponent | DiscordButtonComponent | DiscordInputTextComponent>
+  components: Exclude<DiscordMessageComponent, DiscordActionRow>[]
 }
 
 /** https://discord.com/developers/docs/interactions/message-components#select-menu-object */
 export interface DiscordSelectMenuComponent {
-  type: MessageComponentTypes.SelectMenu
+  type:
+    | MessageComponentTypes.SelectMenu
+    | MessageComponentTypes.SelectMenuChannels
+    | MessageComponentTypes.SelectMenuRoles
+    | MessageComponentTypes.SelectMenuUsers
+    | MessageComponentTypes.SelectMenuUsersAndRoles
   /** A custom identifier for this component. Maximum 100 characters. */
   custom_id: string
   /** A custom placeholder text if nothing is selected. Maximum 150 characters. */
@@ -1666,10 +1672,23 @@ export interface DiscordSelectMenuComponent {
   min_values?: number
   /** The maximum number of items that can be selected. Default 1. Between 1-25. */
   max_values?: number
+  /**
+   * List of default values for auto-populated select menu components
+   *
+   * @remarks
+   * The number of default values must be in the range defined by min_values and max_values
+   */
+  default_values?: DiscordSelectMenuDefaultValue[]
   /** List of channel types to include in a channel select menu options list */
-  channelTypes?: ChannelTypes[]
+  channel_types?: ChannelTypes[]
   /** The choices! Maximum of 25 items. */
-  options: DiscordSelectOption[]
+  options?: DiscordSelectOption[]
+  /**
+   * Whether select menu is disabled
+   *
+   * @default false
+   */
+  disabled?: boolean
 }
 
 export interface DiscordSelectOption {

--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -113,7 +113,12 @@ export interface ActionRow {
   /** Action rows are a group of buttons. */
   type: MessageComponentTypes.ActionRow
   /** The components in this row */
-  components: Exclude<MessageComponent, ActionRow>[]
+  components:
+    | [Exclude<MessageComponent, ActionRow>]
+    | [ButtonComponent, ButtonComponent]
+    | [ButtonComponent, ButtonComponent, ButtonComponent]
+    | [ButtonComponent, ButtonComponent, ButtonComponent, ButtonComponent]
+    | [ButtonComponent, ButtonComponent, ButtonComponent, ButtonComponent, ButtonComponent]
 }
 
 /** https://discord.com/developers/docs/interactions/message-components#button-object-button-structure */

--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -97,27 +97,23 @@ export interface CreateMessageOptions {
   poll?: CreatePoll
 }
 
-export type MessageComponents = ActionRow[]
+export type MessageComponents = MessageComponent[]
+export type MessageComponent =
+  | ActionRow
+  | ButtonComponent
+  | InputTextComponent
+  | SelectMenuComponent
+  | SelectMenuChannelsComponent
+  | SelectMenuRolesComponent
+  | SelectMenuUsersComponent
+  | SelectMenuUsersAndRolesComponent
 
 /** https://discord.com/developers/docs/interactions/message-components#actionrow */
 export interface ActionRow {
   /** Action rows are a group of buttons. */
   type: MessageComponentTypes.ActionRow
   /** The components in this row */
-  components:
-    | [
-        | ButtonComponent
-        | InputTextComponent
-        | SelectMenuComponent
-        | SelectMenuChannelsComponent
-        | SelectMenuRolesComponent
-        | SelectMenuUsersComponent
-        | SelectMenuUsersAndRolesComponent,
-      ]
-    | [ButtonComponent, ButtonComponent]
-    | [ButtonComponent, ButtonComponent, ButtonComponent]
-    | [ButtonComponent, ButtonComponent, ButtonComponent, ButtonComponent]
-    | [ButtonComponent, ButtonComponent, ButtonComponent, ButtonComponent, ButtonComponent]
+  components: Exclude<MessageComponent, ActionRow>[]
 }
 
 /** https://discord.com/developers/docs/interactions/message-components#button-object-button-structure */


### PR DESCRIPTION
Action-Row are not always at the top-level of a components tree, however they still can't be nested so the types has been adjusted to match this behavior

- Upstream: https://github.com/discord/discord-api-docs/pull/7115

> [!WARNING]
> This is a breaking change due to some members in `DiscordSelectMenuComponent` having an incorrect name.

> [!NOTE]
> Some values on `DiscordSelectMenuComponent` were missing and got added