### PR TITLE
fix(rest): errors returned from makeRequest() doesn't provide more info rest is proxied

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -533,6 +533,10 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
     },
 
     async makeRequest(method, route, options) {
+      // This error needs to be created here because of how stack traces get calculated
+      const error = new Error()
+      error.message = 'Failed to send request to discord.'
+
       if (rest.isProxied) {
         if (rest.authorization) {
           options ??= {}
@@ -543,18 +547,27 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
         const result = await fetch(`${rest.baseUrl}/v${rest.version}${route}`, rest.createRequestBody(method, options))
 
         if (!result.ok) {
+          const errText = await result.text().catch(() => null)
+
+          if (errText) {
+            error.cause = {
+              ok: false,
+              status: result.status,
+              body: errText,
+            }
+
+            throw error
+          }
+
           const err = (await result.json().catch(() => {})) as Record<string, any>
           // Legacy Handling to not break old code or when body is missing
           if (!err?.body) throw new Error(`Error: ${err.message ?? result.statusText}`)
+
           throw new Error(JSON.stringify(err))
         }
 
         return result.status !== 204 ? await result.json() : undefined
       }
-
-      // This error needs to be created here because of how stack traces get calculated
-      const error = new Error()
-      error.message = 'Failed to send request to discord.'
 
       return await new Promise(async (resolve, reject) => {
         const payload: SendRequestOptions = {


### PR DESCRIPTION
Currently when you get an error from rest when you're using a rest proxy, the error message will be like this:

```
Error: Error: 404: Not Found
    at Object.makeRequest (file:///D:/test/dd-test/node_modules/@discordeno/rest/dist/esm/manager.js:412:43)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Object.get (file:///D:/test/dd-test/node_modules/@discordeno/rest/dist/esm/manager.js:442:29)
    at async Object.getGuild (file:///D:/test/dd-test/node_modules/@discordeno/rest/dist/esm/manager.js:1054:20)
    at async Object.getGuild (file:///D:/test/dd-test/node_modules/@discordeno/bot/dist/esm/helpers.js:292:34)
```

But when you get an error while you don't use a rest proxy, the error message will be like this:
```
Error: Failed to send request to discord.
    at Object.makeRequest (file:///D:/test/dd-test/node_modules/@discordeno/rest/dist/esm/manager.js:418:27)
    at Object.get (file:///D:/test/dd-test/node_modules/@discordeno/rest/dist/esm/manager.js:442:40)
    at Object.getGuild (file:///D:/test/dd-test/node_modules/@discordeno/rest/dist/esm/manager.js:1054:31)
    at Object.getGuild (file:///D:/test/dd-test/node_modules/@discordeno/bot/dist/esm/helpers.js:292:49)
    at Timeout._onTimeout (file:///D:/test/dd-test/index.js:59:27)
    at listOnTimeout (node:internal/timers:569:17)
    at process.processTimers (node:internal/timers:512:7) {
  cause: {
    ok: false,
    status: 404,
    body: '{"message": "Unknown Guild", "code": 10004}'
  }
}
```

This PR tries to match the above returned error format (unless there's nothing returned from Discord) even when using a rest proxy