### PR TITLE
docs: Use as instead of specifying the generic

### DIFF
--- a/website/docs/desired-properties.md
+++ b/website/docs/desired-properties.md
@@ -194,9 +194,9 @@ const desiredProperties = createDesiredPropertiesObject({
 
 interface BotDesiredProperties extends Required<typeof desiredProperties> {}
 
-const bot = createBot<BotDesiredProperties>({
+const bot = createBot({
   // Your usual createBot options, such as token and intents
-  desiredProperties,
+  desiredProperties: desiredProperties as BotDesiredProperties,
 });
 ```
 


### PR DESCRIPTION
If we specify the generic other generics stop being inferred so if we specify the desired properties behavior to ChangeType it type errors as TS still thinks that it should be RemoveKey