### PR TITLE
fix(bot): Add missing breaks in component transformer switch

### DIFF
--- a/packages/bot/src/transformers/component.ts
+++ b/packages/bot/src/transformers/component.ts
@@ -15,16 +15,20 @@ export function transformComponent(bot: Bot, payload: DiscordMessageComponent): 
   switch (payload.type) {
     case MessageComponentTypes.ActionRow:
       component = transformActionRow(bot, payload)
+      break
     case MessageComponentTypes.Button:
       component = transformButtonComponent(bot, payload as DiscordButtonComponent)
+      break
     case MessageComponentTypes.InputText:
       component = transformInputTextComponent(bot, payload as DiscordInputTextComponent)
+      break
     case MessageComponentTypes.SelectMenu:
     case MessageComponentTypes.SelectMenuChannels:
     case MessageComponentTypes.SelectMenuRoles:
     case MessageComponentTypes.SelectMenuUsers:
     case MessageComponentTypes.SelectMenuUsersAndRoles:
       component = transformSelectMenuComponent(bot, payload as DiscordSelectMenuComponent)
+      break
   }
 
   return bot.transformers.customizers.component(bot, payload, component)


### PR DESCRIPTION
Add some missing breaks in the switch in the component transformer that were causing it to return the incorrect set of data most of the times