### PR TITLE
chore(.github): Assign @discordeno/team to most codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,3 @@
 *                          @discordeno/team
 
 /.github/CODEOWNERS        @Skillz4Killz @itohatweb
-/.github/workflows/        @discordeno/team
-/.yarn/                    @discordeno/team
-/.yarnrc.yml               @discordeno/team
-/codecov.yml               @discordeno/team
-/packages/*/package.json   @discordeno/team
-/package.json              @discordeno/team
-/turbo.json                @discordeno/team


### PR DESCRIPTION
Also removes /.github/sync.yml, that file does not exist
