### PR TITLE
Improve consistency for snowflakeToTimestamp

### DIFF
--- a/packages/bot/src/utils.ts
+++ b/packages/bot/src/utils.ts
@@ -8,6 +8,6 @@ export function bigintToSnowflake(snowflake: BigString): string {
   return snowflake === 0n ? '' : snowflake.toString()
 }
 
-export function snowflakeToTimestamp(id: bigint): number {
-  return Number(id / 4194304n + 1420070400000n)
+export function snowflakeToTimestamp(snowflake: BigString): number {
+  return Number(BigInt(snowflake) / 4194304n + 1420070400000n)
 }


### PR DESCRIPTION
The other two functions use BigString so why not snowflakeToTimestamp?