### PR TITLE
refactor: don't log about resuming in shard.handleClose

### DIFF
--- a/packages/gateway/src/Shard.ts
+++ b/packages/gateway/src/Shard.ts
@@ -458,7 +458,7 @@ export class DiscordenoShard {
           this.state = ShardState.Disconnected
           this.events.disconnected?.(this)
 
-        this.goingOffline = false
+          this.goingOffline = false
 
           return
         }
@@ -472,7 +472,6 @@ export class DiscordenoShard {
       case GatewayCloseEventCodes.RateLimited:
       case GatewayCloseEventCodes.AlreadyAuthenticated:
       default: {
-        this.logger.info(`[Shard] Shard #${this.id} closed with code ${close.code}. Attempting to resume...`)
         // We don't want to get into an infinite loop where we resume forever, so if we were already resuming we identify instead
         this.state = this.state === ShardState.Resuming ? ShardState.Identifying : ShardState.Resuming
         this.events.disconnected?.(this)


### PR DESCRIPTION
Since we already have a debug log that logs close code with reason in `shard.handleClose()` and another log for `shard.resume()`, this one is redundant.

Moreover, something has changed on Discord/CloudFlare/Hetzner's side around 2 months ago and since then, the number of shard closures has increased with close code `1006` and this log is spamming the console (yes I have verified it's not my code or just my server but is something that people using other libraries are also experiencing).