### PR TITLE
chore: Disable runOn folderOpen for turbo watch vscode task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,7 +12,6 @@
         "panel": "dedicated"
       },
       "runOptions": {
-        "runOn": "folderOpen",
         "instanceLimit": 1
       },
       "problemMatcher": []


### PR DESCRIPTION
The task currently opens up as soon as visual studio code opens the folder
and it is very much annoying since it pops up immediately and also for example
for me it makes my pc lag quite a bit due to the amount of files being watched
and git processes that it spawns to calculate the hashes (this is at least
my understanding of what it is doing with all the git processes)
