### PR TITLE
feat(types,bot): Add command target to interaction response messages

### DIFF
--- a/packages/bot/src/transformers.ts
+++ b/packages/bot/src/transformers.ts
@@ -632,6 +632,8 @@ export interface TransformersDesiredProperties {
     originalResponseMessageId: boolean
     interactedMessageId: boolean
     triggeringInteractionMetadata: boolean
+    targetUser: boolean
+    targetMessageId: boolean
   }
   messageInteraction: {
     id: boolean
@@ -1276,6 +1278,8 @@ export function createDesiredPropertiesObject(
       originalResponseMessageId: defaultValue,
       interactedMessageId: defaultValue,
       triggeringInteractionMetadata: defaultValue,
+      targetMessageId: defaultValue,
+      targetUser: defaultValue,
       ...desiredProperties.messageInteractionMetadata,
     },
     messageInteraction: {

--- a/packages/bot/src/transformers/message.ts
+++ b/packages/bot/src/transformers/message.ts
@@ -262,14 +262,25 @@ export function transformMessageInteractionMetadata(bot: Bot, payload: DiscordMe
         payload.authorizing_integration_owners['1'],
       )
   }
-  if (props.interactedMessageId && payload.interacted_message_id)
-    metadata.interactedMessageId = bot.transformers.snowflake(payload.interacted_message_id)
   if (props.originalResponseMessageId && payload.original_response_message_id)
     metadata.originalResponseMessageId = bot.transformers.snowflake(payload.original_response_message_id)
-  if (props.triggeringInteractionMetadata && payload.triggering_interaction_metadata)
-    metadata.triggeringInteractionMetadata = bot.transformers.messageInteractionMetadata(bot, payload.triggering_interaction_metadata)
   if (props.type) metadata.type = payload.type
   if (props.user && payload.user) metadata.user = bot.transformers.user(bot, payload.user)
+  // Application command metadata
+  if ('target_user' in payload) {
+    if (props.targetUser && payload.target_user) metadata.targetUser = bot.transformers.user(bot, payload.target_user)
+    if (props.targetMessageId && payload.target_message_id) metadata.targetMessageId = bot.transformers.snowflake(payload.target_message_id)
+  }
+  // Message component metadata
+  if ('interacted_message_id' in payload) {
+    if (props.interactedMessageId && payload.interacted_message_id)
+      metadata.interactedMessageId = bot.transformers.snowflake(payload.interacted_message_id)
+  }
+  // Modal submit metadata
+  if ('triggering_interaction_metadata' in payload) {
+    if (props.triggeringInteractionMetadata && payload.triggering_interaction_metadata)
+      metadata.triggeringInteractionMetadata = bot.transformers.messageInteractionMetadata(bot, payload.triggering_interaction_metadata)
+  }
 
   return bot.transformers.customizers.messageInteractionMetadata(bot, payload, metadata)
 }

--- a/packages/bot/src/transformers/types.ts
+++ b/packages/bot/src/transformers/types.ts
@@ -1195,9 +1195,33 @@ export interface MessageInteractionMetadata {
   authorizingIntegrationOwners: Partial<Record<DiscordApplicationIntegrationType, bigint>>
   /** ID of the original response message, present only on follow-up messages */
   originalResponseMessageId?: bigint
-  /** ID of the message that contained interactive component, present only on messages created from component interactions */
+  /**
+   * The user the command was run on, present only on user command interactions
+   *
+   * @remarks
+   * Only present when the interaction metadata is about an application command
+   */
+  targetUser?: User
+  /**
+   * The ID of the message the command was run on, present only on message command interactions. The original response message will also have message_reference and referenced_message pointing to this message.
+   *
+   * @remarks
+   * Only present when the interaction metadata is about an application command
+   */
+  targetMessageId?: bigint
+  /**
+   * ID of the message that contained interactive component, present only on messages created from component interactions
+   *
+   * @remarks
+   * Only present when the interaction metadata is about a message component
+   */
   interactedMessageId?: bigint
-  /** Metadata for the interaction that was used to open the modal, present only on modal submit interactions */
+  /**
+   * Metadata for the interaction that was used to open the modal, present only on modal submit interactions
+   *
+   * @remarks
+   * Only present when the interaction metadata is about a modal submit
+   */
   triggeringInteractionMetadata?: MessageInteractionMetadata
 }
 

--- a/packages/types/src/discord.ts
+++ b/packages/types/src/discord.ts
@@ -1373,8 +1373,8 @@ export interface DiscordMessage {
    */
   stickers?: DiscordSticker[]
   /**
-   * The message associated with the `message_reference`
-   * Note: This field is only returned for messages with a `type` of `19` (REPLY). If the message is a reply but the `referenced_message` field is not present, the backend did not attempt to fetch the message that was being replied to, so its state is unknown. If the field exists but is null, the referenced message was deleted.
+   * The message associated with the 'message_reference'
+   * Note: This field is only returned for messages with a 'type' of '19', '21', or '23'. If the message is one of these but the 'referenced_message' field is not present, the backend did not attempt to fetch the message that was being replied to, so its state is unknown. If the field exists but is null, the referenced message was deleted.
    */
   referenced_message?: DiscordMessage
   /** The message associated with the `message_reference`. This is a minimal subset of fields in a message (e.g. `author` is excluded.)  */
@@ -1674,9 +1674,32 @@ export interface DiscordMessageInteraction {
   member?: Partial<DiscordMember>
 }
 
-/** https://discord.com/developers/docs/resources/channel#message-interaction-metadata-object-message-interaction-metadata-structure */
-export interface DiscordMessageInteractionMetadata {
+/** https://discord.com/developers/docs/resources/message#message-interaction-metadata-object */
+export type DiscordMessageInteractionMetadata =
+  | DiscordApplicationCommandInteractionMetadata
+  | DiscordMessageComponentInteractionMetadata
+  | DiscordModalSubmitInteractionMetadata
+
+/** https://discord.com/developers/docs/resources/message#message-interaction-metadata-object-application-command-interaction-metadata-structure */
+export interface DiscordApplicationCommandInteractionMetadata {
   /** Id of the interaction */
+  id: string
+  /** The type of interaction */
+  type: InteractionTypes
+  /** User who triggered the interaction */
+  user: DiscordUser
+  /** IDs for installation context(s) related to an interaction */
+  authorizing_integration_owners: Partial<Record<`${DiscordApplicationIntegrationType}`, string>>
+  /** ID of the original response message, present only on follow-up messages */
+  original_response_message_id?: string
+  /** The user the command was run on, present only on user command interactions */
+  target_user?: DiscordUser
+  /** The ID of the message the command was run on, present only on message command interactions. The original response message will also have message_reference and referenced_message pointing to this message. */
+  target_message_id?: string
+}
+
+/** https://discord.com/developers/docs/resources/message#message-interaction-metadata-object-message-component-interaction-metadata-structure */
+export interface DiscordMessageComponentInteractionMetadata {
   id: string
   /** The type of interaction */
   type: InteractionTypes
@@ -1688,6 +1711,19 @@ export interface DiscordMessageInteractionMetadata {
   original_response_message_id?: string
   /** ID of the message that contained interactive component, present only on messages created from component interactions */
   interacted_message_id?: string
+}
+
+/** https://discord.com/developers/docs/resources/message#message-interaction-metadata-object-modal-submit-interaction-metadata-structure */
+export interface DiscordModalSubmitInteractionMetadata {
+  id: string
+  /** The type of interaction */
+  type: InteractionTypes
+  /** User who triggered the interaction */
+  user: DiscordUser
+  /** IDs for installation context(s) related to an interaction */
+  authorizing_integration_owners: Partial<Record<`${DiscordApplicationIntegrationType}`, string>>
+  /** ID of the original response message, present only on follow-up messages */
+  original_response_message_id?: string
   /** Metadata for the interaction that was used to open the modal, present only on modal submit interactions */
   triggering_interaction_metadata?: DiscordMessageInteractionMetadata
 }


### PR DESCRIPTION
Add command target to interaction response messages

- Upstream: https://github.com/discord/discord-api-docs/pull/7181