### PR TITLE
fix(rest): Fix the remark on `getWebhook`

### DIFF
--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -2368,7 +2368,7 @@ export interface RestManager {
    * @returns An instance of {@link CamelizedDiscordWebhook}.
    *
    * @remarks
-   * Requires the `MANAGE_WEBHOOKS` permission.
+   * Requires the `MANAGE_WEBHOOKS` permission unless the application making the request owns the webhook.
    *
    * @see {@link https://discord.com/developers/docs/resources/webhook#get-webhook}
    */


### PR DESCRIPTION
Fix the remark on `getWebhook`

- upstream: https://github.com/discord/discord-api-docs/pull/7229