### PR TITLE
fix(utils): set Date.now() as timestamp if none is provided in EmbedsBuilder.setTimestamp()

### DIFF
--- a/packages/utils/src/builders/embeds.ts
+++ b/packages/utils/src/builders/embeds.ts
@@ -240,7 +240,7 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
    * @returns {EmbedsBuilder}
    */
   setTimestamp(timestamp?: string | number | Date): this {
-    this.#currentEmbed.timestamp = new Date(timestamp!).toISOString()
+    this.#currentEmbed.timestamp = new Date(timestamp ?? Date.now()).toISOString()
 
     return this
   }


### PR DESCRIPTION
Uses a fallback value if nothing is passed because the timestamp property is marked as optional. This prevents errors when using the function without arguments. If needed I can add a comment to the jsdoc to explain that this is what happends when nothing is being passed into the function since the "default" changed now.