### PR TITLE
fix(bot): Incorrect return type in `interaction.respond`

### DIFF
--- a/packages/bot/src/transformers/channel.ts
+++ b/packages/bot/src/transformers/channel.ts
@@ -20,7 +20,10 @@ export function separateOverwrites(v: bigint): [number, bigint, bigint, bigint] 
   return [Number(unpack64(v, 3)), unpack64(v, 2), unpack64(v, 0), unpack64(v, 1)] as [number, bigint, bigint, bigint]
 }
 
-export const baseChannel = {
+export const baseChannel: Channel = {
+  // This allows typescript to still check for type errors on functions below
+  ...(undefined as unknown as Channel),
+
   get archived() {
     return !!this.toggles?.archived
   },
@@ -62,7 +65,7 @@ export const baseChannel = {
       archived: !!this.toggles?.archived,
     }
   },
-} as Channel
+}
 
 export function transformChannel(bot: Bot, payload: { channel: DiscordChannel } & { guildId?: BigString }): Channel {
   const channel = Object.create(baseChannel) as Channel

--- a/packages/bot/src/transformers/guild.ts
+++ b/packages/bot/src/transformers/guild.ts
@@ -3,7 +3,10 @@ import { Collection, iconHashToBigInt } from '@discordeno/utils'
 import type { Bot, Channel, Guild } from '../index.js'
 import { GuildToggles } from './toggles/guild.js'
 
-const baseGuild = {
+const baseGuild: Guild = {
+  // This allows typescript to still check for type errors on functions below
+  ...(undefined as unknown as Guild),
+
   get threads() {
     if (!this.channels) return new Collection<bigint, Channel>()
 
@@ -16,7 +19,7 @@ const baseGuild = {
   get features() {
     return this.toggles.features
   },
-} as Guild
+}
 
 export function transformGuild(bot: Bot, payload: { guild: DiscordGuild } & { shardId: number }): Guild {
   const guildId = bot.transformers.snowflake(payload.guild.id)

--- a/packages/bot/src/transformers/interaction.ts
+++ b/packages/bot/src/transformers/interaction.ts
@@ -25,7 +25,10 @@ import type {
   Message,
 } from '../index.js'
 
-const baseInteraction = {
+const baseInteraction: Interaction = {
+  // This allows typescript to still check for type errors on functions below
+  ...(undefined as unknown as Interaction),
+
   async respond(response, options) {
     let type = InteractionResponseTypes.ChannelMessageWithSource
 
@@ -104,7 +107,7 @@ const baseInteraction = {
     if (messageId) return await this.bot?.helpers.deleteFollowupMessage(this.token, messageId)
     else return await this.bot?.helpers.deleteOriginalInteractionResponse(this.token)
   },
-} as Interaction
+}
 
 export function transformInteraction(bot: Bot, payload: { interaction: DiscordInteraction; shardId: number }): Interaction {
   const guildId = payload.interaction.guild_id ? bot.transformers.snowflake(payload.interaction.guild_id) : undefined

--- a/packages/bot/src/transformers/member.ts
+++ b/packages/bot/src/transformers/member.ts
@@ -5,7 +5,10 @@ import { Permissions } from './toggles/Permissions.js'
 import { MemberToggles } from './toggles/member.js'
 import type { Member } from './types.js'
 
-const baseMember = {
+const baseMember: Member = {
+  // This allows typescript to still check for type errors on functions below
+  ...(undefined as unknown as Member),
+
   get deaf() {
     return !!this.toggles?.has('deaf')
   },
@@ -30,7 +33,7 @@ const baseMember = {
   get completedOnboarding() {
     return !!this.toggles?.completedOnboarding
   },
-} as Member
+}
 
 export function transformMember(bot: Bot, payload: DiscordMember, guildId: BigString, userId: BigString): Member {
   const member: Member = Object.create(baseMember)

--- a/packages/bot/src/transformers/message.ts
+++ b/packages/bot/src/transformers/message.ts
@@ -12,7 +12,10 @@ import { ToggleBitfield } from './toggles/ToggleBitfield.js'
 
 const EMPTY_STRING = ''
 
-const baseMessage = {
+const baseMessage: Message = {
+  // This allows typescript to still check for type errors on functions below
+  ...(undefined as unknown as Message),
+
   get crossposted() {
     return this.flags?.contains(MessageFlags.Crossposted) ?? false
   },
@@ -123,7 +126,7 @@ const baseMessage = {
     if (value) this.flags.add(MessageFlags.Urgent)
     else this.flags.remove(MessageFlags.Urgent)
   },
-} as Message
+}
 
 export function transformMessage(bot: Bot, payload: DiscordMessage): Message {
   const guildId = payload.guild_id ? bot.transformers.snowflake(payload.guild_id) : undefined

--- a/packages/bot/src/transformers/role.ts
+++ b/packages/bot/src/transformers/role.ts
@@ -3,7 +3,10 @@ import { type Bot, type Role, iconHashToBigInt } from '../index.js'
 import { Permissions } from './toggles/Permissions.js'
 import { RoleToggles } from './toggles/role.js'
 
-const baseRole = {
+const baseRole: Role = {
+  // This allows typescript to still check for type errors on functions below
+  ...(undefined as unknown as Role),
+
   get tags() {
     return {
       botId: this.internalTags?.botId,
@@ -38,7 +41,7 @@ const baseRole = {
   get guildConnections() {
     return !!this.toggles?.has('guildConnections')
   },
-} as Role
+}
 
 export function transformRole(bot: Bot, payload: { role: DiscordRole } & { guildId: BigString }): Role {
   const role: Role = Object.create(baseRole)

--- a/packages/bot/src/transformers/types.ts
+++ b/packages/bot/src/transformers/types.ts
@@ -875,7 +875,10 @@ export interface Interaction {
    *
    * If the interaction has been already acknowledged, indicated by {@link Interaction.acknowledged}, it will send a followup message instead.
    */
-  respond: (response: string | InteractionCallbackData, options?: { isPrivate?: boolean; withResponse?: boolean }) => Promise<Message | void>
+  respond: (
+    response: string | InteractionCallbackData,
+    options?: { isPrivate?: boolean; withResponse?: boolean },
+  ) => Promise<Message | InteractionCallbackResponse | void>
   /**
    * Edit the original response of an interaction or a followup if the message id is provided.
    *

--- a/packages/bot/src/transformers/user.ts
+++ b/packages/bot/src/transformers/user.ts
@@ -2,7 +2,10 @@ import type { DiscordUser } from '@discordeno/types'
 import { iconHashToBigInt } from '@discordeno/utils'
 import { type Bot, ToggleBitfield, type User, UserToggles } from '../index.js'
 
-const baseUser = {
+const baseUser: User = {
+  // This allows typescript to still check for type errors on functions below
+  ...(undefined as unknown as User),
+
   get tag() {
     return `${this.username}#${this.discriminator}`
   },
@@ -18,7 +21,7 @@ const baseUser = {
   get verified() {
     return !!this.toggles?.has('verified')
   },
-} as User
+}
 
 export function transformUser(bot: Bot, payload: DiscordUser): User {
   const user: User = Object.create(baseUser)


### PR DESCRIPTION
This also changes the way we type our base structures, as using `as` was suppressing errors such as the one fixed in this PR