### PR TITLE
fix!: Remove `WithAtLeast`

### DIFF
--- a/packages/bot/src/commandOptionsParser.ts
+++ b/packages/bot/src/commandOptionsParser.ts
@@ -2,6 +2,7 @@ import { ApplicationCommandOptionTypes } from '@discordeno/types'
 import type {
   Attachment,
   Channel,
+  CompleteDesiredProperties,
   DesiredPropertiesBehavior,
   Interaction,
   InteractionDataOption,
@@ -11,17 +12,16 @@ import type {
   TransformProperty,
   TransformersDesiredProperties,
   User,
-  WithAtLeast,
 } from './index.js'
 
 export function commandOptionsParser<
-  TProps extends WithAtLeast<TransformersDesiredProperties, { interaction: { data: true } }>,
+  TProps extends TransformersDesiredProperties & { interaction: { data: true } },
   TBehavior extends DesiredPropertiesBehavior,
 >(__interaction: SetupDesiredProps<Interaction, TProps, TBehavior>, options?: InteractionDataOption[]): ParsedInteractionOption<TProps, TBehavior> {
   // This is necessary as typescript gets really confused when using __interaction alone, as it will say that 'data' does not exist despite it surely exist since we have the WithAtLeast
   const interaction = __interaction as SetupDesiredProps<
     Interaction,
-    WithAtLeast<TransformersDesiredProperties, { interaction: { data: true } }>,
+    CompleteDesiredProperties<{ interaction: { data: true } }>,
     DesiredPropertiesBehavior.RemoveKey
   >
 

--- a/packages/bot/src/desiredProperties.ts
+++ b/packages/bot/src/desiredProperties.ts
@@ -729,10 +729,6 @@ type Complete<TObj, TDefault> = {
   [K in keyof TObj]-?: undefined extends TObj[K] ? TDefault : Exclude<TObj[K], undefined>
 }
 
-export type WithAtLeast<T extends TransformersDesiredProperties, AtLeast extends RecursivePartial<TransformersDesiredProperties>> = T & {
-  [K in keyof T]: K extends keyof AtLeast ? Complete<AtLeast[K], false> & T[K] : T[K]
-}
-
 type JoinTuple<T extends string[], TDelimiter extends string> = T extends readonly [infer F extends string, ...infer R extends string[]]
   ? R['length'] extends 0
     ? F


### PR DESCRIPTION
This removes the `WithAtLeast` type helper and replaces its usage with `& { ... }` as they seem to do the same thing.
