### PR TITLE
feat(bot)!: Remove bot.events.guildUnavailable

### DIFF
--- a/packages/bot/src/events.ts
+++ b/packages/bot/src/events.ts
@@ -136,8 +136,7 @@ export type EventHandlers<TProps extends TransformersDesiredProperties, TBehavio
   guildBanAdd: (user: SetupDesiredProps<User, TProps, TBehavior>, guildId: bigint) => unknown
   guildBanRemove: (user: SetupDesiredProps<User, TProps, TBehavior>, guildId: bigint) => unknown
   guildCreate: (guild: SetupDesiredProps<Guild, TProps, TBehavior>) => unknown
-  guildDelete: (id: bigint, shardId: number) => unknown
-  guildUnavailable: (id: bigint, shardId: number) => unknown
+  guildDelete: (data: { id: bigint; unavailable: boolean }, shardId: number) => unknown
   guildUpdate: (guild: SetupDesiredProps<Guild, TProps, TBehavior>) => unknown
   raw: (data: DiscordGatewayPayload, shardId: number) => unknown
   roleCreate: (role: SetupDesiredProps<Role, TProps, TBehavior>) => unknown

--- a/packages/bot/src/handlers/guilds/GUILD_DELETE.ts
+++ b/packages/bot/src/handlers/guilds/GUILD_DELETE.ts
@@ -2,14 +2,15 @@ import type { DiscordGatewayPayload, DiscordUnavailableGuild } from '@discordeno
 import type { Bot } from '../../bot.js'
 
 export async function handleGuildDelete(bot: Bot, data: DiscordGatewayPayload, shardId: number): Promise<void> {
+  if (!bot.events.guildDelete) return
+
   const payload = data.d as DiscordUnavailableGuild
 
-  if (bot.events.guildUnavailable && payload.unavailable) {
-    bot.events.guildUnavailable(bot.transformers.snowflake(payload.id), shardId)
-    return
-  }
-
-  if (bot.events.guildDelete) {
-    bot.events.guildDelete(bot.transformers.snowflake(payload.id), shardId)
-  }
+  bot.events.guildDelete(
+    {
+      id: bot.transformers.snowflake(payload.id),
+      unavailable: payload.unavailable ?? false,
+    },
+    shardId,
+  )
 }


### PR DESCRIPTION
It is now merged with the guildDelete event
