### PR TITLE
test(rest): Don't create as many channel, ensure we delete the resources we create

### DIFF
--- a/packages/rest/tests/e2e/emoji.spec.ts
+++ b/packages/rest/tests/e2e/emoji.spec.ts
@@ -30,7 +30,9 @@ describe('Create and delete emojis', () => {
 
     // Assertions
     expect(emoji.id).to.be.exist
+
     await rest.deleteEmoji(e2eCache.guild.id, emoji.id!)
+
     await expect(rest.getEmoji(e2eCache.guild.id, emoji.id!)).to.eventually.rejected
   })
 
@@ -44,7 +46,9 @@ describe('Create and delete emojis', () => {
 
     // Assertions
     expect(emoji.id).to.be.exist
+
     await rest.deleteEmoji(e2eCache.guild.id, emoji.id!, 'with a reason')
+
     await expect(rest.getEmoji(e2eCache.guild.id, emoji.id!)).to.eventually.rejected
   })
 })

--- a/packages/rest/tests/e2e/guild.spec.ts
+++ b/packages/rest/tests/e2e/guild.spec.ts
@@ -19,7 +19,13 @@ describe('Manage Guilds', async () => {
       name: 'e2e-afk-channel',
       type: ChannelTypes.GuildVoice,
     })
+
     expect(voiceChannel.id).to.be.exist
+
+    after(async () => {
+      // Clean up the AFK channel created for testing
+      await rest.deleteChannel(voiceChannel.id)
+    })
 
     // Set the AFK channel
     const edited = await rest.editGuild(e2eCache.guild.id, {
@@ -33,9 +39,6 @@ describe('Manage Guilds', async () => {
     // Reset the AFK channel
     const edited2 = await rest.editGuild(e2eCache.guild.id, { afkChannelId: null })
     expect(edited2.afkChannelId).to.be.null
-
-    // Clean up the AFK channel
-    await rest.deleteChannel(voiceChannel.id)
   })
 
   it('Get audit logs', async () => {
@@ -51,14 +54,7 @@ describe('Manage Guilds', async () => {
 
   it('Banning members', async () => {
     // Ban members
-    await rest.banMember(
-      e2eCache.guild.id,
-      '379643682984296448',
-      {
-        deleteMessageSeconds: 604800,
-      },
-      'Blame Wolf',
-    )
+    await rest.banMember(e2eCache.guild.id, '379643682984296448', { deleteMessageSeconds: 604800 }, 'Blame Wolf')
     await rest.banMember(e2eCache.guild.id, '416477607966670869')
 
     const fetchedBan = await rest.getBan(e2eCache.guild.id, '379643682984296448')

--- a/packages/rest/tests/e2e/member.spec.ts
+++ b/packages/rest/tests/e2e/member.spec.ts
@@ -7,14 +7,14 @@ chaiUse(chaiAsPromised)
 describe('Member tests', () => {
   it("Fetches the bot and compares the bot's id with the fetched member's id", async () => {
     const member = await rest.getMember(e2eCache.guildId, rest.applicationId)
+
     expect(member?.user.id).to.exist
     expect(member?.user.id).to.equal(rest.applicationId.toString())
   })
 
   it('Gets a member list and checks if the bot is in the member list', async () => {
-    const members = await rest.getMembers(e2eCache.guildId, {
-      limit: 10,
-    })
+    const members = await rest.getMembers(e2eCache.guildId, { limit: 10 })
+
     expect(members.some((m) => m.user.id === rest.applicationId.toString())).to.equal(true)
   })
 
@@ -27,15 +27,11 @@ describe('Member tests', () => {
 
   it("Edit a bot's nickname", async () => {
     const nick = 'lts20050703'
-    const member = await rest.editBotMember(e2eCache.guildId, {
-      nick,
-    })
+    const member = await rest.editBotMember(e2eCache.guildId, { nick })
     expect(member.nick).to.equal(nick)
 
     // Change nickname back
-    const member2 = await rest.editBotMember(e2eCache.guildId, {
-      nick: null,
-    })
+    const member2 = await rest.editBotMember(e2eCache.guildId, { nick: null })
     expect(member2.nick).to.null
   })
 

--- a/packages/rest/tests/e2e/message.spec.ts
+++ b/packages/rest/tests/e2e/message.spec.ts
@@ -3,8 +3,6 @@ import { expect } from 'chai'
 import { describe, it } from 'mocha'
 import { e2eCache, rest } from './utils.js'
 
-// TODO: we need to create this many channels?
-
 describe('Send a message', () => {
   it('With content', async () => {
     const message = await rest.sendMessage(e2eCache.channel.id, { content: 'testing rate limit manager' })
@@ -62,17 +60,15 @@ describe('Send a message', () => {
 
 describe('Manage reactions', async () => {
   it('Add and delete a unicode reaction', async () => {
-    const reactionChannel = await rest.createChannel(e2eCache.guild.id, { name: 'reactions' })
-    after(async () => {
-      // Clean up the channel created for testing
-      await rest.deleteChannel(reactionChannel.id)
-    })
-    const message = await rest.sendMessage(reactionChannel.id, { content: 'add reaction test' })
+    const message = await rest.sendMessage(e2eCache.channel.id, { content: 'add reaction test' })
     await rest.addReaction(message.channelId, message.id, '📙')
+
     const reacted = await rest.getMessage(message.channelId, message.id)
     expect(reacted.reactions?.length).to.be.greaterThanOrEqual(1)
+
     await rest.deleteOwnReaction(message.channelId, message.id, '📙')
     const unreacted = await rest.getMessage(message.channelId, message.id)
+
     // Use boolean comparison because when its 0 length discord sends undefined
     expect(!!unreacted.reactions?.length).to.be.equal(false)
   })
@@ -82,20 +78,26 @@ describe('Manage reactions', async () => {
       name: 'discordeno',
       image: await urlToBase64('https://cdn.discordapp.com/emojis/785403373817823272.webp?size=96'),
     })
-    const emojiCode = `<:${emoji.name!}:${emoji.id!}>`
-    const reactionChannel = await rest.createChannel(e2eCache.guild.id, { name: 'reactions' })
+
     after(async () => {
-      // Clean up the channel created for testing
-      await rest.deleteChannel(reactionChannel.id)
+      // Clean up the emoji created for testing
+      await rest.deleteEmoji(e2eCache.guild.id, emoji.id!)
     })
-    const message = await rest.sendMessage(reactionChannel.id, { content: 'add reaction test' })
+
+    const emojiCode = `<:${emoji.name!}:${emoji.id!}>`
+
+    const message = await rest.sendMessage(e2eCache.channel.id, { content: 'add reaction test' })
     await rest.addReaction(message.channelId, message.id, emojiCode)
+
     const reacted = await rest.getMessage(message.channelId, message.id)
     expect(reacted.reactions?.length).to.be.greaterThanOrEqual(1)
-    const reactions = await rest.getReactions(reactionChannel.id, message.id, processReactionString(emojiCode))
+
+    const reactions = await rest.getReactions(e2eCache.channel.id, message.id, processReactionString(emojiCode))
     expect(reactions?.length).to.be.greaterThanOrEqual(1)
+
     await rest.deleteOwnReaction(message.channelId, message.id, emojiCode)
     const unreacted = await rest.getMessage(message.channelId, message.id)
+
     // Use boolean comparison because when its 0 length discord sends undefined
     expect(!!unreacted.reactions?.length).to.be.equal(false)
   })
@@ -105,18 +107,23 @@ describe('Manage reactions', async () => {
       name: 'discordeno',
       image: await urlToBase64('https://cdn.discordapp.com/emojis/785403373817823272.webp?size=96'),
     })
-    const emojiCode = `<:${emoji.name!}:${emoji.id!}>`
-    const reactionChannel = await rest.createChannel(e2eCache.guild.id, { name: 'reactions' })
+
     after(async () => {
-      // Clean up the channel created for testing
-      await rest.deleteChannel(reactionChannel.id)
+      // Clean up the emoji created for testing
+      await rest.deleteEmoji(e2eCache.guild.id, emoji.id!)
     })
-    const message = await rest.sendMessage(reactionChannel.id, { content: 'add reaction test' })
+
+    const emojiCode = `<:${emoji.name!}:${emoji.id!}>`
+
+    const message = await rest.sendMessage(e2eCache.channel.id, { content: 'add reaction test' })
     await rest.addReactions(message.channelId, message.id, [emojiCode, '📙'])
+
     const reacted = await rest.getMessage(message.channelId, message.id)
     expect(reacted.reactions?.length).to.be.greaterThanOrEqual(1)
+
     await rest.deleteReactionsAll(message.channelId, message.id)
     const unreacted = await rest.getMessage(message.channelId, message.id)
+
     // Use boolean comparison because when its 0 length discord sends undefined
     expect(!!unreacted.reactions?.length).to.equal(false)
   })
@@ -126,21 +133,28 @@ describe('Manage reactions', async () => {
       name: 'discordeno',
       image: await urlToBase64('https://cdn.discordapp.com/emojis/785403373817823272.webp?size=96'),
     })
-    const emojiCode = `<:${emoji.name!}:${emoji.id!}>`
-    const reactionChannel = await rest.createChannel(e2eCache.guild.id, { name: 'reactions' })
+
     after(async () => {
-      // Clean up the channel created for testing
-      await rest.deleteChannel(reactionChannel.id)
+      // Clean up the emoji created for testing
+      await rest.deleteEmoji(e2eCache.guild.id, emoji.id!)
     })
-    const message = await rest.sendMessage(reactionChannel.id, { content: 'add reaction test' })
+
+    const emojiCode = `<:${emoji.name!}:${emoji.id!}>`
+
+    const message = await rest.sendMessage(e2eCache.channel.id, { content: 'add reaction test' })
     await rest.addReactions(message.channelId, message.id, [emojiCode, '📙'], true)
+
     const reacted = await rest.getMessage(message.channelId, message.id)
     expect(reacted.reactions?.length).to.be.greaterThanOrEqual(1)
+
     await rest.deleteReactionsEmoji(message.channelId, message.id, emojiCode)
+
     const unreacted = await rest.getMessage(message.channelId, message.id)
     expect(unreacted.reactions?.length).to.greaterThanOrEqual(1)
+
     await rest.deleteUserReaction(message.channelId, message.id, rest.applicationId.toString(), '📙')
     const noreacted = await rest.getMessage(message.channelId, message.id)
+
     // Use boolean comparison because when its 0 length discord sends undefined
     expect(!!noreacted.reactions?.length).to.equal(false)
   })
@@ -148,57 +162,50 @@ describe('Manage reactions', async () => {
 
 describe('Manage pins', () => {
   it('Pin, get, and unpin messages', async () => {
-    const channel = await rest.createChannel(e2eCache.guild.id, { name: 'pinning' })
-    after(async () => {
-      // Clean up the channel created for testing
-      await rest.deleteChannel(channel.id)
-    })
-    const message = await rest.sendMessage(channel.id, { content: 'pin me' })
-    const message2 = await rest.sendMessage(channel.id, { content: 'pin me 2' })
-    await rest.pinMessage(channel.id, message.id)
-    await rest.pinMessage(channel.id, message2.id, 'with a reason')
-    const pins = await rest.getPinnedMessages(channel.id)
-    expect(pins.length).to.equal(2)
-    expect(pins.some((p) => p.id === message.id)).to.equal(true)
-    await rest.unpinMessage(channel.id, message.id)
-    await rest.unpinMessage(channel.id, message2.id, 'with a reason')
-    const unpinned = await rest.getPinnedMessages(channel.id)
-    expect(unpinned.length).to.equal(0)
+    const message = await rest.sendMessage(e2eCache.channel.id, { content: 'pin me' })
+    const message2 = await rest.sendMessage(e2eCache.channel.id, { content: 'pin me 2' })
+
+    await rest.pinMessage(e2eCache.channel.id, message.id)
+    await rest.pinMessage(e2eCache.channel.id, message2.id, 'with a reason')
+
+    const pins = await rest.getChannelPins(e2eCache.channel.id)
+
+    expect(pins.items.length).to.equal(2)
+    expect(pins.items.some((p) => p.message.id === message.id)).to.equal(true)
+
+    await rest.unpinMessage(e2eCache.channel.id, message.id)
+    await rest.unpinMessage(e2eCache.channel.id, message2.id, 'with a reason')
+
+    const unpinned = await rest.getChannelPins(e2eCache.channel.id)
+    expect(unpinned.items.length).to.equal(0)
   })
 })
 
 describe('Rate limit manager testing', () => {
   it('Send 10 messages to 1 channel', async () => {
-    const channel = await rest.createChannel(e2eCache.guild.id, { name: 'rate-limit-1' })
-
-    after(async () => {
-      // Clean up the channel created for testing
-      await rest.deleteChannel(channel.id)
+    const promises = Array.from({ length: 10 }, async (_, i) => {
+      await rest.sendMessage(e2eCache.channel.id, { content: `10 messages to 1 channel testing rate limit manager ${i}` })
     })
 
-    await Promise.all(
-      [0, 1, 2, 3, 4, 5, 6, 7, 8, 9].map(async (i) => {
-        await rest.sendMessage(channel.id, { content: `10 messages to 1 channel testing rate limit manager ${i}` })
-      }),
-    )
+    await Promise.all(promises)
   })
 
   it('Send 10 messages to 10 channels', async () => {
-    await Promise.all(
-      [...Array(10).keys()].map(async () => {
-        const channel = await rest.createChannel(e2eCache.guild.id, { name: 'rate-limit-x' })
+    // Create 10 channels and send a message to each
+    const promises = Array.from({ length: 10 }, async (_, i) => {
+      const channel = await rest.createChannel(e2eCache.guild.id, { name: `rate-limit-${i}` })
 
-        after(async () => {
-          // Clean up the channel created for testing
-          await rest.deleteChannel(channel.id)
-        })
+      after(async () => {
+        await rest.deleteChannel(channel.id)
+      })
 
-        await Promise.all(
-          [...Array(10).keys()].map(async (_, index) => {
-            await rest.sendMessage(channel.id, { content: `testing rate limit manager ${index}` })
-          }),
-        )
-      }),
-    )
+      const messagePromises = Array.from({ length: 10 }, async (_, j) => {
+        await rest.sendMessage(channel.id, { content: `testing rate limit manager ${j}` })
+      })
+
+      await Promise.all(messagePromises)
+    })
+
+    await Promise.all(promises)
   })
 })

--- a/packages/rest/tests/e2e/misc.spec.ts
+++ b/packages/rest/tests/e2e/misc.spec.ts
@@ -3,12 +3,7 @@ import { e2eCache, rest } from './utils.js'
 
 describe('Typings', () => {
   it('Trigger Typing Indication', async () => {
-    const channel = await rest.createChannel(e2eCache.guild.id, { name: 'typing' })
-    after(async () => {
-      // Clean up the channel created for testing
-      await rest.deleteChannel(channel.id)
-    })
-    await rest.triggerTypingIndicator(channel.id)
+    await rest.triggerTypingIndicator(e2eCache.channel.id)
   })
 })
 

--- a/packages/rest/tests/e2e/role.spec.ts
+++ b/packages/rest/tests/e2e/role.spec.ts
@@ -6,17 +6,13 @@ import { e2eCache, rest } from './utils.js'
 describe('Role tests', async () => {
   // Create a role with a reason
   it('Create a role with a reason', async () => {
-    const role = await rest.createRole(
-      e2eCache.guild?.id,
-      {
-        name: `test role ${Date.now()}`,
-      },
-      'test reason',
-    )
+    const role = await rest.createRole(e2eCache.guild?.id, { name: `test role ${Date.now()}` }, 'test reason')
+
     after(async () => {
       // Clean up the role created for testing
       await rest.deleteRole(e2eCache.guild.id, role.id)
     })
+
     expect(role.id).to.exist
   })
 
@@ -25,10 +21,12 @@ describe('Role tests', async () => {
     const role = await rest.createRole(e2eCache.guild.id, {
       name: `test role ${Date.now()}`,
     })
+
     after(async () => {
       // Clean up the role created for testing
       await rest.deleteRole(e2eCache.guild.id, role.id)
     })
+
     expect(role.id).to.exist
   })
 
@@ -37,7 +35,9 @@ describe('Role tests', async () => {
     const role = await rest.createRole(e2eCache.guild.id, {
       name: `test role ${Date.now()}`,
     })
+
     await rest.deleteRole(e2eCache.guild.id, role.id)
+
     const deletedRoles = await rest.getRoles(e2eCache.guild.id)
     expect(deletedRoles.some((r) => r.id === role.id)).to.equal(false)
   })
@@ -47,10 +47,12 @@ describe('Role tests', async () => {
     const role = await rest.createRole(e2eCache.guild.id, {
       name: `test role ${Date.now()}`,
     })
+
     after(async () => {
       // Clean up the role created for testing
       await rest.deleteRole(e2eCache.guild.id, role.id)
     })
+
     const edited = await rest.editRole(e2eCache.guild.id, role.id, {
       name: 'test role 4',
       color: 0x0000ff,
@@ -58,15 +60,18 @@ describe('Role tests', async () => {
       mentionable: true,
       permissions: ['SEND_MESSAGES', 'VIEW_CHANNEL'],
     })
+
     expect(edited.name).to.equal('test role 4')
     expect(edited.color).to.equal(0x0000ff)
     expect(edited.hoist).to.equal(true)
     expect(edited.mentionable).to.equal(true)
     expect(edited.permissions.toString()).to.equal(calculateBits(['SEND_MESSAGES', 'VIEW_CHANNEL']))
+
     await rest.editRole(e2eCache.guild.id, role.id, {
       hoist: false,
       mentionable: false,
     })
+
     const roles = await rest.getRoles(e2eCache.guild.id)
     const unedited = roles.find((r) => r.id === role.id)
     expect(unedited?.hoist).to.equal(false)
@@ -77,21 +82,26 @@ describe('Role tests', async () => {
     const role = await rest.createRole(e2eCache.guild.id, {
       name: `test role ${Date.now()}`,
     })
+
     after(async () => {
       // Clean up the role created for testing
       await rest.deleteRole(e2eCache.guild.id, role.id)
     })
+
     // Assign the role to the user
     await rest.addRole(e2eCache.guild.id, rest.applicationId, role.id)
     const member = await rest.getMember(e2eCache.guild.id, rest.applicationId)
     expect(member?.roles.includes(role.id)).to.equal(true)
+
     await rest.removeRole(e2eCache.guild.id, rest.applicationId, role.id)
     const removed = await rest.getMember(e2eCache.guild.id, rest.applicationId)
     expect(removed?.roles.includes(role.id)).to.equal(false)
+
     // With a reason
     await rest.addRole(e2eCache.guild.id, rest.applicationId, role.id, 'test reason')
     const member2 = await rest.getMember(e2eCache.guild.id, rest.applicationId)
     expect(member2?.roles.includes(role.id)).to.equal(true)
+
     await rest.removeRole(e2eCache.guild.id, rest.applicationId, role.id, 'test reason')
     const member3 = await rest.getMember(e2eCache.guild.id, rest.applicationId)
     expect(member3?.roles.includes(role.id)).to.equal(false)

--- a/packages/rest/tests/e2e/stickers.spec.ts
+++ b/packages/rest/tests/e2e/stickers.spec.ts
@@ -22,34 +22,35 @@ describe('Sticker tests', async () => {
         name: 'ddlogo.png',
       },
     })
+
     expect(sticker.name).to.equal('sticker name')
     expect(sticker.description).to.equal('sticker description')
     expect(sticker.tags).to.equal('sticker tags')
-    const channel = await rest.createChannel(e2eCache.guild.id, {
-      name: 'test',
-    })
-    after(async () => {
-      // Clean up the channel created for testing
-      await rest.deleteChannel(channel.id)
-    })
-    const message = await rest.sendMessage(channel.id, {
+
+    const message = await rest.sendMessage(e2eCache.channel.id, {
       stickerIds: [sticker.id],
     })
+
     expect(message.stickerItems?.[0].formatType).to.equal(StickerFormatTypes.Png)
     expect(message.stickerItems?.[0].id).to.equal(sticker.id)
     expect(message.stickerItems?.[0].name).to.equal(sticker.name)
+
     const getSticker = await rest.getGuildSticker(e2eCache.guild.id, sticker.id)
+
     expect(getSticker.name).to.equal('sticker name')
     expect(getSticker.description).to.equal('sticker description')
     expect(getSticker.tags).to.equal('sticker tags')
+
     const editSticker = await rest.editGuildSticker(e2eCache.guild.id, sticker.id, {
       name: 'sticker name',
       description: 'sticker description',
       tags: 'sticker tags',
     })
+
     expect(editSticker.name).to.equal('sticker name')
     expect(editSticker.description).to.equal('sticker description')
     expect(editSticker.tags).to.equal('sticker tags')
+
     const sticker2 = await rest.createGuildSticker(e2eCache.guild.id, {
       name: 'sticker 2',
       description: 'sticker 2',
@@ -59,12 +60,15 @@ describe('Sticker tests', async () => {
         name: 'ddlogo.png',
       },
     })
+
     after(async () => {
       // Clean up the sticker created for testing
       await rest.deleteGuildSticker(e2eCache.guild.id, sticker2.id)
     })
+
     const stickers = await rest.getGuildStickers(e2eCache.guild.id)
     expect(stickers.length).to.greaterThan(1)
+
     await rest.deleteGuildSticker(e2eCache.guild.id, sticker.id)
     await expect(rest.getGuildSticker(e2eCache.guild.id, sticker.id)).to.eventually.rejected
   })

--- a/packages/rest/tests/e2e/webhook.spec.ts
+++ b/packages/rest/tests/e2e/webhook.spec.ts
@@ -6,76 +6,74 @@ chaiUse(chaiAsPromised)
 
 describe('Webhook helpers', async () => {
   it('Manage webhooks', async () => {
-    const channel = await rest.createChannel(e2eCache.guild.id, {
-      name: 'wbhook',
-    })
-    after(async () => {
-      // Clean up the channel after the tests
-      await rest.deleteChannel(channel.id)
-    })
-
-    const webhook = await rest.createWebhook(channel.id, {
+    const webhook = await rest.createWebhook(e2eCache.channel.id, {
       name: 'idk',
     })
     expect(webhook).to.exist
     expect(webhook.name).to.equal('idk')
     expect(webhook.token).to.exist
+
     const fetched = await rest.getWebhook(webhook.id)
     expect(fetched).to.exist
     expect(webhook.id).to.equal(fetched.id)
+
     const fetched2 = await rest.getWebhookWithToken(webhook.id, webhook.token!)
     expect(webhook.id).to.equal(fetched2.id)
+
     const edited = await rest.editWebhook(webhook.id, {
       name: 'edited',
     })
     expect(webhook.name).to.not.equal(edited.name)
+
     const edited2 = await rest.editWebhookWithToken(webhook.id, webhook.token!, {
       name: 'editedtoken',
     })
     expect(edited.name).to.not.equal(edited2.name)
-    await rest.createWebhook(channel.id, { name: 'idkk' })
-    const hooks = await rest.getChannelWebhooks(channel.id)
+
+    await rest.createWebhook(e2eCache.channel.id, { name: 'idkk' })
+    const hooks = await rest.getChannelWebhooks(e2eCache.channel.id)
     expect(hooks.length).to.greaterThan(1)
-    const guildHooks = await rest.getGuildWebhooks(channel.guildId!)
+
+    const guildHooks = await rest.getGuildWebhooks(e2eCache.guild.id)
     expect(guildHooks.length).to.greaterThan(1)
+
     await rest.deleteWebhook(webhook.id)
     // Fetch the webhook to validate it was deleted
     await expect(rest.getWebhook(webhook.id)).to.eventually.rejected
-    const hookToDelete = await rest.createWebhook(channel.id, {
+
+    const hookToDelete = await rest.createWebhook(e2eCache.channel.id, {
       name: 'delme',
     })
     expect(hookToDelete?.id).to.exist
     expect(hookToDelete.token).to.exist
+
     await rest.deleteWebhookWithToken(hookToDelete.id, hookToDelete.token!)
     // Fetch the webhook to validate it was deleted
     await expect(rest.getWebhook(hookToDelete.id)).to.eventually.rejected
   })
 
   it('Manage webhook messages', async () => {
-    const channel = await rest.createChannel(e2eCache.guild.id, {
-      name: 'wbhook',
-    })
-    after(async () => {
-      // Clean up the channel after the tests
-      await rest.deleteChannel(channel.id)
-    })
-    const webhook = await rest.createWebhook(channel.id, {
+    const webhook = await rest.createWebhook(e2eCache.channel.id, {
       name: 'idk',
     })
     expect(webhook).to.exist
+
     const message = await rest.executeWebhook(webhook.id, webhook.token!, {
       content: 'discordeno is best lib',
       wait: true,
     })
     expect(message?.id).to.exist
+
     const message2 = await rest.getWebhookMessage(webhook.id, webhook.token!, message!.id)
     expect(message2).to.exist
     expect(message2.content).to.equal(message?.content)
+
     const edited3 = await rest.editWebhookMessage(webhook.id, webhook.token!, message!.id, {
       content: 'different',
     })
     expect(edited3).to.exist
     expect(edited3.content).to.not.equal(message2.content)
+
     await rest.deleteWebhookMessage(webhook.id, webhook.token!, message!.id)
     await expect(rest.getWebhookMessage(webhook.id, webhook.token!, message!.id)).to.eventually.rejected
   })


### PR DESCRIPTION
Currently we create a lot of channels despite having one "global" channel per E2E execution



Also we created emojis but never deleted them, so now tests are failing because we ran out of emoji capacity

