### PR TITLE
refactor: use dotenv/config instead of calling the function manually

### DIFF
--- a/examples/bigbot/src/config.ts
+++ b/examples/bigbot/src/config.ts
@@ -1,5 +1,6 @@
-import { Intents } from '@discordeno/bot'
 import 'dotenv/config'
+
+import { Intents } from '@discordeno/bot'
 
 // #region Mapping of environment variables to javascript variables with some minimal parsing
 

--- a/examples/reaction-roles/src/bot.ts
+++ b/examples/reaction-roles/src/bot.ts
@@ -1,8 +1,7 @@
+import 'dotenv/config'
+
 import { createBot } from '@discordeno/bot'
 import events from './events/index.js'
-
-import { config } from 'dotenv'
-config()
 
 const token = process.env.TOKEN
 

--- a/examples/reaction-roles/src/register-commands.ts
+++ b/examples/reaction-roles/src/register-commands.ts
@@ -1,6 +1,4 @@
-import { config } from 'dotenv'
-
-config()
+import 'dotenv/config'
 
 import { bot } from './bot.js'
 import commands from './commands/index.js'

--- a/website/docs/beginner/env.md
+++ b/website/docs/beginner/env.md
@@ -52,9 +52,7 @@ _or using yarn, pnpm or bun_
 We now need to load the `.env` from our code so let's add the following code to your typescript file:
 
 ```ts
-import dotenv from 'dotenv'
-
-dotenv.config()
+import 'dotenv/config'
 ```
 
 This will import the dotenv module and add all the variables we declared in our `.env` file into the node environment variables

--- a/website/docs/bigbot/step-2-rest.md
+++ b/website/docs/bigbot/step-2-rest.md
@@ -52,10 +52,8 @@ This code we have created will maintain a manager that will handle all the outgo
 Now you can make another file like `services/rest/index.ts`. Then paste the code below:
 
 ```ts
-import dotenv from 'dotenv'
+import 'dotenv/config'
 import express from 'express'
-
-dotenv.config()
 
 import { REST } from './rest.ts'
 

--- a/website/docs/bigbot/step-3-gateway.md
+++ b/website/docs/bigbot/step-3-gateway.md
@@ -112,11 +112,9 @@ You can adjust the amount of **shardsPerWorker** and **totalWorkers** to fit you
 Let's make a file called `services/gateway/index.ts` and paste the following code:
 
 ```ts
+import 'dotenv/config'
 import { logger } from '@discordeno/utils'
-import dotenv from 'dotenv'
 import express from 'express'
-
-dotenv.config()
 
 const AUTHORIZATION = process.env.AUTHORIZATION as string
 
@@ -212,11 +210,9 @@ Now, we need to setup a sharder process to spawn all our shards in each server. 
 Just like before, we are going to make another http listener to listen for incoming requests from the gateway manager and delegate them outwards to different workers. Make a file called `services/gateway/sharding/index.ts`
 
 ```ts
-import dotenv from 'dotenv'
+import 'dotenv/config'
 import express from 'express'
 import { Worker } from 'worker_threads'
-
-dotenv.config()
 
 const AUTHORIZATION = process.env.AUTHORIZATION as string
 
@@ -284,13 +280,11 @@ Most of this code is another http listener again. The part we are going to focus
 Now that we have our sharding master process ready, create a file called `services/gateway/sharding/worker.ts` for it to spawn and forward requests to.
 
 ```ts
+import 'dotenv/config'
 import { DiscordenoShard } from '@discordeno/gateway'
 import { logger } from '@discordeno/utils'
 import { Intents } from '@discordeno/types'
 import { parentPort, workerData } from 'worker_threads'
-import dotenv from 'dotenv'
-
-dotenv.config()
 
 if (!parentPort) throw new Error('Parent port is null')
 

--- a/website/docs/bigbot/step-4-bot.md
+++ b/website/docs/bigbot/step-4-bot.md
@@ -57,10 +57,8 @@ There you go. You now have an event handler working perfectly.
 Once, again we are going to create a quick http listener that will listen for events coming from the shards and process them accordingly. Create a file like `services/bot/index.ts` and paste the code below:
 
 ```ts
-import dotenv from 'dotenv'
+import 'dotenv/config'
 import express from 'express'
-
-dotenv.config()
 
 const AUTHORIZATION = process.env.AUTHORIZATION as string
 

--- a/website/docs/examples/node.md
+++ b/website/docs/examples/node.md
@@ -21,10 +21,8 @@ After you installed the `@discordeno/bot` package with npm, yarn, pnpm or bun yo
 This is how you can use it to create a bot that logs into discord:
 
 ```ts
-import dotenv from 'dotenv'
+import 'dotenv/config'
 import { createBot } from '@discordeno/bot'
-
-dotenv.config()
 
 const bot = createBot({
   token: process.env.token,

--- a/website/docs/examples/reactionroles.md
+++ b/website/docs/examples/reactionroles.md
@@ -22,9 +22,8 @@ Before going forward, please make sure you have finished everything on this list
 First let's go ahead and set up the base files we need to make this work. Create an `src/index.ts` file.
 
 ```ts
+import 'dotenv/config'
 import { createBot } from '@discordeno/bot'
-import { config } from 'dotenv'
-config()
 
 export const bot = createBot({
   token: process.env.TOKEN,
@@ -412,12 +411,10 @@ In this file we can add all of the events we want. In this guide we only need th
 To tell Discordeno to run the events, we need another change. Go back to the `src/index.ts` file.
 
 ```ts
+import 'dotenv/config'
 import { createBot } from '@discordeno/bot'
-import { config } from 'dotenv'
 // insert-next-line
 import events from './events/index.js'
-
-config()
 
 export const bot = createBot({
   token: process.env.TOKEN,


### PR DESCRIPTION
Originally discussed in https://github.com/discordeno/discordeno/pull/4246, I have updated dotenv imports to use `dotenv/config` instead of calling `config()` as per the recommendation from the dotenv creators on their GitHub and npm readme.

I have tried to be consistent with other usages by having it at the top of the files with a new line below. However, I'm not sure if the same applies to markdown examples. 