### PR TITLE
ci: Use `biome ci` in lib-check format

### DIFF
--- a/.github/workflows/lib-check.yml
+++ b/.github/workflows/lib-check.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Build Types
         run: yarn build:type --cache-dir=".turbo"
       - name: Check Formatting
-        run: yarn check:all
+        run: yarn biome ci --reporter=github
 
   test-type-unit-and-integration-test:
     name: Typecheck Tests


### PR DESCRIPTION
The change was done in https://github.com/discordeno/discordeno/pull/4319 but during the main branch merge(s) it got lost due to conflicts (?)



So this pr actually makes lib-check use `biome ci`

