### PR TITLE
fix(bot): Error out on unknown props for desired prop

### DIFF
--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -23,7 +23,7 @@ import { type Transformers, createTransformers } from './transformers.js'
  * @returns Bot
  */
 export function createBot<
-  TProps extends RecursivePartial<TransformersDesiredProperties>,
+  TProps extends RecursivePartial<TransformersDesiredProperties & { [key: PropertyKey]: never }>,
   TBehavior extends DesiredPropertiesBehavior = DesiredPropertiesBehavior.RemoveKey,
 >(options: CreateBotOptions<TProps, TBehavior>): Bot<CompleteDesiredProperties<TProps>, TBehavior> {
   type CompleteProps = CompleteDesiredProperties<TProps>


### PR DESCRIPTION
Currently if you provide an unknown desired property to `createBot` Typescript is completely cool with it, this should fix it