### PR TITLE
feat(types): Add the poll object to `InteractionCallbackData`

### DIFF
--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -530,6 +530,8 @@ export interface InteractionCallbackData {
   flags?: number
   /** Autocomplete choices (max of 25 choices) */
   choices?: Camelize<DiscordApplicationCommandOptionChoice[]>
+  /** Details about the poll */
+  poll?: CreatePoll
 }
 
 /** https://discord.com/developers/docs/interactions/slash-commands#interaction-response */


### PR DESCRIPTION
Add the poll object to `InteractionCallbackData`, this allows for both sending a poll and edit it in a response

- Upstream: https://github.com/discord/discord-api-docs/pull/7090