### PR TITLE
fix(gateway): shard.resume() ending in a loop of constant resumes

### DIFF
--- a/packages/gateway/src/manager.ts
+++ b/packages/gateway/src/manager.ts
@@ -355,11 +355,9 @@ export function createGatewayManager(options: CreateGatewayManagerOptions): Gate
       }
     },
     async shutdown(code, reason, clearReshardingInterval = true) {
-      gateway.shards.forEach((shard) => shard.close(code, reason))
-
       if (clearReshardingInterval) clearInterval(gateway.resharding.checkIntervalId)
 
-      await delay(5000)
+      await Promise.all(Array.from(gateway.shards.values()).map((shard) => shard.close(code, reason)))
     },
     async sendPayload(shardId, payload) {
       const shard = gateway.shards.get(shardId)


### PR DESCRIPTION
Currently, calling `shard.resume()` closes old socket (which calls `handleClose()`) and creates a new one and updates `this.socket`. However, resume doesn't wait for the old socket to be closed, so it creates new socket and connects, and then `handleClose()` is being called. This function sets `this.socket` to `undefined`, causing new socket object to be gone, which prevents us from sending heartbeat on the new socket, which causes Discord to send `1000` close close, which makes us try to resume again and this is stuck on a loop (and sometimes stuck on identify loop, causing token to be reset).

This PR fixes that issue by having a function that will be called inside `handleClose` so `resume` can wait until the function is called