### PR TITLE
ci: Release v19

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,8 @@ jobs:
         if: ${{ github.event_name != 'release' && github.event.action != 'published' }}
         run: node ./scripts/bumpVersionByCommit.js ${{ matrix.package }}
 
-      # If the action is running from a release use the latest tag, otherwise use the dev tag
-      - run: npm publish --tag ${{ github.event_name == 'release' && github.event.action == 'published' && 'latest' || 'dev' }} --access public --provenance
+      # If the action is running from a release use the latest tag, otherwise use the next tag
+      - run: npm publish --tag ${{ github.event_name == 'release' && github.event.action == 'published' && 'latest' || 'next' }} --access public --provenance
         working-directory: packages/${{ matrix.package }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - packages/**
       - .github/**
+  release:
+      types: [published]
   workflow_dispatch:
 
 jobs:
@@ -45,9 +47,11 @@ jobs:
       - name: build Package
         run: yarn release-build --cache-dir=".turbo" --filter=./packages/${{ matrix.package }}
       - name: Bump Package Version
+        if: ${{ github.event_name != 'release' && github.event.action != 'published' }}
         run: node ./scripts/bumpVersionByCommit.js ${{ matrix.package }}
 
-      - run: npm publish --access public
+      # If the action is running from a release use the latest tag, otherwise use the dev tag
+      - run: npm publish --tag ${{ github.event_name == 'release' && github.event.action == 'published' && 'latest' || 'dev' }} --access public --provenance
         working-directory: packages/${{ matrix.package }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discordeno-monorepo",
-  "version": "19.0.0-alpha.1",
+  "version": "19.0.0",
   "private": true,
   "type": "module",
   "workspaces": [
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "chokidar-cli": "^3.0.0",
-    "discordeno": "19.0.0-alpha.1",
+    "discordeno": "19.0.0",
     "husky": "^9.1.6",
     "lint-staged": "^15.2.10",
     "turbo": "^2.3.0",

--- a/packages/benchmarks/package.json
+++ b/packages/benchmarks/package.json
@@ -23,11 +23,11 @@
     "bench": "node dist/index.js"
   },
   "dependencies": {
-    "@discordeno/bot": "19.0.0-beta.1",
-    "@discordeno/gateway": "19.0.0-alpha.1",
-    "@discordeno/rest": "19.0.0-alpha.1",
-    "@discordeno/types": "19.0.0-beta.1",
-    "@discordeno/utils": "19.0.0-beta.1",
+    "@discordeno/bot": "19.0.0",
+    "@discordeno/gateway": "19.0.0",
+    "@discordeno/rest": "19.0.0",
+    "@discordeno/types": "19.0.0",
+    "@discordeno/utils": "19.0.0",
     "benchmark": "^2.1.4"
   },
   "devDependencies": {

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discordeno/bot",
-  "version": "19.0.0-beta.1",
+  "version": "19.0.0",
   "main": "./dist/esm/index.js",
   "exports": {
     "import": "./dist/esm/index.js",
@@ -29,10 +29,10 @@
     "test:test-type": "tsc --project tests/tsconfig.json"
   },
   "dependencies": {
-    "@discordeno/gateway": "19.0.0-alpha.1",
-    "@discordeno/rest": "19.0.0-alpha.1",
-    "@discordeno/types": "19.0.0-beta.1",
-    "@discordeno/utils": "19.0.0-beta.1"
+    "@discordeno/gateway": "19.0.0",
+    "@discordeno/rest": "19.0.0",
+    "@discordeno/types": "19.0.0",
+    "@discordeno/utils": "19.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/packages/discordeno/package.json
+++ b/packages/discordeno/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discordeno",
-  "version": "19.0.0-alpha.1",
+  "version": "19.0.0",
   "main": "./dist/esm/index.js",
   "exports": {
     "import": "./dist/esm/index.js",
@@ -29,11 +29,11 @@
     "test:test-type": "tsc --project tests/tsconfig.json"
   },
   "dependencies": {
-    "@discordeno/bot": "19.0.0-beta.1",
-    "@discordeno/gateway": "19.0.0-alpha.1",
-    "@discordeno/rest": "19.0.0-alpha.1",
-    "@discordeno/types": "19.0.0-beta.1",
-    "@discordeno/utils": "19.0.0-beta.1"
+    "@discordeno/bot": "19.0.0",
+    "@discordeno/gateway": "19.0.0",
+    "@discordeno/rest": "19.0.0",
+    "@discordeno/types": "19.0.0",
+    "@discordeno/utils": "19.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discordeno/gateway",
-  "version": "19.0.0-alpha.1",
+  "version": "19.0.0",
   "main": "./dist/esm/index.js",
   "exports": {
     "import": "./dist/esm/index.js",
@@ -29,8 +29,8 @@
     "test:test-type": "tsc --project tests/tsconfig.json"
   },
   "dependencies": {
-    "@discordeno/types": "19.0.0-beta.1",
-    "@discordeno/utils": "19.0.0-beta.1",
+    "@discordeno/types": "19.0.0",
+    "@discordeno/utils": "19.0.0",
     "ws": "^8.18.0"
   },
   "optionalDependencies": {

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discordeno/rest",
-  "version": "19.0.0-alpha.1",
+  "version": "19.0.0",
   "main": "./dist/esm/index.js",
   "exports": {
     "import": "./dist/esm/index.js",
@@ -30,8 +30,8 @@
     "test:test-type": "tsc --project tests/tsconfig.json"
   },
   "dependencies": {
-    "@discordeno/types": "19.0.0-beta.1",
-    "@discordeno/utils": "19.0.0-beta.1"
+    "@discordeno/types": "19.0.0",
+    "@discordeno/utils": "19.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -62,7 +62,7 @@ import { createRoutes } from './routes.js'
 import type { CreateRequestBodyOptions, CreateRestManagerOptions, MakeRequestOptions, RestManager, SendRequestOptions } from './types.js'
 
 // TODO: make dynamic based on package.json file
-const version = '19.0.0-alpha.1'
+const version = '19.0.0'
 
 export const DISCORD_API_VERSION = 10
 export const DISCORD_API_URL = 'https://discord.com/api'

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discordeno/types",
-  "version": "19.0.0-beta.1",
+  "version": "19.0.0",
   "main": "./dist/esm/index.js",
   "exports": {
     "import": "./dist/esm/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discordeno/utils",
-  "version": "19.0.0-beta.1",
+  "version": "19.0.0",
   "main": "./dist/esm/index.js",
   "exports": {
     "import": "./dist/esm/index.js",
@@ -29,7 +29,7 @@
     "test:test-type": "tsc --project tests/tsconfig.json"
   },
   "dependencies": {
-    "@discordeno/types": "19.0.0-beta.1"
+    "@discordeno/types": "19.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -112,15 +112,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@discordeno/bot@npm:19.0.0-beta.1, @discordeno/bot@workspace:packages/bot":
+"@discordeno/bot@npm:19.0.0, @discordeno/bot@workspace:packages/bot":
   version: 0.0.0-use.local
   resolution: "@discordeno/bot@workspace:packages/bot"
   dependencies:
     "@biomejs/biome": "npm:^1.9.4"
-    "@discordeno/gateway": "npm:19.0.0-alpha.1"
-    "@discordeno/rest": "npm:19.0.0-alpha.1"
-    "@discordeno/types": "npm:19.0.0-beta.1"
-    "@discordeno/utils": "npm:19.0.0-beta.1"
+    "@discordeno/gateway": "npm:19.0.0"
+    "@discordeno/rest": "npm:19.0.0"
+    "@discordeno/types": "npm:19.0.0"
+    "@discordeno/utils": "npm:19.0.0"
     "@swc/cli": "npm:^0.5.0"
     "@swc/core": "npm:^1.9.2"
     "@types/chai": "npm:^5.0.1"
@@ -137,13 +137,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@discordeno/gateway@npm:19.0.0-alpha.1, @discordeno/gateway@workspace:packages/gateway":
+"@discordeno/gateway@npm:19.0.0, @discordeno/gateway@workspace:packages/gateway":
   version: 0.0.0-use.local
   resolution: "@discordeno/gateway@workspace:packages/gateway"
   dependencies:
     "@biomejs/biome": "npm:^1.9.4"
-    "@discordeno/types": "npm:19.0.0-beta.1"
-    "@discordeno/utils": "npm:19.0.0-beta.1"
+    "@discordeno/types": "npm:19.0.0"
+    "@discordeno/utils": "npm:19.0.0"
     "@swc/cli": "npm:^0.5.0"
     "@swc/core": "npm:^1.9.2"
     "@types/chai": "npm:^5.0.1"
@@ -167,13 +167,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@discordeno/rest@npm:19.0.0-alpha.1, @discordeno/rest@workspace:packages/rest":
+"@discordeno/rest@npm:19.0.0, @discordeno/rest@workspace:packages/rest":
   version: 0.0.0-use.local
   resolution: "@discordeno/rest@workspace:packages/rest"
   dependencies:
     "@biomejs/biome": "npm:^1.9.4"
-    "@discordeno/types": "npm:19.0.0-beta.1"
-    "@discordeno/utils": "npm:19.0.0-beta.1"
+    "@discordeno/types": "npm:19.0.0"
+    "@discordeno/utils": "npm:19.0.0"
     "@swc/cli": "npm:^0.5.0"
     "@swc/core": "npm:^1.9.2"
     "@types/chai": "npm:^5.0.1"
@@ -193,7 +193,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@discordeno/types@npm:19.0.0-beta.1, @discordeno/types@workspace:packages/types":
+"@discordeno/types@npm:19.0.0, @discordeno/types@workspace:packages/types":
   version: 0.0.0-use.local
   resolution: "@discordeno/types@workspace:packages/types"
   dependencies:
@@ -210,12 +210,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@discordeno/utils@npm:19.0.0-beta.1, @discordeno/utils@workspace:packages/utils":
+"@discordeno/utils@npm:19.0.0, @discordeno/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@discordeno/utils@workspace:packages/utils"
   dependencies:
     "@biomejs/biome": "npm:^1.9.4"
-    "@discordeno/types": "npm:19.0.0-beta.1"
+    "@discordeno/types": "npm:19.0.0"
     "@swc/cli": "npm:^0.5.0"
     "@swc/core": "npm:^1.9.2"
     "@types/chai": "npm:^5.0.1"
@@ -1031,11 +1031,11 @@ __metadata:
   resolution: "benchmarks@workspace:packages/benchmarks"
   dependencies:
     "@biomejs/biome": "npm:^1.9.4"
-    "@discordeno/bot": "npm:19.0.0-beta.1"
-    "@discordeno/gateway": "npm:19.0.0-alpha.1"
-    "@discordeno/rest": "npm:19.0.0-alpha.1"
-    "@discordeno/types": "npm:19.0.0-beta.1"
-    "@discordeno/utils": "npm:19.0.0-beta.1"
+    "@discordeno/bot": "npm:19.0.0"
+    "@discordeno/gateway": "npm:19.0.0"
+    "@discordeno/rest": "npm:19.0.0"
+    "@discordeno/types": "npm:19.0.0"
+    "@discordeno/utils": "npm:19.0.0"
     "@swc/cli": "npm:^0.5.0"
     "@swc/core": "npm:^1.9.2"
     "@types/benchmark": "npm:^2.1.5"
@@ -1662,7 +1662,7 @@ __metadata:
   dependencies:
     "@biomejs/biome": "npm:^1.9.4"
     chokidar-cli: "npm:^3.0.0"
-    discordeno: "npm:19.0.0-alpha.1"
+    discordeno: "npm:19.0.0"
     husky: "npm:^9.1.6"
     lint-staged: "npm:^15.2.10"
     turbo: "npm:^2.3.0"
@@ -1672,16 +1672,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"discordeno@npm:19.0.0-alpha.1, discordeno@workspace:packages/discordeno":
+"discordeno@npm:19.0.0, discordeno@workspace:packages/discordeno":
   version: 0.0.0-use.local
   resolution: "discordeno@workspace:packages/discordeno"
   dependencies:
     "@biomejs/biome": "npm:^1.9.4"
-    "@discordeno/bot": "npm:19.0.0-beta.1"
-    "@discordeno/gateway": "npm:19.0.0-alpha.1"
-    "@discordeno/rest": "npm:19.0.0-alpha.1"
-    "@discordeno/types": "npm:19.0.0-beta.1"
-    "@discordeno/utils": "npm:19.0.0-beta.1"
+    "@discordeno/bot": "npm:19.0.0"
+    "@discordeno/gateway": "npm:19.0.0"
+    "@discordeno/rest": "npm:19.0.0"
+    "@discordeno/types": "npm:19.0.0"
+    "@discordeno/utils": "npm:19.0.0"
     "@swc/cli": "npm:^0.5.0"
     "@swc/core": "npm:^1.9.2"
     "@types/chai": "npm:^5.0.1"


### PR DESCRIPTION
This bumps the version of all packages to 19.0.0 and also configures the CI release to use `next` tag for commit releases and `latest` if a release has been published

The `next` tag was used because we use `.next-` in the semver suffix for our commit releases

> [!NOTE]
> This also enables NPM release provenance (https://docs.npmjs.com/cli/v10/commands/npm-publish#provenance)