### PR TITLE
fix: EmbedsBuilder missing s typo

### DIFF
--- a/packages/utils/src/builders/embeds.ts
+++ b/packages/utils/src/builders/embeds.ts
@@ -12,7 +12,7 @@ import type {
  * A builder to help create Discord embeds.
  *
  * @example
- * const embeds = new EmbedBuilder()
+ * const embeds = new EmbedsBuilder()
  *  .setTitle('My Embed')
  *  .setDescription('This is my new embed')
  *  .newEmbed()


### PR DESCRIPTION
Fixes a small typo in the EmbedsBuilder tsdoc, @itohatweb requsted to make a seperate pr for this in #4077 