### PR TITLE
fix(bot): Use desired properties in InteractionResolvedXYZ

### DIFF
--- a/packages/bot/src/commandOptionsParser.ts
+++ b/packages/bot/src/commandOptionsParser.ts
@@ -9,7 +9,6 @@ import type {
   Member,
   Role,
   SetupDesiredProps,
-  TransformProperty,
   TransformersDesiredProperties,
   User,
 } from './index.js'
@@ -74,17 +73,35 @@ export type InteractionResolvedData<TProps extends TransformersDesiredProperties
   | string
   | number
   | boolean
-  | TransformProperty<InteractionResolvedUser, TProps, TBehavior>
-  | TransformProperty<InteractionResolvedChannel, TProps, TBehavior>
-  | TransformProperty<Role, TProps, TBehavior>
-  | TransformProperty<Attachment, TProps, TBehavior>
+  | InteractionResolvedDataUser<TProps, TBehavior>
+  | InteractionResolvedDataChannel<TProps, TBehavior>
+  | SetupDesiredProps<Role, TProps, TBehavior>
+  | SetupDesiredProps<Attachment, TProps, TBehavior>
   | ParsedInteractionOption<TProps, TBehavior>
 
+export interface InteractionResolvedDataUser<TProps extends TransformersDesiredProperties, TBehavior extends DesiredPropertiesBehavior> {
+  user: SetupDesiredProps<User, TProps, TBehavior>
+  member: InteractionResolvedDataMember<TProps, TBehavior>
+}
+
+export type InteractionResolvedDataChannel<TProps extends TransformersDesiredProperties, TBehavior extends DesiredPropertiesBehavior> = Pick<
+  SetupDesiredProps<Channel, TProps, TBehavior>,
+  Extract<keyof SetupDesiredProps<Channel, TProps, TBehavior>, 'id' | 'name' | 'type' | 'permissions' | 'threadMetadata' | 'parentId'>
+>
+
+export type InteractionResolvedDataMember<TProps extends TransformersDesiredProperties, TBehavior extends DesiredPropertiesBehavior> = Omit<
+  SetupDesiredProps<Member, TProps, TBehavior>,
+  'user' | 'deaf' | 'mute'
+>
+
+/** @deprecated Use {@link InteractionResolvedDataUser} */
 export interface InteractionResolvedUser {
   user: User
   member: InteractionResolvedMember
 }
 
+/** @deprecated Use {@link InteractionResolvedDataChannel} */
 export type InteractionResolvedChannel = Pick<Channel, 'id' | 'name' | 'type' | 'permissions' | 'threadMetadata' | 'parentId'>
 
+/** @deprecated Use {@link InteractionResolvedDataMember} */
 export type InteractionResolvedMember = Omit<Member, 'user' | 'deaf' | 'mute'>


### PR DESCRIPTION
Currently the `InteractionResolvedUser`, `InteractionResolvedChannel` and `InteractionResolvedMember` used the complete `User`, `Channel`, `Member` without any desired properties and relied on the user to apply them, which is not really feasible even when using `TransformProperty` like we were doing, as that will need to have the entire object to work

> [!NOTE]
> The old types still exist, new types named `InteractionResolvedDataXYZ` now use desired properties directly, however they are marked as deprecated