### PR TITLE
fix(gateway): close not resolving in some cases

### DIFF
--- a/packages/gateway/src/Shard.ts
+++ b/packages/gateway/src/Shard.ts
@@ -130,12 +130,17 @@ export class DiscordenoShard {
   async close(code: number, reason: string): Promise<void> {
     if (this.socket?.readyState !== NodeWebSocket.OPEN) return
 
-    this.socket?.close(code, reason)
-
-    // We need to wait for the socket to be fully closed, otherwise there'll be race condition issues if we try to connect again, resulting in unexpected behavior.
-    await new Promise((resolve) => {
+    // This has to be created before the actual call to socket.close as for example Bun calls socket.onclose immediately on the .close() call instead of waiting for the connection to end
+    const promise = new Promise((resolve) => {
       this.resolveAfterClose = resolve
     })
+
+    this.socket.close(code, reason)
+
+    this.logger.debug(`[Shard] Waiting for Shard #${this.id} to close the socket.`)
+
+    // We need to wait for the socket to be fully closed, otherwise there'll be race condition issues if we try to connect again, resulting in unexpected behavior.
+    await promise
 
     // Reset the resolveAfterClose function after it has been resolved.
     this.resolveAfterClose = undefined
@@ -583,6 +588,7 @@ export class DiscordenoShard {
         break
       }
       case GatewayOpcodes.Reconnect: {
+        this.logger.debug(`[Shard] Received a Reconnect for Shard #${this.id}`)
         this.events.requestedReconnect?.(this)
 
         await this.resume()

--- a/packages/gateway/src/Shard.ts
+++ b/packages/gateway/src/Shard.ts
@@ -128,7 +128,12 @@ export class DiscordenoShard {
 
   /** Close the socket connection to discord if present. */
   async close(code: number, reason: string): Promise<void> {
-    if (this.socket?.readyState !== NodeWebSocket.OPEN) return
+    this.logger.debug(`[Shard] Request for Shard #${this.id} to close the socket.`)
+
+    if (this.socket?.readyState !== NodeWebSocket.OPEN) {
+      this.logger.debug(`[Shard] Shard #${this.id}'s ready state is ${this.socket?.readyState}, Unable to close.`)
+      return
+    }
 
     // This has to be created before the actual call to socket.close as for example Bun calls socket.onclose immediately on the .close() call instead of waiting for the connection to end
     const promise = new Promise((resolve) => {
@@ -141,6 +146,8 @@ export class DiscordenoShard {
 
     // We need to wait for the socket to be fully closed, otherwise there'll be race condition issues if we try to connect again, resulting in unexpected behavior.
     await promise
+
+    this.logger.debug(`[Shard] Shard #${this.id} closed the socket.`)
 
     // Reset the resolveAfterClose function after it has been resolved.
     this.resolveAfterClose = undefined


### PR DESCRIPTION
In some case, such as when running in Bun, the `WebSocket.onclose` event handler is fired before we can actually set the `resolveAfterClose` to know that the `WebSocket` and the underlying TCP resources are dropped, so the code never resolved and gets stuck waiting forever