### PR TITLE
feat!: add missing params to getThreadMember() and getThreadMembers()

### DIFF
--- a/packages/bot/src/helpers.ts
+++ b/packages/bot/src/helpers.ts
@@ -74,6 +74,7 @@ import type {
   GetReactions,
   GetScheduledEventUsers,
   GetScheduledEvents,
+  GetThreadMember,
   GetUserGuilds,
   GetWebhookMessageOptions,
   InteractionCallbackData,
@@ -82,6 +83,7 @@ import type {
   ListArchivedThreads,
   ListGuildMembers,
   ListSkuSubscriptionsOptions,
+  ListThreadMembers,
   MfaLevels,
   ModifyApplicationEmoji,
   ModifyChannel,
@@ -489,11 +491,11 @@ export function createBotHelpers<TProps extends TransformersDesiredProperties, T
     getSticker: async (stickerId) => {
       return bot.transformers.sticker(bot, snakelize(await bot.rest.getSticker(stickerId)))
     },
-    getThreadMember: async (channelId, userId) => {
-      return bot.transformers.threadMember(bot, snakelize(await bot.rest.getThreadMember(channelId, userId)))
+    getThreadMember: async (channelId, userId, options) => {
+      return bot.transformers.threadMember(bot, snakelize(await bot.rest.getThreadMember(channelId, userId, options)))
     },
-    getThreadMembers: async (channelId) => {
-      return (await bot.rest.getThreadMembers(channelId)).map((res) => bot.transformers.threadMember(bot, snakelize(res)))
+    getThreadMembers: async (channelId, options) => {
+      return (await bot.rest.getThreadMembers(channelId, options)).map((res) => bot.transformers.threadMember(bot, snakelize(res)))
     },
     getReactions: async (channelId, messageId, reaction, options) => {
       return (await bot.rest.getReactions(channelId, messageId, reaction, options)).map((res) => bot.transformers.user(bot, snakelize(res)))
@@ -1003,8 +1005,8 @@ export type BotHelpers<TProps extends TransformersDesiredProperties, TBehavior e
   getOwnVoiceState: (guildId: BigString) => Promise<SetupDesiredProps<VoiceState, TProps, TBehavior>>
   getUserVoiceState: (guildId: BigString, userId: BigString) => Promise<SetupDesiredProps<VoiceState, TProps, TBehavior>>
   getSticker: (stickerId: BigString) => Promise<SetupDesiredProps<Sticker, TProps, TBehavior>>
-  getThreadMember: (channelId: BigString, userId: BigString) => Promise<ThreadMember>
-  getThreadMembers: (channelId: BigString) => Promise<ThreadMember[]>
+  getThreadMember: (channelId: BigString, userId: BigString, options: GetThreadMember) => Promise<ThreadMember>
+  getThreadMembers: (channelId: BigString, options: ListThreadMembers) => Promise<ThreadMember[]>
   getReactions: (
     channelId: BigString,
     messageId: BigString,

--- a/packages/bot/src/helpers.ts
+++ b/packages/bot/src/helpers.ts
@@ -1005,8 +1005,8 @@ export type BotHelpers<TProps extends TransformersDesiredProperties, TBehavior e
   getOwnVoiceState: (guildId: BigString) => Promise<SetupDesiredProps<VoiceState, TProps, TBehavior>>
   getUserVoiceState: (guildId: BigString, userId: BigString) => Promise<SetupDesiredProps<VoiceState, TProps, TBehavior>>
   getSticker: (stickerId: BigString) => Promise<SetupDesiredProps<Sticker, TProps, TBehavior>>
-  getThreadMember: (channelId: BigString, userId: BigString, options: GetThreadMember) => Promise<ThreadMember>
-  getThreadMembers: (channelId: BigString, options: ListThreadMembers) => Promise<ThreadMember[]>
+  getThreadMember: (channelId: BigString, userId: BigString, options?: GetThreadMember) => Promise<ThreadMember>
+  getThreadMembers: (channelId: BigString, options?: ListThreadMembers) => Promise<ThreadMember[]>
   getReactions: (
     channelId: BigString,
     messageId: BigString,

--- a/packages/bot/src/transformers.ts
+++ b/packages/bot/src/transformers.ts
@@ -470,7 +470,12 @@ export type Transformers<TProps extends TransformersDesiredProperties, TBehavior
     bot: Bot<TProps, TBehavior>,
     payload: DiscordInviteStageInstance & { guildId: BigString },
   ) => SetupDesiredProps<InviteStageInstance, TProps, TBehavior>
-  member: (bot: Bot<TProps, TBehavior>, payload: DiscordMember, guildId: BigString, userId: BigString) => SetupDesiredProps<Member, TProps, TBehavior>
+  member: (
+    bot: Bot<TProps, TBehavior>,
+    payload: DiscordMember,
+    guildId: BigString | undefined,
+    userId: BigString,
+  ) => SetupDesiredProps<Member, TProps, TBehavior>
   message: (bot: Bot<TProps, TBehavior>, payload: { message: DiscordMessage; shardId: number }) => SetupDesiredProps<Message, TProps, TBehavior>
   messageCall: (bot: Bot<TProps, TBehavior>, payload: DiscordMessageCall) => SetupDesiredProps<MessageCall, TProps, TBehavior>
   messageInteractionMetadata: (

--- a/packages/bot/src/transformers/threadMember.ts
+++ b/packages/bot/src/transformers/threadMember.ts
@@ -7,7 +7,7 @@ export function transformThreadMember(bot: Bot, payload: DiscordThreadMember): T
     userId: payload.user_id ? bot.transformers.snowflake(payload.user_id) : undefined,
     joinTimestamp: Date.parse(payload.join_timestamp),
     flags: payload.flags,
-    member: payload.member ? bot.transformers.member(bot, payload.member, 0n, bot.transformers.snowflake(payload.user_id)) : undefined,
+    member: payload.member ? bot.transformers.member(bot, payload.member, undefined, bot.transformers.snowflake(payload.user_id)) : undefined,
   } as ThreadMember
 
   return bot.transformers.customizers.threadMember(bot, payload, threadMember)

--- a/packages/bot/src/transformers/threadMember.ts
+++ b/packages/bot/src/transformers/threadMember.ts
@@ -7,6 +7,7 @@ export function transformThreadMember(bot: Bot, payload: DiscordThreadMember): T
     userId: payload.user_id ? bot.transformers.snowflake(payload.user_id) : undefined,
     joinTimestamp: Date.parse(payload.join_timestamp),
     flags: payload.flags,
+    member: payload.member ? bot.transformers.member(bot, payload.member, 0n, bot.transformers.snowflake(payload.user_id)) : undefined,
   } as ThreadMember
 
   return bot.transformers.customizers.threadMember(bot, payload, threadMember)

--- a/packages/bot/src/transformers/types.ts
+++ b/packages/bot/src/transformers/types.ts
@@ -1033,8 +1033,13 @@ export interface Member {
   id: bigint
   /** The compressed form of all the boolean values on this user. */
   toggles?: MemberToggles
-  /** The guild id where this member is. */
-  guildId: bigint
+  /**
+   * The guild id where this member is.
+   *
+   * @remarks
+   * This will always be present unless the member object is from thread member object.
+   * */
+  guildId?: bigint
   /** The user this guild member represents */
   user?: User
   /** This user's guild nickname */

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -1356,12 +1356,12 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       return await rest.get<DiscordSticker[]>(rest.routes.guilds.stickers(guildId))
     },
 
-    async getThreadMember(channelId, userId) {
-      return await rest.get<DiscordThreadMember>(rest.routes.channels.threads.user(channelId, userId))
+    async getThreadMember(channelId, userId, options) {
+      return await rest.get<DiscordThreadMember>(rest.routes.channels.threads.getUser(channelId, userId, options))
     },
 
-    async getThreadMembers(channelId) {
-      return await rest.get<DiscordThreadMember[]>(rest.routes.channels.threads.members(channelId))
+    async getThreadMembers(channelId, options) {
+      return await rest.get<DiscordThreadMember[]>(rest.routes.channels.threads.members(channelId, options))
     },
 
     async getReactions(channelId, messageId, reaction, options) {

--- a/packages/rest/src/routes.ts
+++ b/packages/rest/src/routes.ts
@@ -161,11 +161,28 @@ export function createRoutes(): RestRoutes {
         active: (guildId) => {
           return `/guilds/${guildId}/threads/active`
         },
-        members: (channelId) => {
-          return `/channels/${channelId}/thread-members`
+        members: (channelId, options) => {
+          let url = `/channels/${channelId}/thread-members?`
+
+          if (options) {
+            if (options.withMember) url += `with_member=${options.withMember}`
+            if (options.limit) url += `&limit=${options.limit}`
+            if (options.after) url += `&after=${options.after}`
+          }
+
+          return url
         },
         me: (channelId) => {
           return `/channels/${channelId}/thread-members/@me`
+        },
+        getUser(channelId, userId, options) {
+          let url = `/channels/${channelId}/thread-members/${userId}?`
+
+          if (options) {
+            if (options.withMember) url += `with_member=${options.withMember}`
+          }
+
+          return url
         },
         user: (channelId, userId) => {
           return `/channels/${channelId}/thread-members/${userId}`

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -108,6 +108,7 @@ import type {
   GetReactions,
   GetScheduledEventUsers,
   GetScheduledEvents,
+  GetThreadMember,
   GetUserGuilds,
   GetWebhookMessageOptions,
   InteractionCallbackData,
@@ -116,6 +117,7 @@ import type {
   ListArchivedThreads,
   ListGuildMembers,
   ListSkuSubscriptionsOptions,
+  ListThreadMembers,
   MfaLevels,
   ModifyApplicationEmoji,
   ModifyChannel,
@@ -2265,15 +2267,17 @@ export interface RestManager {
    *
    * @param channelId - The ID of the thread to get the thread member of.
    * @param userId - The user ID of the thread member to get.
+   * @param options - The parameters for the fetching of the thread member.
    * @returns An instance of {@link DiscordThreadMember}.
    *
    * @see {@link https://discord.com/developers/docs/resources/channel#get-thread-member}
    */
-  getThreadMember: (channelId: BigString, userId: BigString) => Promise<Camelize<DiscordThreadMember>>
+  getThreadMember: (channelId: BigString, userId: BigString, options: GetThreadMember) => Promise<Camelize<DiscordThreadMember>>
   /**
    * Gets the list of thread members for a thread.
    *
    * @param channelId - The ID of the thread to get the thread members of.
+   * @param options - The parameters for the fetching of the thread members.
    * @returns A collection of {@link DiscordThreadMember} assorted by user ID.
    *
    * @remarks
@@ -2281,7 +2285,7 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/channel#list-thread-members}
    */
-  getThreadMembers: (channelId: BigString) => Promise<Camelize<DiscordThreadMember>[]>
+  getThreadMembers: (channelId: BigString, options: ListThreadMembers) => Promise<Camelize<DiscordThreadMember>[]>
   /**
    * Gets the list of users that reacted with an emoji to a message.
    *

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -2272,7 +2272,7 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/channel#get-thread-member}
    */
-  getThreadMember: (channelId: BigString, userId: BigString, options: GetThreadMember) => Promise<Camelize<DiscordThreadMember>>
+  getThreadMember: (channelId: BigString, userId: BigString, options?: GetThreadMember) => Promise<Camelize<DiscordThreadMember>>
   /**
    * Gets the list of thread members for a thread.
    *
@@ -2285,7 +2285,7 @@ export interface RestManager {
    *
    * @see {@link https://discord.com/developers/docs/resources/channel#list-thread-members}
    */
-  getThreadMembers: (channelId: BigString, options: ListThreadMembers) => Promise<Camelize<DiscordThreadMember>[]>
+  getThreadMembers: (channelId: BigString, options?: ListThreadMembers) => Promise<Camelize<DiscordThreadMember>[]>
   /**
    * Gets the list of users that reacted with an emoji to a message.
    *

--- a/packages/rest/src/typings/routes.ts
+++ b/packages/rest/src/typings/routes.ts
@@ -80,11 +80,11 @@ export interface RestRoutes {
       /** Route for active threads. */
       active: (guildId: BigString) => string
       /** Route for members in a thread. */
-      members: (channelId: BigString, options: ListThreadMembers) => string
+      members: (channelId: BigString, options?: ListThreadMembers) => string
       /** Route for the bot member in a thread. */
       me: (channelId: BigString) => string
       /** Route for getting a specific member in a thread. */
-      getUser: (channelId: BigString, userId: BigString, options: GetThreadMember) => string
+      getUser: (channelId: BigString, userId: BigString, options?: GetThreadMember) => string
       /** Route for a specific member in a thread apart from the route for getting the member. */
       user: (channelId: BigString, userId: BigString) => string
       /** Route for handling archived threads. */

--- a/packages/rest/src/typings/routes.ts
+++ b/packages/rest/src/typings/routes.ts
@@ -9,11 +9,13 @@ import type {
   GetPollAnswerVotes,
   GetReactions,
   GetScheduledEventUsers,
+  GetThreadMember,
   GetUserGuilds,
   InteractionCallbackOptions,
   ListArchivedThreads,
   ListGuildMembers,
   ListSkuSubscriptionsOptions,
+  ListThreadMembers,
 } from '@discordeno/types'
 
 export interface RestRoutes {
@@ -78,10 +80,12 @@ export interface RestRoutes {
       /** Route for active threads. */
       active: (guildId: BigString) => string
       /** Route for members in a thread. */
-      members: (channelId: BigString) => string
+      members: (channelId: BigString, options: ListThreadMembers) => string
       /** Route for the bot member in a thread. */
       me: (channelId: BigString) => string
-      /** Route for a specific member in a thread. */
+      /** Route for getting a specific member in a thread. */
+      getUser: (channelId: BigString, userId: BigString, options: GetThreadMember) => string
+      /** Route for a specific member in a thread apart from the route for getting the member. */
       user: (channelId: BigString, userId: BigString) => string
       /** Route for handling archived threads. */
       archived: (channelId: BigString) => string

--- a/packages/types/src/discord/channel.ts
+++ b/packages/types/src/discord/channel.ts
@@ -1,5 +1,6 @@
 /** Types for: https://discord.com/developers/docs/resources/channel */
 
+import type { DiscordMember } from './guild.js'
 import type { DiscordMessageComponents } from './interactions.js'
 import type { DiscordAllowedMentions, DiscordAttachment, DiscordEmbed, MessageFlags } from './message.js'
 import type { DiscordUser } from './user.js'
@@ -199,6 +200,8 @@ export interface DiscordThreadMember {
   user_id: string
   /** The time the current user last joined the thread */
   join_timestamp: string
+  /** The member object of the user */
+  member?: DiscordMember
 }
 
 /** https://discord.com/developers/docs/resources/channel#thread-member-object-thread-member-structure, the first asterisk */

--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -384,6 +384,18 @@ export interface ListArchivedThreads {
   limit?: number
 }
 
+/** https://discord.com/developers/docs/resources/channel#get-thread-member-query-string-params */
+export interface GetThreadMember {
+  withMember?: boolean
+}
+
+/** https://discord.com/developers/docs/resources/channel#list-thread-members-query-string-params */
+export interface ListThreadMembers {
+  withMember?: boolean
+  after?: boolean
+  limit?: boolean
+}
+
 /** https://discord.com/developers/docs/resources/audit-log#get-guild-audit-log-query-string-parameters */
 export interface GetGuildAuditLog {
   /** Entries from a specific user ID */

--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -392,8 +392,8 @@ export interface GetThreadMember {
 /** https://discord.com/developers/docs/resources/channel#list-thread-members-query-string-params */
 export interface ListThreadMembers {
   withMember?: boolean
-  after?: boolean
-  limit?: boolean
+  after?: BigString
+  limit?: BigString
 }
 
 /** https://discord.com/developers/docs/resources/audit-log#get-guild-audit-log-query-string-parameters */

--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -386,13 +386,17 @@ export interface ListArchivedThreads {
 
 /** https://discord.com/developers/docs/resources/channel#get-thread-member-query-string-params */
 export interface GetThreadMember {
+  /** Whether to include a guild member object for the thread member */
   withMember?: boolean
 }
 
 /** https://discord.com/developers/docs/resources/channel#list-thread-members-query-string-params */
 export interface ListThreadMembers {
+  /** Whether to include a guild member object for the thread member */
   withMember?: boolean
+  /** Get thread members after this user ID */
   after?: BigString
+  /** Max number of thread members to return (1-100). Defaults to 100. */
   limit?: BigString
 }
 


### PR DESCRIPTION
This is a breaking change because `Member.guildId` is now marked optional, as there are some places where it's impossible to get guild id of the thread member