### PR TITLE
fix(rest): Use files[n] for uploading files

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -257,7 +257,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       if (options?.files !== undefined) {
         const form = new FormData()
         for (let i = 0; i < options.files.length; ++i) {
-          form.append(`file${i}`, options.files[i].blob, options.files[i].name)
+          form.append(`files[${i}]`, options.files[i].blob, options.files[i].name)
         }
 
         // Have to use changeToDiscordFormat or else JSON.stringify may throw an error for the presence of BigInt(s) in the json


### PR DESCRIPTION
We used `file<n>` instead of `files[<n>]`, while this still works it makes stuff that relies on the file index fail, for example `attachments` when used will error about it being unable to find the file data that the id refers to