### PR TITLE
fix(types,bot)!: Dates are nullable not optional in Entitilement

### DIFF
--- a/packages/bot/src/transformers/types.ts
+++ b/packages/bot/src/transformers/types.ts
@@ -659,9 +659,9 @@ export interface Entitlement {
   type: DiscordEntitlementType
   /** Entitlement was deleted */
   deleted: boolean
-  /** Start date at which the entitlement is valid. Not present when using test entitlements */
+  /** Start date at which the entitlement is valid. */
   startsAt?: number
-  /** Date at which the entitlement is no longer valid. Not present when using test entitlements */
+  /** Date at which the entitlement is no longer valid. */
   endsAt?: number
   /** For consumable items, whether or not the entitlement has been consumed */
   consumed?: boolean

--- a/packages/types/src/discord.ts
+++ b/packages/types/src/discord.ts
@@ -3732,10 +3732,10 @@ export interface DiscordEntitlement {
   type: DiscordEntitlementType
   /** Entitlement was deleted */
   deleted: boolean
-  /** Start date at which the entitlement is valid. Not present when using test entitlements */
-  starts_at?: string
-  /** Date at which the entitlement is no longer valid. Not present when using test entitlements */
-  ends_at?: string
+  /** Start date at which the entitlement is valid. */
+  starts_at: string | null
+  /** Date at which the entitlement is no longer valid. */
+  ends_at: string | null
   /** For consumable items, whether or not the entitlement has been consumed */
   consumed?: boolean
 }


### PR DESCRIPTION
Entitlements dates are nullable and not optional as discord always sends them but with null in some cases

- Upstream: https://github.com/discord/discord-api-docs/pull/7288

> [!WARNING]
> This is breaking as changing a `?: ` (optional) to nullable (`| null`) will cause some type errors if you are using the member