### PR TITLE
fix(bot): ACK the interaction only after a successful response

### DIFF
--- a/packages/bot/src/transformers/interaction.ts
+++ b/packages/bot/src/transformers/interaction.ts
@@ -51,8 +51,14 @@ export const baseInteraction: InternalBot['transformers']['$inferredTypes']['int
     if (this.type === InteractionTypes.ModalSubmit && type === InteractionResponseTypes.Modal)
       throw new Error('Cannot respond to a modal interaction with another modal.')
 
+    const result = await this.bot.helpers.sendInteractionResponse(
+      this.id,
+      this.token,
+      { type, data: response },
+      { withResponse: options?.withResponse },
+    )
     this.acknowledged = true
-    return await this.bot.helpers.sendInteractionResponse(this.id, this.token, { type, data: response }, { withResponse: options?.withResponse })
+    return result
   },
   async edit(response, messageId, options) {
     if (this.type === InteractionTypes.ApplicationCommandAutocomplete) throw new Error('Cannot edit an autocomplete interaction.')
@@ -68,13 +74,14 @@ export const baseInteraction: InternalBot['transformers']['$inferredTypes']['int
       if (this.type !== InteractionTypes.MessageComponent && this.type !== InteractionTypes.ModalSubmit)
         throw new Error("This interaction has not been responded to yet and this isn't a MessageComponent or ModalSubmit interaction.")
 
-      this.acknowledged = true
-      return await this.bot.helpers.sendInteractionResponse(
+      const result = await this.bot.helpers.sendInteractionResponse(
         this.id,
         this.token,
         { type: InteractionResponseTypes.UpdateMessage, data: response },
         options,
       )
+      this.acknowledged = true
+      return result
     }
 
     return await this.bot.helpers.editOriginalInteractionResponse(this.token, response)
@@ -86,14 +93,19 @@ export const baseInteraction: InternalBot['transformers']['$inferredTypes']['int
     if (this.type !== InteractionTypes.MessageComponent && this.type !== InteractionTypes.ModalSubmit)
       throw new Error("Cannot defer to then edit an interaction that isn't a MessageComponent or ModalSubmit interaction.")
 
+    const result = await this.bot.helpers.sendInteractionResponse(
+      this.id,
+      this.token,
+      { type: InteractionResponseTypes.DeferredUpdateMessage },
+      options,
+    )
     this.acknowledged = true
-    return await this.bot.helpers.sendInteractionResponse(this.id, this.token, { type: InteractionResponseTypes.DeferredUpdateMessage }, options)
+    return result
   },
   async defer(isPrivate, options) {
     if (this.acknowledged) throw new Error('Cannot defer an already responded interaction.')
 
-    this.acknowledged = true
-    return await this.bot.helpers.sendInteractionResponse(
+    const result = await this.bot.helpers.sendInteractionResponse(
       this.id,
       this.token,
       {
@@ -104,6 +116,8 @@ export const baseInteraction: InternalBot['transformers']['$inferredTypes']['int
       },
       options,
     )
+    this.acknowledged = true
+    return result
   },
   async delete(messageId) {
     if (this.type === InteractionTypes.ApplicationCommandAutocomplete) throw new Error('Cannot delete an autocomplete interaction')


### PR DESCRIPTION
If we ACK the interaction and the request is not successful and then the user tries to use the helpers again they will almost always get an error about unknown webhooks or unknown interactions

test code:
```ts
bot.events.interactionCreate = async (interaction) => {
  try {
    await interaction.respond({ components: [{ type: MessageComponentTypes.TextDisplay, content: 'Hello World!' }] })
  } catch (error) {
    await interaction.respond({ content: 'An error occurred while processing your request.\nDetails: ```ts\n' + inspect(error) + '```' })
  }
}
```