### PR TITLE
fix(types): Remove comment limit on number of components

### DIFF
--- a/packages/types/src/discord/components.ts
+++ b/packages/types/src/discord/components.ts
@@ -318,7 +318,7 @@ export enum SeparatorSpacingSize {
 export interface DiscordContainerComponent extends DiscordBaseComponent {
   type: MessageComponentTypes.Container
 
-  /** Up to 10 components of the type action row, text display, section, media gallery, separator, or file */
+  /** Components of the type action row, text display, section, media gallery, separator, or file */
   components: Array<
     | DiscordActionRow
     | DiscordTextDisplayComponent

--- a/packages/types/src/discordeno.ts
+++ b/packages/types/src/discordeno.ts
@@ -399,7 +399,7 @@ export interface SeparatorComponent extends BaseComponent {
 export interface ContainerComponent extends BaseComponent {
   type: MessageComponentTypes.Container
 
-  /** Up to 10 components of the type action row, text display, section, media gallery, separator, or file */
+  /** Components of the type action row, text display, section, media gallery, separator, or file */
   components: Array<ActionRow | TextDisplayComponent | SectionComponent | MediaGalleryComponent | SeparatorComponent | FileComponent>
   /** Color for the accent on the container as RGB from 0x000000 to 0xFFFFFF */
   accentColor?: number


### PR DESCRIPTION
The limit is still in place however it is 40 total now, so it is a bit more complicated to explain and the discord docs are better at doing so than what we can do with JSDoc

- Upstream: https://github.com/discord/discord-api-docs/pull/7534