### PR TITLE
Allow edit and deferEdit on modal submit interaction

### DIFF
--- a/packages/bot/src/transformers/interaction.ts
+++ b/packages/bot/src/transformers/interaction.ts
@@ -63,7 +63,7 @@ export const baseInteraction: InternalBot['transformers']['$inferredTypes']['int
 
     if (!this.acknowledged) {
       if (this.type !== InteractionTypes.MessageComponent && this.type !== InteractionTypes.ModalSubmit)
-        throw new Error("This interaction has not been responded to yet and this isn't a MessageComponent interaction.")
+        throw new Error("This interaction has not been responded to yet and this isn't a MessageComponent or ModalSubmit interaction.")
 
       this.acknowledged = true
       return await this.bot.helpers.sendInteractionResponse(
@@ -81,7 +81,7 @@ export const baseInteraction: InternalBot['transformers']['$inferredTypes']['int
     if (this.acknowledged) throw new Error('Cannot defer an already responded interaction.')
 
     if (this.type !== InteractionTypes.MessageComponent && this.type !== InteractionTypes.ModalSubmit)
-      throw new Error("Cannot defer to then edit an interaction that isn't a MessageComponent interaction.")
+      throw new Error("Cannot defer to then edit an interaction that isn't a MessageComponent or ModalSubmit interaction.")
 
     this.acknowledged = true
     return await this.bot.helpers.sendInteractionResponse(this.id, this.token, { type: InteractionResponseTypes.DeferredUpdateMessage }, options)

--- a/packages/bot/src/transformers/interaction.ts
+++ b/packages/bot/src/transformers/interaction.ts
@@ -62,7 +62,7 @@ export const baseInteraction: InternalBot['transformers']['$inferredTypes']['int
     }
 
     if (!this.acknowledged) {
-      if (this.type !== InteractionTypes.MessageComponent)
+      if (this.type !== InteractionTypes.MessageComponent && this.type !== InteractionTypes.ModalSubmit)
         throw new Error("This interaction has not been responded to yet and this isn't a MessageComponent interaction.")
 
       this.acknowledged = true
@@ -80,7 +80,7 @@ export const baseInteraction: InternalBot['transformers']['$inferredTypes']['int
     if (this.type === InteractionTypes.ApplicationCommandAutocomplete) throw new Error('Cannot edit an autocomplete interaction.')
     if (this.acknowledged) throw new Error('Cannot defer an already responded interaction.')
 
-    if (this.type !== InteractionTypes.MessageComponent)
+    if (this.type !== InteractionTypes.MessageComponent && this.type !== InteractionTypes.ModalSubmit)
       throw new Error("Cannot defer to then edit an interaction that isn't a MessageComponent interaction.")
 
     this.acknowledged = true


### PR DESCRIPTION
Allow `ModalSubmit` interactions to be responded to by the `interaction.edit()` function and `interaction.deferEdit()`. Previously, these functions only allowed `MessageComponent` interactions, however modal interactions work as well.

Previously, this was only possible with `bot.helpers.sendInteractionResponse()` with type `InteractionResponseTypes.UpdateMessage`