### PR TITLE
feat(bot)!: Make desiredProperties required

### DIFF
--- a/packages/benchmarks/src/benchmarks/memory.ts
+++ b/packages/benchmarks/src/benchmarks/memory.ts
@@ -9,6 +9,7 @@ await memoryBenchmark(
       token: ' ',
       applicationId: 1n,
       events: {},
+      desiredProperties: {},
     }),
   (bot, event) => {
     const eventName = snakeToCamelCase(event.payload.t!)

--- a/packages/benchmarks/src/benchmarks/transformers.ts
+++ b/packages/benchmarks/src/benchmarks/transformers.ts
@@ -26,38 +26,45 @@ const bot = createBot({
   token: process.env.DISCORD_TOKEN ?? ' ',
   applicationId: 1n,
   events: {},
+  desiredProperties: {
+    message: {
+      activity: true,
+      application: true,
+      applicationId: true,
+      attachments: true,
+      author: true,
+      channelId: true,
+      components: true,
+      content: true,
+      editedTimestamp: true,
+      embeds: true,
+      guildId: true,
+      id: true,
+      member: true,
+      mentionedChannelIds: true,
+      mentionedRoleIds: true,
+      mentions: true,
+      nonce: true,
+      reactions: true,
+      stickerItems: true,
+      thread: true,
+      type: true,
+      webhookId: true,
+    },
+    messageInteraction: {
+      id: true,
+      member: true,
+      name: true,
+      user: true,
+      type: true,
+    },
+    messageReference: {
+      channelId: true,
+      guildId: true,
+      messageId: true,
+    },
+  },
 })
-
-bot.transformers.desiredProperties.message.activity = true
-bot.transformers.desiredProperties.message.application = true
-bot.transformers.desiredProperties.message.applicationId = true
-bot.transformers.desiredProperties.message.attachments = true
-bot.transformers.desiredProperties.message.author = true
-bot.transformers.desiredProperties.message.channelId = true
-bot.transformers.desiredProperties.message.components = true
-bot.transformers.desiredProperties.message.content = true
-bot.transformers.desiredProperties.message.editedTimestamp = true
-bot.transformers.desiredProperties.message.embeds = true
-bot.transformers.desiredProperties.message.guildId = true
-bot.transformers.desiredProperties.message.id = true
-bot.transformers.desiredProperties.messageInteraction.id = true
-bot.transformers.desiredProperties.messageInteraction.member = true
-bot.transformers.desiredProperties.messageInteraction.name = true
-bot.transformers.desiredProperties.messageInteraction.user = true
-bot.transformers.desiredProperties.messageInteraction.type = true
-bot.transformers.desiredProperties.message.member = true
-bot.transformers.desiredProperties.message.mentionedChannelIds = true
-bot.transformers.desiredProperties.message.mentionedRoleIds = true
-bot.transformers.desiredProperties.message.mentions = true
-bot.transformers.desiredProperties.messageReference.messageId = true
-bot.transformers.desiredProperties.messageReference.channelId = true
-bot.transformers.desiredProperties.messageReference.guildId = true
-bot.transformers.desiredProperties.message.nonce = true
-bot.transformers.desiredProperties.message.reactions = true
-bot.transformers.desiredProperties.message.stickerItems = true
-bot.transformers.desiredProperties.message.thread = true
-bot.transformers.desiredProperties.message.type = true
-bot.transformers.desiredProperties.message.webhookId = true
 
 const URL = 'https://discordeno.js.org/'
 const IMAGE_HASH = '5fff867ae5f666fcd0626bd84f5e69c0'

--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -129,10 +129,8 @@ export interface CreateBotOptions<TProps extends RecursivePartial<TransformersDe
   handlers?: Partial<Record<GatewayDispatchEventNames, BotGatewayHandler<CompleteDesiredProperties<NoInfer<TProps>>, TBehavior>>>
   /**
    * Set the desired properties for the bot
-   *
-   * @default {}
    */
-  desiredProperties?: TProps
+  desiredProperties: TProps
   /**
    * Set the desired properties behavior for undesired properties
    *

--- a/packages/bot/tests/e2e/resetguilds.spec.ts
+++ b/packages/bot/tests/e2e/resetguilds.spec.ts
@@ -11,6 +11,7 @@ describe('[Bot] Can start and stop the bot', () => {
   it('Start and stop the bot', async () => {
     const bot = createBot({
       token,
+      desiredProperties: {},
     })
 
     await bot.start()


### PR DESCRIPTION
Allowing desired properties to be omitted makes it harder to get started with discordeno as you won't know you need them unless you read the docs
