### PR TITLE
fix(shutdown): prevent resume when closed with `GatewayCloseEventCodes.NormalClosure`.

### DIFF
--- a/packages/gateway/src/Shard.ts
+++ b/packages/gateway/src/Shard.ts
@@ -407,6 +407,7 @@ export class DiscordenoShard {
       }
       // On these codes a manual start will be done.
       case GatewayCloseEventCodes.NormalClosure:
+      case GatewayCloseEventCodes.GoingAway:
       case ShardSocketCloseCodes.Shutdown:
       case ShardSocketCloseCodes.ReIdentifying:
       case ShardSocketCloseCodes.Resharded:

--- a/packages/gateway/src/Shard.ts
+++ b/packages/gateway/src/Shard.ts
@@ -406,6 +406,7 @@ export class DiscordenoShard {
         return
       }
       // On these codes a manual start will be done.
+      case GatewayCloseEventCodes.NormalClosure:
       case ShardSocketCloseCodes.Shutdown:
       case ShardSocketCloseCodes.ReIdentifying:
       case ShardSocketCloseCodes.Resharded:

--- a/packages/types/src/shared.ts
+++ b/packages/types/src/shared.ts
@@ -830,6 +830,8 @@ export type PermissionStrings = keyof typeof BitwisePermissionFlags
 export enum GatewayCloseEventCodes {
   /** A normal closure of the gateway. You may attempt to reconnect. */
   NormalClosure = 1000,
+  /** The endpoint is going away. Invalidates bot and bot will appear offline.  */
+  GoingAway = 1001,
   /** We're not sure what went wrong. Try reconnecting? */
   UnknownError = 4000,
   /** You sent an invalid [Gateway opcode](https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-opcodes) or an invalid payload for an opcode. Don't do that! */


### PR DESCRIPTION
According to Discord developers portal documentation page, [initializing a disconnect](https://discord.com/developers/docs/events/gateway#initiating-a-disconnect) section suggests that close codes `1000` (`GatewayCloseEventCodes.NormalClosure`) and `1001` will invalidate bot and bot will appear offline. By taking a look at how shutting down process works in `discordeno`, it seemed like the library is lacking the ability to fully shutdown with the bot appearing offline.

Therefore, I experimented with closing gateway manually by providing the close codes `1000` and `1001`. The code `1001` is not allowed by `discordeno`, which is fine. However, the code `1000` triggers session resume, which I assumed a bug.

I kindly ask to review my pull request and consider the little change I've added. Appreciated in advance!

Open to discussions!