### PR TITLE
refactor(bot): export base objects with getters from transformers

### DIFF
--- a/packages/bot/src/transformers/emoji.ts
+++ b/packages/bot/src/transformers/emoji.ts
@@ -2,7 +2,10 @@ import type { DiscordDefaultReactionEmoji, DiscordEmoji } from '@discordeno/type
 import type { DefaultReactionEmoji, Emoji, InternalBot } from '../index.js'
 import { EmojiToggles } from './toggles/emoji.js'
 
-const baseEmoji = {
+export const baseEmoji: InternalBot['transformers']['$inferredTypes']['emoji'] = {
+  // This allows typescript to still check for type errors on functions below
+  ...(undefined as unknown as InternalBot['transformers']['$inferredTypes']['emoji']),
+
   get animated() {
     return this.toggles?.animated
   },
@@ -15,7 +18,7 @@ const baseEmoji = {
   get available() {
     return this.toggles.available
   },
-} as Emoji
+}
 
 export function transformEmoji(bot: InternalBot, payload: DiscordEmoji): typeof bot.transformers.$inferredTypes.emoji {
   const props = bot.transformers.desiredProperties.emoji

--- a/packages/bot/src/transformers/guild.ts
+++ b/packages/bot/src/transformers/guild.ts
@@ -3,7 +3,7 @@ import { Collection, iconHashToBigInt } from '@discordeno/utils'
 import type { Channel, Guild, InternalBot } from '../index.js'
 import { GuildToggles } from './toggles/guild.js'
 
-const baseGuild: InternalBot['transformers']['$inferredTypes']['guild'] = {
+export const baseGuild: InternalBot['transformers']['$inferredTypes']['guild'] = {
   // This allows typescript to still check for type errors on functions below
   ...(undefined as unknown as InternalBot['transformers']['$inferredTypes']['guild']),
 

--- a/packages/bot/src/transformers/interaction.ts
+++ b/packages/bot/src/transformers/interaction.ts
@@ -26,7 +26,7 @@ import type {
   Message,
 } from '../index.js'
 
-const baseInteraction: InternalBot['transformers']['$inferredTypes']['interaction'] = {
+export const baseInteraction: InternalBot['transformers']['$inferredTypes']['interaction'] = {
   // This allows typescript to still check for type errors on functions below
   ...(undefined as unknown as InternalBot['transformers']['$inferredTypes']['interaction']),
 

--- a/packages/bot/src/transformers/member.ts
+++ b/packages/bot/src/transformers/member.ts
@@ -5,7 +5,7 @@ import { Permissions } from './toggles/Permissions.js'
 import { MemberToggles } from './toggles/member.js'
 import type { Member } from './types.js'
 
-const baseMember: InternalBot['transformers']['$inferredTypes']['member'] = {
+export const baseMember: InternalBot['transformers']['$inferredTypes']['member'] = {
   // This allows typescript to still check for type errors on functions below
   ...(undefined as unknown as InternalBot['transformers']['$inferredTypes']['member']),
 

--- a/packages/bot/src/transformers/message.ts
+++ b/packages/bot/src/transformers/message.ts
@@ -20,7 +20,7 @@ import { ToggleBitfield } from './toggles/ToggleBitfield.js'
 
 const EMPTY_STRING = ''
 
-const baseMessage: InternalBot['transformers']['$inferredTypes']['message'] = {
+export const baseMessage: InternalBot['transformers']['$inferredTypes']['message'] = {
   // This allows typescript to still check for type errors on functions below
   ...(undefined as unknown as InternalBot['transformers']['$inferredTypes']['message']),
 

--- a/packages/bot/src/transformers/role.ts
+++ b/packages/bot/src/transformers/role.ts
@@ -3,7 +3,7 @@ import { type InternalBot, type Role, iconHashToBigInt } from '../index.js'
 import { Permissions } from './toggles/Permissions.js'
 import { RoleToggles } from './toggles/role.js'
 
-const baseRole: InternalBot['transformers']['$inferredTypes']['role'] = {
+export const baseRole: InternalBot['transformers']['$inferredTypes']['role'] = {
   // This allows typescript to still check for type errors on functions below
   ...(undefined as unknown as InternalBot['transformers']['$inferredTypes']['role']),
 

--- a/packages/bot/src/transformers/user.ts
+++ b/packages/bot/src/transformers/user.ts
@@ -2,7 +2,7 @@ import type { DiscordUser } from '@discordeno/types'
 import { iconHashToBigInt } from '@discordeno/utils'
 import { type InternalBot, ToggleBitfield, type User, UserToggles } from '../index.js'
 
-const baseUser: InternalBot['transformers']['$inferredTypes']['user'] = {
+export const baseUser: InternalBot['transformers']['$inferredTypes']['user'] = {
   // This allows typescript to still check for type errors on functions below
   ...(undefined as unknown as InternalBot['transformers']['$inferredTypes']['user']),
 


### PR DESCRIPTION
This PR exports objects like `baseGuild`, `baseRole` etc. so users can import it and use if they need (needed for `dd-cache-proxy` to provide the getters like dd does).

Types for `baseEmoji` is also changed to be consistent with others.