### PR TITLE
fix: add chokidar as dev dependencie 

### DIFF
--- a/examples/bigbot/package.json
+++ b/examples/bigbot/package.json
@@ -32,6 +32,7 @@
     "@swc/core": "^1.9.2",
     "@types/amqplib": "^0.10.5",
     "@types/node": "^22.9.0",
+    "chokidar": "^4.0.3",
     "typescript": "^5.6.3"
   }
 }

--- a/examples/bigbot/yarn.lock
+++ b/examples/bigbot/yarn.lock
@@ -746,6 +746,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chokidar@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "chokidar@npm:4.0.3"
+  dependencies:
+    readdirp: "npm:^4.0.1"
+  checksum: bf2a575ea5596000e88f5db95461a9d59ad2047e939d5a4aac59dd472d126be8f1c1ff3c7654b477cf532d18f42a97279ef80ee847972fd2a25410bf00b80b59
+  languageName: node
+  linkType: hard
+
 "chownr@npm:^2.0.0":
   version: 2.0.0
   resolution: "chownr@npm:2.0.0"
@@ -850,6 +859,7 @@ __metadata:
     "@types/node": "npm:^22.9.0"
     amqplib: "npm:^0.10.4"
     chalk: "npm:^5.3.0"
+    chokidar: "npm:^4.0.3"
     dotenv: "npm:^16.4.7"
     fastify: "npm:^5.1.0"
     typescript: "npm:^5.6.3"
@@ -2156,6 +2166,13 @@ __metadata:
   dependencies:
     readable-stream: "npm:^3.6.0"
   checksum: d3a5bf9d707c01183d546a64864aa63df4d9cb835dfd2bf89ac8305e17389feef2170c4c14415a10d38f9b9bfddf829a57aaef7c53c8b40f11d499844bf8f1a4
+  languageName: node
+  linkType: hard
+
+"readdirp@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "readdirp@npm:4.0.2"
+  checksum: 4ef93103307c7d5e42e78ecf201db58c984c4d66882a27c956250478b49c2444b1ff6aea8ce0f5e4157b2c07ce2fe870ad16c92ebd7c6ff30391ded6e42b9873
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds the chokidar package thats required for the --watch option used by the build:watch command.