### PR TITLE
fix(types): Add missing skuId property in ButtonComponent

### DIFF
--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -149,7 +149,7 @@ export interface ButtonComponent {
     animated?: boolean
   }
   /** Identifier for a purchasable SKU, only available when using premium-style buttons */
-  skuId?: bigint
+  skuId?: BigString
   /** optional url for link-style buttons that can navigate a user to the web. Only type 5 Link buttons can have a url */
   url?: string
   /** Whether or not this button is disabled */

--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -148,6 +148,8 @@ export interface ButtonComponent {
     /** Whether this emoji is animated */
     animated?: boolean
   }
+  /** Identifier for a purchasable SKU, only available when using premium-style buttons */
+  sku_id?: bigint
   /** optional url for link-style buttons that can navigate a user to the web. Only type 5 Link buttons can have a url */
   url?: string
   /** Whether or not this button is disabled */

--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -149,7 +149,7 @@ export interface ButtonComponent {
     animated?: boolean
   }
   /** Identifier for a purchasable SKU, only available when using premium-style buttons */
-  sku_id?: bigint
+  skuId?: bigint
   /** optional url for link-style buttons that can navigate a user to the web. Only type 5 Link buttons can have a url */
   url?: string
   /** Whether or not this button is disabled */


### PR DESCRIPTION
This pull request includes a small change to the `ButtonComponent` interface in the `discordeno.ts` file. The change adds a new property to support premium-style buttons.

* [`packages/types/src/discordeno.ts`](diffhunk://#diff-e25808c8da925da054561fc5fc6a56358d75ecb11c90d8d0d8b0596c88aed095R151-R152): Added `skuId` property to the `ButtonComponent` interface to identify purchasable SKUs for premium-style buttons.