### PR TITLE
fix(bot)!: fix type errors when using `commandOptionsParser`

### DIFF
--- a/packages/bot/src/commandOptionsParser.ts
+++ b/packages/bot/src/commandOptionsParser.ts
@@ -8,6 +8,7 @@ import type {
   Member,
   Role,
   SetupDesiredProps,
+  TransformProperty,
   TransformersDesiredProperties,
   User,
   WithAtLeast,
@@ -73,23 +74,17 @@ export type InteractionResolvedData<TProps extends TransformersDesiredProperties
   | string
   | number
   | boolean
-  | InteractionResolvedUser<TProps, TBehavior>
-  | InteractionResolvedChannel<TProps, TBehavior>
-  | SetupDesiredProps<Role, TProps, TBehavior>
-  | SetupDesiredProps<Attachment, TProps, TBehavior>
+  | TransformProperty<InteractionResolvedUser, TProps, TBehavior>
+  | TransformProperty<InteractionResolvedChannel, TProps, TBehavior>
+  | TransformProperty<Role, TProps, TBehavior>
+  | TransformProperty<Attachment, TProps, TBehavior>
   | ParsedInteractionOption<TProps, TBehavior>
 
-export interface InteractionResolvedUser<TProps extends TransformersDesiredProperties, TBehavior extends DesiredPropertiesBehavior> {
-  user: SetupDesiredProps<User, TProps, TBehavior>
-  member: InteractionResolvedMember<TProps, TBehavior>
+export interface InteractionResolvedUser {
+  user: User
+  member: InteractionResolvedMember
 }
 
-export type InteractionResolvedChannel<TProps extends TransformersDesiredProperties, TBehavior extends DesiredPropertiesBehavior> = Omit<
-  SetupDesiredProps<Channel, TProps, TBehavior>,
-  Exclude<keyof Channel, 'id' | 'name' | 'type' | 'permissions' | 'threadMetadata' | 'parentId'>
->
+export type InteractionResolvedChannel = Pick<Channel, 'id' | 'name' | 'type' | 'permissions' | 'threadMetadata' | 'parentId'>
 
-export type InteractionResolvedMember<TProps extends TransformersDesiredProperties, TBehavior extends DesiredPropertiesBehavior> = Omit<
-  SetupDesiredProps<Member, TProps, TBehavior>,
-  'user' | 'deaf' | 'mute'
->
+export type InteractionResolvedMember = Omit<Member, 'user' | 'deaf' | 'mute'>

--- a/packages/bot/src/commandOptionsParser.ts
+++ b/packages/bot/src/commandOptionsParser.ts
@@ -1,57 +1,95 @@
 import { ApplicationCommandOptionTypes } from '@discordeno/types'
-import type { Attachment, Channel, Interaction, InteractionDataOption, Member, Role, User } from './index.js'
+import type {
+  Attachment,
+  Channel,
+  DesiredPropertiesBehavior,
+  Interaction,
+  InteractionDataOption,
+  Member,
+  Role,
+  SetupDesiredProps,
+  TransformersDesiredProperties,
+  User,
+  WithAtLeast,
+} from './index.js'
 
-export function commandOptionsParser(interaction: Interaction, options?: InteractionDataOption[]): ParsedInteractionOption {
+export function commandOptionsParser<
+  TProps extends WithAtLeast<TransformersDesiredProperties, { interaction: { data: true } }>,
+  TBehavior extends DesiredPropertiesBehavior,
+>(__interaction: SetupDesiredProps<Interaction, TProps, TBehavior>, options?: InteractionDataOption[]): ParsedInteractionOption<TProps, TBehavior> {
+  // This is necessary as typescript gets really confused when using __interaction alone, as it will say that 'data' does not exist despite it surely exist since we have the WithAtLeast
+  const interaction = __interaction as SetupDesiredProps<
+    Interaction,
+    WithAtLeast<TransformersDesiredProperties, { interaction: { data: true } }>,
+    DesiredPropertiesBehavior.RemoveKey
+  >
+
   if (!interaction.data) return {}
   if (!options) options = interaction.data.options ?? []
 
-  const args: ParsedInteractionOption = {}
+  const args: ParsedInteractionOption<TProps, TBehavior> = {}
 
   for (const option of options) {
     switch (option.type) {
       case ApplicationCommandOptionTypes.SubCommandGroup:
       case ApplicationCommandOptionTypes.SubCommand:
-        args[option.name] = commandOptionsParser(interaction, option.options)
+        args[option.name] = commandOptionsParser(interaction, option.options) as InteractionResolvedData<TProps, TBehavior>
         break
       case ApplicationCommandOptionTypes.Channel:
-        args[option.name] = interaction.data.resolved?.channels?.get(BigInt(option.value!)) as InteractionResolvedChannel
+        args[option.name] = interaction.data.resolved?.channels?.get(BigInt(option.value!)) as InteractionResolvedData<TProps, TBehavior>
         break
       case ApplicationCommandOptionTypes.Role:
-        args[option.name] = interaction.data.resolved?.roles?.get(BigInt(option.value!)) as Role
+        args[option.name] = interaction.data.resolved?.roles?.get(BigInt(option.value!)) as InteractionResolvedData<TProps, TBehavior>
         break
       case ApplicationCommandOptionTypes.User:
         args[option.name] = {
-          user: interaction.data.resolved?.users?.get(BigInt(option.value!)) as User,
-          member: interaction.data.resolved?.members?.get(BigInt(option.value!)) as InteractionResolvedMember,
+          user: interaction.data.resolved?.users?.get(BigInt(option.value!)) as InteractionResolvedData<TProps, TBehavior>,
+          member: interaction.data.resolved?.members?.get(BigInt(option.value!)) as InteractionResolvedData<TProps, TBehavior>,
         }
         break
       case ApplicationCommandOptionTypes.Attachment:
-        args[option.name] = interaction.data.resolved?.attachments?.get(BigInt(option.value!)) as Attachment
+        args[option.name] = interaction.data.resolved?.attachments?.get(BigInt(option.value!)) as InteractionResolvedData<TProps, TBehavior>
         break
       case ApplicationCommandOptionTypes.Mentionable:
         // Mentionable are roles or users
-        args[option.name] = (interaction.data.resolved?.roles?.get(BigInt(option.value!)) as Role) ?? {
-          user: interaction.data.resolved?.users?.get(BigInt(option.value!)) as User,
-          member: interaction.data.resolved?.members?.get(BigInt(option.value!)) as InteractionResolvedMember,
+        args[option.name] = (interaction.data.resolved?.roles?.get(BigInt(option.value!)) as ParsedInteractionOption<TProps, TBehavior>[string]) ?? {
+          user: interaction.data.resolved?.users?.get(BigInt(option.value!)) as InteractionResolvedData<TProps, TBehavior>,
+          member: interaction.data.resolved?.members?.get(BigInt(option.value!)) as InteractionResolvedData<TProps, TBehavior>,
         }
         break
       default:
-        args[option.name] = option.value as ParsedInteractionOption[string]
+        args[option.name] = option.value as InteractionResolvedData<TProps, TBehavior>
     }
   }
 
   return args
 }
 
-export interface ParsedInteractionOption {
-  [key: string]: string | number | boolean | InteractionResolvedUser | InteractionResolvedChannel | Role | Attachment | ParsedInteractionOption
+export interface ParsedInteractionOption<TProps extends TransformersDesiredProperties, TBehavior extends DesiredPropertiesBehavior> {
+  [key: string]: InteractionResolvedData<TProps, TBehavior>
 }
 
-export interface InteractionResolvedUser {
-  user: User
-  member: InteractionResolvedMember
+export type InteractionResolvedData<TProps extends TransformersDesiredProperties, TBehavior extends DesiredPropertiesBehavior> =
+  | string
+  | number
+  | boolean
+  | InteractionResolvedUser<TProps, TBehavior>
+  | InteractionResolvedChannel<TProps, TBehavior>
+  | SetupDesiredProps<Role, TProps, TBehavior>
+  | SetupDesiredProps<Attachment, TProps, TBehavior>
+  | ParsedInteractionOption<TProps, TBehavior>
+
+export interface InteractionResolvedUser<TProps extends TransformersDesiredProperties, TBehavior extends DesiredPropertiesBehavior> {
+  user: SetupDesiredProps<User, TProps, TBehavior>
+  member: InteractionResolvedMember<TProps, TBehavior>
 }
 
-export type InteractionResolvedChannel = Pick<Channel, 'id' | 'name' | 'type' | 'permissions' | 'threadMetadata' | 'parentId'>
+export type InteractionResolvedChannel<TProps extends TransformersDesiredProperties, TBehavior extends DesiredPropertiesBehavior> = Omit<
+  SetupDesiredProps<Channel, TProps, TBehavior>,
+  Exclude<keyof Channel, 'id' | 'name' | 'type' | 'permissions' | 'threadMetadata' | 'parentId'>
+>
 
-export type InteractionResolvedMember = Omit<Member, 'user' | 'deaf' | 'mute'>
+export type InteractionResolvedMember<TProps extends TransformersDesiredProperties, TBehavior extends DesiredPropertiesBehavior> = Omit<
+  SetupDesiredProps<Member, TProps, TBehavior>,
+  'user' | 'deaf' | 'mute'
+>

--- a/packages/bot/src/desiredProperties.ts
+++ b/packages/bot/src/desiredProperties.ts
@@ -815,7 +815,7 @@ type GetErrorWhenUndesired<
     TransformersDesiredPropertiesMetadata[KeyByValue<TransformersObjects, T>]['dependencies'],
     TProps[KeyByValue<TransformersObjects, T>]
   >,
-> = TIsDesired extends true ? TransformProperty<T[Key], TProps, TBehavior> : TIsDesired | TransformProperty<T[Key], TProps, TBehavior>
+> = TIsDesired extends true ? TransformProperty<T[Key], TProps, TBehavior> : TIsDesired
 
 type IsObject<T> = T extends object ? (T extends Function ? false : true) : false
 

--- a/packages/bot/src/desiredProperties.ts
+++ b/packages/bot/src/desiredProperties.ts
@@ -820,7 +820,7 @@ type GetErrorWhenUndesired<
 type IsObject<T> = T extends object ? (T extends Function ? false : true) : false
 
 // If the object is a transformed object, a collection of transformed object or an array of transformed objects we need to apply the desired props to them as well
-export type TransformProperty<
+type TransformProperty<
   T,
   TProps extends TransformersDesiredProperties,
   TBehavior extends DesiredPropertiesBehavior,

--- a/packages/bot/src/desiredProperties.ts
+++ b/packages/bot/src/desiredProperties.ts
@@ -820,7 +820,7 @@ type GetErrorWhenUndesired<
 type IsObject<T> = T extends object ? (T extends Function ? false : true) : false
 
 // If the object is a transformed object, a collection of transformed object or an array of transformed objects we need to apply the desired props to them as well
-type TransformProperty<
+export type TransformProperty<
   T,
   TProps extends TransformersDesiredProperties,
   TBehavior extends DesiredPropertiesBehavior,

--- a/packages/bot/src/transformers/interaction.ts
+++ b/packages/bot/src/transformers/interaction.ts
@@ -19,7 +19,6 @@ import type {
   InteractionCallbackResponse,
   InteractionDataOption,
   InteractionDataResolved,
-  InteractionResolvedChannel,
   InteractionResource,
   InternalBot,
   Member,
@@ -236,7 +235,7 @@ export function transformInteractionDataResolved(
   if (payload.resolved.channels) {
     transformed.channels = new Collection(
       Object.entries(payload.resolved.channels).map(([_id, value]) => {
-        const channel = bot.transformers.channel(bot, { channel: value }) as InteractionResolvedChannel
+        const channel = bot.transformers.channel(bot, { channel: value })
         return [channel.id, channel]
       }),
     )

--- a/packages/bot/src/transformers/interaction.ts
+++ b/packages/bot/src/transformers/interaction.ts
@@ -19,6 +19,7 @@ import type {
   InteractionCallbackResponse,
   InteractionDataOption,
   InteractionDataResolved,
+  InteractionResolvedChannel,
   InteractionResource,
   InternalBot,
   Member,
@@ -235,7 +236,7 @@ export function transformInteractionDataResolved(
   if (payload.resolved.channels) {
     transformed.channels = new Collection(
       Object.entries(payload.resolved.channels).map(([_id, value]) => {
-        const channel = bot.transformers.channel(bot, { channel: value })
+        const channel = bot.transformers.channel(bot, { channel: value }) as InteractionResolvedChannel
         return [channel.id, channel]
       }),
     )


### PR DESCRIPTION
Fix the types for `commandOptionsParser`, this also changes the `TransformProperty` to check the nested objects to ensure all objects have the correct desired proprieties applied to them
