### PR TITLE
fix(bot): Use an object to present desired properties errors

### DIFF
--- a/packages/bot/src/desiredProperties.ts
+++ b/packages/bot/src/desiredProperties.ts
@@ -846,6 +846,11 @@ export type DesiredPropertiesMapper<T extends TransformersObjects[keyof Transfor
   [Key in DesirableProperties<T>]: boolean
 }
 
+declare const TypeErrorSymbol: unique symbol
+interface DesiredPropertiesError<T extends string> {
+  [TypeErrorSymbol]: T
+}
+
 type AreDependenciesSatisfied<T, TDependencies extends Record<string, string[]> | undefined, TProps> = {
   [K in keyof T]: IsKeyDesired<T[K], TDependencies, TProps> extends true ? true : false
 }
@@ -856,7 +861,7 @@ type IsKeyDesired<TKey, TDependencies extends Record<string, string[]> | undefin
     ? // Yes, this is a key to include
       true
     : // No, this is a key to exclude
-      `This property is not set as desired in desiredProperties option in createBot(), so you can't use it. More info here: https://discordeno.js.org/desired-props`
+      DesiredPropertiesError<`This property is not set as desired in desiredProperties option in createBot(), so you can't use it. More info here: https://discordeno.js.org/desired-props`>
   : // No, it is a props with dependencies?
     TKey extends keyof TDependencies
     ? // Yes, has all of its dependencies satisfied?
@@ -864,7 +869,7 @@ type IsKeyDesired<TKey, TDependencies extends Record<string, string[]> | undefin
       ? // Yes, this is a key to include
         true
       : // No, this is a key to not include
-        `This property depends on the following properties: ${JoinTuple<NonNullable<TDependencies>[TKey], ', '>}. Not all of these props are set as desired in desiredProperties option in createBot(), so you can't use it. More info here: https://discordeno.js.org/desired-props`
+        DesiredPropertiesError<`This property depends on the following properties: ${JoinTuple<NonNullable<TDependencies>[TKey], ', '>}. Not all of these props are set as desired in desiredProperties option in createBot(), so you can't use it. More info here: https://discordeno.js.org/desired-props`>
     : // No, we include it but it does not have neither props nor dependencies
       true
 

--- a/website/docs/desired-properties.md
+++ b/website/docs/desired-properties.md
@@ -152,10 +152,15 @@ The caveats of this behavior are the following:
 
 #### `ChangeType`
 
-All the "undesired" properties will be typed with a string that will explain why the property is disabled, this may also include the dependencies for said property if those are present.
+All the "undesired" properties will be typed with a string wrapped in a type that will explain why the property is disabled, this may also include the dependencies for said property if those are present.
 
 The caveats of this behavior are the following:
-- Typescript may not always error on the usage of undesired properties, as in some cases, strings can be a valid option (e.g. channel.name is always a string so typescript won't error)
+- Typescript may not always error on the usage of undesired properties, as in some cases, the object without any property can be a valid thing to use (e.g. `message.poll` is an object, so if you only check if `message.poll` exists Typescript won't error)
+
+The types for undesired properties will be like the following:
+```js
+(property) content: DesiredPropertiesError<"This property is not set as desired in desiredProperties option in createBot(), so you can't use it. More info here: https://discordeno.js.org/desired-props">
+```
 
 ### Removing TypeScript Clutter
 


### PR DESCRIPTION
Using an object allows typescript to error in more cases as with strings
if the original propriety was a string it would not error for stuff like
`.endsWith(...)`

We use a symbol to make sure the type doesn't actually become a generic
object, but instead is a specific type that can be checked against.
