### PR TITLE
feat(bot,rest): Deprecate `createGuild` and `createGuildFromTemplate`

### DIFF
--- a/packages/bot/src/helpers.ts
+++ b/packages/bot/src/helpers.ts
@@ -837,12 +837,14 @@ export type BotHelpers<TProps extends TransformersDesiredProperties, TBehavior e
     reason?: string,
   ) => Promise<SetupDesiredProps<Channel, TProps, TBehavior>>
   createGlobalApplicationCommand: (command: CreateApplicationCommand, options?: CreateGlobalApplicationCommandOptions) => Promise<ApplicationCommand>
+  /** @deprecated */
   createGuild: (options: CreateGuild) => Promise<SetupDesiredProps<Guild, TProps, TBehavior>>
   createGuildApplicationCommand: (
     command: CreateApplicationCommand,
     guildId: BigString,
     options?: CreateGuildApplicationCommandOptions,
   ) => Promise<ApplicationCommand>
+  /** @deprecated */
   createGuildFromTemplate: (templateCode: string, options: CreateGuildFromTemplate) => Promise<SetupDesiredProps<Guild, TProps, TBehavior>>
   createGuildSticker: (
     guildId: BigString,

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -474,6 +474,11 @@ export interface RestManager {
    * @param options - The parameters for the creation of the guild.
    * @returns An instance of the created {@link DiscordGuild}.
    *
+   * @deprecated
+   * This endpoint is deprecated by Discord and will be disabled on July 15 2025.
+   *
+   * Check Discord announcement for details: {@link https://discord.com/developers/docs/change-log#deprecating-guild-creation-by-apps}
+   *
    * @remarks
    * ⚠️ This route can only be used by bots in __fewer than 10 guilds__.
    *
@@ -510,6 +515,12 @@ export interface RestManager {
    * @param templateCode - The code of the template.
    * @param options - The parameters for the creation of the guild.
    * @returns An instance of the created {@link DiscordGuild}.
+   *
+   * @deprecated
+   * This endpoint is deprecated by Discord and will be disabled on July 15 2025.
+   *
+   * Check Discord announcement for details: {@link https://discord.com/developers/docs/change-log#deprecating-guild-creation-by-apps}
+   *
    *
    * @remarks
    * ⚠️ This route can only be used by bots in __fewer than 10 guilds__.


### PR DESCRIPTION
While discord does not say anything explicit about deprecating the `createGuildFromTemplate` endpoint, it is a fair assumption to make that it is included in this change

- upstream: https://github.com/discord/discord-api-docs/pull/7469