### PR TITLE
fix: thread create autoArchiveDuration being a required param

### DIFF
--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -993,7 +993,7 @@ export interface CreateForumPostWithMessage {
   /** 1-100 character thread name */
   name: string
   /** Duration in minutes to automatically archive the thread after recent activity */
-  autoArchiveDuration: 60 | 1440 | 4320 | 10080
+  autoArchiveDuration?: 60 | 1440 | 4320 | 10080
   /** Amount of seconds a user has to wait before sending another message (0-21600) */
   rateLimitPerUser?: number | null
   /** contents of the first message in the forum/media thread */
@@ -1037,7 +1037,7 @@ export interface StartThreadWithMessage {
   /** 1-100 character thread name */
   name: string
   /** Duration in minutes to automatically archive the thread after recent activity */
-  autoArchiveDuration: 60 | 1440 | 4320 | 10080
+  autoArchiveDuration?: 60 | 1440 | 4320 | 10080
   /** Amount of seconds a user has to wait before sending another message (0-21600) */
   rateLimitPerUser?: number | null
 }
@@ -1046,7 +1046,7 @@ export interface StartThreadWithoutMessage {
   /** 1-100 character thread name */
   name: string
   /** Duration in minutes to automatically archive the thread after recent activity */
-  autoArchiveDuration: 60 | 1440 | 4320 | 10080
+  autoArchiveDuration?: 60 | 1440 | 4320 | 10080
   /** Amount of seconds a user has to wait before sending another message (0-21600) */
   rateLimitPerUser?: number | null
   /** the type of thread to create */


### PR DESCRIPTION
`auto_archive_duration` is an optional param, see:

https://discord.com/developers/docs/resources/channel#start-thread-from-message-json-params
https://discord.com/developers/docs/resources/channel#start-thread-without-message-json-params
https://discord.com/developers/docs/resources/channel#start-thread-in-forum-or-media-channel-jsonform-params