### PR TITLE
fix(bot): role.name property missing because of empty role names

### DIFF
--- a/packages/bot/src/transformers/role.ts
+++ b/packages/bot/src/transformers/role.ts
@@ -47,7 +47,8 @@ export function transformRole(bot: InternalBot, payload: { role: DiscordRole; gu
   const role: Role = Object.create(baseRole)
   const props = bot.transformers.desiredProperties.role
   if (props.id && payload.role.id) role.id = bot.transformers.snowflake(payload.role.id)
-  if (props.name && payload.role.name) role.name = payload.role.name
+  // Role name can be an empty string
+  if (props.name && payload.role.name !== undefined) role.name = payload.role.name
   if (props.position) role.position = payload.role.position
   if (props.guildId && payload.guildId) role.guildId = bot.transformers.snowflake(payload.guildId)
   if (props.color && payload.role.color !== undefined) role.color = payload.role.color


### PR DESCRIPTION
Empty role names can exist but the current code wouldn't add the property if the role name is empty even though in typing it's not an optional property. This PR fixes that issue by checking for undefined instead of truthy value.

Steps to reproduce: change role name to a string with spaces, Discord will change it to an empty string instead (at least when you do it from the client)