### PR TITLE
ci: Use biome ci in lib-check format

### DIFF
--- a/.github/workflows/lib-check.yml
+++ b/.github/workflows/lib-check.yml
@@ -59,20 +59,13 @@ jobs:
           node-version: 20
           cache: yarn
       - run: yarn install --immutable
-      - name: Turbo Cache
-        id: turbo-cache
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-lint-${{ github.sha }}
       - name: Build type cache
-        if: steps.turbo-cache.outputs.cache-hit != 'true'
         uses: actions/cache@v4
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-build:type-${{ github.sha }}
       - name: Check Formatting
-        run: yarn lint --cache-dir=".turbo"
+        run: yarn biome ci --reporter=github
 
   test-type-unit-and-integration-test:
     name: Typecheck Tests


### PR DESCRIPTION
This will allow biome to actually show if there are any format/lint errors as right know unless you go search in the logs they won't get reported 