### PR TITLE
fix(gateway): set a nonce if none is provided for gateway.requestMembers

### DIFF
--- a/denoImportMap.json
+++ b/denoImportMap.json
@@ -1,6 +1,7 @@
 {
   "imports": {
     "node:buffer": "https://deno.land/std@0.176.0/node/buffer.ts",
+    "node:crypto": "https://deno.land/std@0.176.0/node/crypto.ts",
     "node:fs": "https://deno.land/std@0.176.0/node/fs.ts",
     "node:fs/promises": "https://deno.land/std@0.176.0/node/fs/promises.ts",
     "node:events": "https://deno.land/std@0.176.0/node/events.ts",

--- a/packages/gateway/src/manager.ts
+++ b/packages/gateway/src/manager.ts
@@ -818,7 +818,7 @@ export interface GatewayManager extends Required<CreateGatewayManagerOptions> {
    */
   editShardStatus: (shardId: number, data: StatusUpdate) => Promise<void>
   /**
-   * Fetches the list of members for a guild over the gateway. Returns an empty array if `gateway.cache.requestMembers.enabled` is not set and you'll have to handle the `GUILD_MEMBERS_CHUNK` events yourself.
+   * Fetches the list of members for a guild over the gateway. If `gateway.cache.requestMembers.enabled` is not set, this function will return an empty array and you'll have to handle the `GUILD_MEMBERS_CHUNK` events yourself.
    *
    * @param guildId - The ID of the guild to get the list of members for.
    * @param options - The parameters for the fetching of the members.

--- a/packages/gateway/src/manager.ts
+++ b/packages/gateway/src/manager.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto'
 import {
   type AtLeastOne,
   type BigString,
@@ -506,22 +507,32 @@ export function createGatewayManager(options: CreateGatewayManagerOptions): Gate
         options.limit = options.userIds.length
       }
 
-      const members =
-        !gateway.cache.requestMembers.enabled || !options?.nonce
-          ? []
-          : new Promise<Camelize<DiscordMemberWithUser[]>>((resolve, reject) => {
-              // Should never happen.
-              if (!gateway.cache.requestMembers.enabled || !options?.nonce) {
-                reject(new Error("Can't request the members without the nonce or with the feature disabled."))
-                return
-              }
+      if (!options?.nonce) {
+        let nonce = ''
 
-              gateway.cache.requestMembers.pending.set(options.nonce, {
-                nonce: options.nonce,
-                resolve,
-                members: [],
-              })
+        while (!nonce || gateway.cache.requestMembers.pending.has(nonce)) {
+          nonce = randomBytes(16).toString('hex')
+        }
+
+        options ??= { limit: 0 }
+        options.nonce = nonce
+      }
+
+      const members = !gateway.cache.requestMembers.enabled
+        ? []
+        : new Promise<Camelize<DiscordMemberWithUser[]>>((resolve, reject) => {
+            // Should never happen.
+            if (!gateway.cache.requestMembers.enabled || !options?.nonce) {
+              reject(new Error("Can't request the members without the nonce or with the feature disabled."))
+              return
+            }
+
+            gateway.cache.requestMembers.pending.set(options.nonce, {
+              nonce: options.nonce,
+              resolve,
+              members: [],
             })
+          })
 
       await gateway.sendPayload(shardId, {
         op: GatewayOpcodes.RequestGuildMembers,

--- a/packages/gateway/src/manager.ts
+++ b/packages/gateway/src/manager.ts
@@ -818,7 +818,7 @@ export interface GatewayManager extends Required<CreateGatewayManagerOptions> {
    */
   editShardStatus: (shardId: number, data: StatusUpdate) => Promise<void>
   /**
-   * Fetches the list of members for a guild over the gateway.
+   * Fetches the list of members for a guild over the gateway. Returns an empty array if `gateway.cache.requestMembers.enabled` is not set and you'll have to handle the `GUILD_MEMBERS_CHUNK` events yourself.
    *
    * @param guildId - The ID of the guild to get the list of members for.
    * @param options - The parameters for the fetching of the members.


### PR DESCRIPTION
Currently `gateway.requestMembers()` returns an empty array if the user doesn't provide a nonce or the `gateway.cache.requestMembers.enabled` is enabled, this gives users the pain of generating their own nonce if they want members to be returned by this function, which could result in bad implementation so this PR makes it generate a nonce by itself so user doesn't have to and could just use `gateway.requestMembers(guildId)`.

This PR also updates the docs comment for `requestMembers` to clarify about the need for `gateway.cache.requestMembers.enabled` to be set if the user wishes to receive members in return value.