### PR TITLE
feat(rest)!: Parse json body when possibile in rest proxy

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -555,12 +555,12 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
         const result = await fetch(`${rest.baseUrl}/v${rest.version}${route}`, rest.createRequestBody(method, options))
 
         if (!result.ok) {
-          const errText = await result.text().catch(() => null)
+          const body = (result.headers.get('Content-Type') === 'apllication/json' ? await result.json() : await result.text()).catch(() => null)
 
           error.cause = {
             ok: false,
             status: result.status,
-            body: errText,
+            body,
           }
 
           throw error

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -555,7 +555,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
         const result = await fetch(`${rest.baseUrl}/v${rest.version}${route}`, rest.createRequestBody(method, options))
 
         if (!result.ok) {
-          const body = (result.headers.get('Content-Type') === 'apllication/json' ? await result.json() : await result.text()).catch(() => null)
+          const body = (result.headers.get('Content-Type') === 'application/json' ? await result.json() : await result.text()).catch(() => null)
 
           error.cause = {
             ok: false,


### PR DESCRIPTION
Currently we always do `.text()` on the rest proxy response body, however when the server gives us json (or at least claims it does) we can parse it as JSON and use that in the error cause