### PR TITLE
chore: Imports directly from files instead of index files

### DIFF
--- a/packages/bot/src/commandOptionsParser.ts
+++ b/packages/bot/src/commandOptionsParser.ts
@@ -1,17 +1,6 @@
 import { ApplicationCommandOptionTypes } from '@discordeno/types'
-import type {
-  Attachment,
-  Channel,
-  CompleteDesiredProperties,
-  DesiredPropertiesBehavior,
-  Interaction,
-  InteractionDataOption,
-  Member,
-  Role,
-  SetupDesiredProps,
-  TransformersDesiredProperties,
-  User,
-} from './index.js'
+import type { CompleteDesiredProperties, DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from './desiredProperties.js'
+import type { Attachment, Channel, Interaction, InteractionDataOption, Member, Role, User } from './transformers/types.js'
 
 export function commandOptionsParser<
   TProps extends TransformersDesiredProperties & { interaction: { data: true } },

--- a/packages/bot/src/desiredProperties.ts
+++ b/packages/bot/src/desiredProperties.ts
@@ -1,7 +1,7 @@
 import type { RecursivePartial } from '@discordeno/types'
 import type { Collection } from '@discordeno/utils'
 import type { Bot } from './bot.js'
-import type { InteractionResolvedDataChannel, InteractionResolvedDataMember } from './index.js'
+import type { InteractionResolvedDataChannel, InteractionResolvedDataMember } from './commandOptionsParser.js'
 import type {
   ActivityInstance,
   ActivityLocation,
@@ -56,7 +56,7 @@ import type {
   UserPrimaryGuild,
   VoiceState,
   Webhook,
-} from './transformers/index.js'
+} from './transformers/types.js'
 
 /**
  * All the objects that support desired properties

--- a/packages/bot/src/handlers.ts
+++ b/packages/bot/src/handlers.ts
@@ -1,5 +1,7 @@
+import type { DiscordGatewayPayload, GatewayDispatchEventNames } from '@discordeno/types'
+import type { Bot } from './bot.js'
+import type { DesiredPropertiesBehavior, TransformersDesiredProperties } from './desiredProperties.js'
 import * as handlers from './handlers/index.js'
-import type { Bot, DesiredPropertiesBehavior, DiscordGatewayPayload, GatewayDispatchEventNames, TransformersDesiredProperties } from './index.js'
 
 export function createBotGatewayHandlers<TProps extends TransformersDesiredProperties, TBehavior extends DesiredPropertiesBehavior>(
   options: Partial<GatewayHandlers<TProps, TBehavior>>,

--- a/packages/bot/src/handlers/channels/CHANNEL_CREATE.ts
+++ b/packages/bot/src/handlers/channels/CHANNEL_CREATE.ts
@@ -1,4 +1,5 @@
-import type { Bot, DiscordChannel, DiscordGatewayPayload } from '../../index.js'
+import type { DiscordChannel, DiscordGatewayPayload } from '@discordeno/types'
+import type { Bot } from '../../bot.js'
 
 export async function handleChannelCreate(bot: Bot, payload: DiscordGatewayPayload, _shardId: number): Promise<void> {
   if (!bot.events.channelCreate) return

--- a/packages/bot/src/handlers/channels/THREAD_CREATE.ts
+++ b/packages/bot/src/handlers/channels/THREAD_CREATE.ts
@@ -1,5 +1,5 @@
 import type { DiscordChannel, DiscordGatewayPayload } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleThreadCreate(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.threadCreate) return

--- a/packages/bot/src/handlers/channels/THREAD_DELETE.ts
+++ b/packages/bot/src/handlers/channels/THREAD_DELETE.ts
@@ -1,5 +1,5 @@
 import type { DiscordChannel, DiscordGatewayPayload } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleThreadDelete(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.threadDelete) return

--- a/packages/bot/src/handlers/channels/THREAD_LIST_SYNC.ts
+++ b/packages/bot/src/handlers/channels/THREAD_LIST_SYNC.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordThreadListSync } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleThreadListSync(bot: Bot, data: DiscordGatewayPayload): Promise<any> {
   if (!bot.events.threadListSync) return

--- a/packages/bot/src/handlers/channels/THREAD_MEMBERS_UPDATE.ts
+++ b/packages/bot/src/handlers/channels/THREAD_MEMBERS_UPDATE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordThreadMembersUpdate } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleThreadMembersUpdate(bot: Bot, data: DiscordGatewayPayload, _shardId: number): Promise<void> {
   if (!bot.events.threadMembersUpdate) return

--- a/packages/bot/src/handlers/channels/THREAD_MEMBER_UPDATE.ts
+++ b/packages/bot/src/handlers/channels/THREAD_MEMBER_UPDATE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordThreadMemberUpdate } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleThreadMemberUpdate(bot: Bot, data: DiscordGatewayPayload, _shardId: number): Promise<void> {
   if (!bot.events.threadMemberUpdate) return

--- a/packages/bot/src/handlers/channels/THREAD_UPDATE.ts
+++ b/packages/bot/src/handlers/channels/THREAD_UPDATE.ts
@@ -1,5 +1,5 @@
 import type { DiscordChannel, DiscordGatewayPayload } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleThreadUpdate(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.threadUpdate) return

--- a/packages/bot/src/handlers/guilds/GUILD_STICKERS_UPDATE.ts
+++ b/packages/bot/src/handlers/guilds/GUILD_STICKERS_UPDATE.ts
@@ -1,4 +1,5 @@
-import type { Bot, DiscordGatewayPayload, DiscordGuildStickersUpdate } from '../../index.js'
+import type { DiscordGatewayPayload, DiscordGuildStickersUpdate } from '@discordeno/types'
+import type { Bot } from '../../bot.js'
 
 export async function handleGuildStickersUpdate(bot: Bot, data: DiscordGatewayPayload, _shardId: number): Promise<void> {
   if (!bot.events.guildStickersUpdate) return

--- a/packages/bot/src/handlers/integrations/INTEGRATION_CREATE.ts
+++ b/packages/bot/src/handlers/integrations/INTEGRATION_CREATE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordIntegrationCreateUpdate } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleIntegrationCreate(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.integrationCreate) return

--- a/packages/bot/src/handlers/integrations/INTEGRATION_DELETE.ts
+++ b/packages/bot/src/handlers/integrations/INTEGRATION_DELETE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordIntegrationDelete } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleIntegrationDelete(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.integrationDelete) return

--- a/packages/bot/src/handlers/integrations/INTEGRATION_UPDATE.ts
+++ b/packages/bot/src/handlers/integrations/INTEGRATION_UPDATE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordIntegrationCreateUpdate } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleIntegrationUpdate(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.integrationUpdate) return

--- a/packages/bot/src/handlers/interactions/APPLICATION_COMMAND_PERMISSIONS_UPDATE.ts
+++ b/packages/bot/src/handlers/interactions/APPLICATION_COMMAND_PERMISSIONS_UPDATE.ts
@@ -1,4 +1,5 @@
-import type { Bot, DiscordGatewayPayload, DiscordGuildApplicationCommandPermissions } from '../../index.js'
+import type { DiscordGatewayPayload, DiscordGuildApplicationCommandPermissions } from '@discordeno/types'
+import type { Bot } from '../../bot.js'
 
 export async function handleApplicationCommandPermissionsUpdate(bot: Bot, data: DiscordGatewayPayload, _shardId: number): Promise<void> {
   if (!bot.events.applicationCommandPermissionsUpdate) return

--- a/packages/bot/src/handlers/interactions/INTERACTION_CREATE.ts
+++ b/packages/bot/src/handlers/interactions/INTERACTION_CREATE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordInteraction } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleInteractionCreate(bot: Bot, data: DiscordGatewayPayload, shardId: number): Promise<void> {
   if (!bot.events.interactionCreate) return

--- a/packages/bot/src/handlers/invites/INVITE_CREATE.ts
+++ b/packages/bot/src/handlers/invites/INVITE_CREATE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordInviteCreate } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleInviteCreate(bot: Bot, data: DiscordGatewayPayload, shardId: number): Promise<void> {
   if (!bot.events.inviteCreate) return

--- a/packages/bot/src/handlers/invites/INVITE_DELETE.ts
+++ b/packages/bot/src/handlers/invites/INVITE_DELETE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordInviteDelete } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleInviteDelete(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.inviteDelete) return

--- a/packages/bot/src/handlers/members/GUILD_MEMBERS_CHUNK.ts
+++ b/packages/bot/src/handlers/members/GUILD_MEMBERS_CHUNK.ts
@@ -1,6 +1,6 @@
 import type { DiscordGatewayPayload, DiscordGuildMembersChunk } from '@discordeno/types'
 import { camelize } from '@discordeno/utils'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleGuildMembersChunk(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   const payload = data.d as DiscordGuildMembersChunk

--- a/packages/bot/src/handlers/members/GUILD_MEMBER_ADD.ts
+++ b/packages/bot/src/handlers/members/GUILD_MEMBER_ADD.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordGuildMemberAdd } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleGuildMemberAdd(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.guildMemberAdd) return

--- a/packages/bot/src/handlers/members/GUILD_MEMBER_REMOVE.ts
+++ b/packages/bot/src/handlers/members/GUILD_MEMBER_REMOVE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordGuildMemberRemove } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleGuildMemberRemove(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.guildMemberRemove) return

--- a/packages/bot/src/handlers/members/GUILD_MEMBER_UPDATE.ts
+++ b/packages/bot/src/handlers/members/GUILD_MEMBER_UPDATE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordGuildMemberUpdate } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleGuildMemberUpdate(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.guildMemberUpdate) return

--- a/packages/bot/src/handlers/messages/MESSAGE_CREATE.ts
+++ b/packages/bot/src/handlers/messages/MESSAGE_CREATE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordMessage } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleMessageCreate(bot: Bot, data: DiscordGatewayPayload, shardId: number): Promise<void> {
   if (!bot.events.messageCreate) return

--- a/packages/bot/src/handlers/messages/MESSAGE_DELETE.ts
+++ b/packages/bot/src/handlers/messages/MESSAGE_DELETE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordMessageDelete } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleMessageDelete(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.messageDelete) return

--- a/packages/bot/src/handlers/messages/MESSAGE_DELETE_BULK.ts
+++ b/packages/bot/src/handlers/messages/MESSAGE_DELETE_BULK.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordMessageDeleteBulk } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleMessageDeleteBulk(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.messageDeleteBulk) return

--- a/packages/bot/src/handlers/messages/MESSAGE_REACTION_ADD.ts
+++ b/packages/bot/src/handlers/messages/MESSAGE_REACTION_ADD.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordMessageReactionAdd } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleMessageReactionAdd(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.reactionAdd) return

--- a/packages/bot/src/handlers/messages/MESSAGE_REACTION_REMOVE.ts
+++ b/packages/bot/src/handlers/messages/MESSAGE_REACTION_REMOVE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordMessageReactionRemove } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleMessageReactionRemove(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.reactionRemove) return

--- a/packages/bot/src/handlers/messages/MESSAGE_REACTION_REMOVE_ALL.ts
+++ b/packages/bot/src/handlers/messages/MESSAGE_REACTION_REMOVE_ALL.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordMessageReactionRemoveAll } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleMessageReactionRemoveAll(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.reactionRemoveAll) return

--- a/packages/bot/src/handlers/messages/MESSAGE_REACTION_REMOVE_EMOJI.ts
+++ b/packages/bot/src/handlers/messages/MESSAGE_REACTION_REMOVE_EMOJI.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordMessageReactionRemoveEmoji } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleMessageReactionRemoveEmoji(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.reactionRemoveEmoji) return

--- a/packages/bot/src/handlers/messages/MESSAGE_UPDATE.ts
+++ b/packages/bot/src/handlers/messages/MESSAGE_UPDATE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordMessage } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleMessageUpdate(bot: Bot, data: DiscordGatewayPayload, shardId: number): Promise<void> {
   if (!bot.events.messageUpdate) return

--- a/packages/bot/src/handlers/misc/PRESENCE_UPDATE.ts
+++ b/packages/bot/src/handlers/misc/PRESENCE_UPDATE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordPresenceUpdate } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handlePresenceUpdate(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.presenceUpdate) return

--- a/packages/bot/src/handlers/misc/RATE_LIMITED.ts
+++ b/packages/bot/src/handlers/misc/RATE_LIMITED.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordRateLimited } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleRateLimited(bot: Bot, data: DiscordGatewayPayload, shardId: number): Promise<void> {
   if (!bot.events.rateLimited) return

--- a/packages/bot/src/handlers/misc/READY.ts
+++ b/packages/bot/src/handlers/misc/READY.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordReady } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleReady(bot: Bot, data: DiscordGatewayPayload, shardId: number): Promise<void> {
   if (!bot.events.ready) return

--- a/packages/bot/src/handlers/misc/RESUMED.ts
+++ b/packages/bot/src/handlers/misc/RESUMED.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleResumed(bot: Bot, _data: DiscordGatewayPayload, shardId: number): Promise<void> {
   if (!bot.events.resumed) return

--- a/packages/bot/src/handlers/misc/TYPING_START.ts
+++ b/packages/bot/src/handlers/misc/TYPING_START.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordTypingStart } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleTypingStart(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.typingStart) return

--- a/packages/bot/src/handlers/misc/USER_UPDATE.ts
+++ b/packages/bot/src/handlers/misc/USER_UPDATE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordUser } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleUserUpdate(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.botUpdate) return

--- a/packages/bot/src/handlers/poll/MESSAGE_POLL_VOTE_ADD.ts
+++ b/packages/bot/src/handlers/poll/MESSAGE_POLL_VOTE_ADD.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordPollVoteAdd } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleMessagePollVoteAdd(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.messagePollVoteAdd) return

--- a/packages/bot/src/handlers/poll/MESSAGE_POLL_VOTE_REMOVE.ts
+++ b/packages/bot/src/handlers/poll/MESSAGE_POLL_VOTE_REMOVE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordPollVoteRemove } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleMessagePollVoteRemove(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.messagePollVoteRemove) return

--- a/packages/bot/src/handlers/roles/GUILD_ROLE_CREATE.ts
+++ b/packages/bot/src/handlers/roles/GUILD_ROLE_CREATE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordGuildRoleCreate } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleGuildRoleCreate(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.roleCreate) return

--- a/packages/bot/src/handlers/roles/GUILD_ROLE_DELETE.ts
+++ b/packages/bot/src/handlers/roles/GUILD_ROLE_DELETE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordGuildRoleDelete } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleGuildRoleDelete(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.roleDelete) return

--- a/packages/bot/src/handlers/roles/GUILD_ROLE_UPDATE.ts
+++ b/packages/bot/src/handlers/roles/GUILD_ROLE_UPDATE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordGuildRoleUpdate } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleGuildRoleUpdate(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.roleUpdate) return

--- a/packages/bot/src/handlers/soundboard/GUILD_SOUNDBOARD_SOUNDS_UPDATE.ts
+++ b/packages/bot/src/handlers/soundboard/GUILD_SOUNDBOARD_SOUNDS_UPDATE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordSoundboardSoundsUpdate } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleGuildSoundboardSoundsUpdate(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.soundboardSoundsUpdate) return

--- a/packages/bot/src/handlers/soundboard/GUILD_SOUNDBOARD_SOUND_CREATE.ts
+++ b/packages/bot/src/handlers/soundboard/GUILD_SOUNDBOARD_SOUND_CREATE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordSoundboardSound } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleGuildSoundboardSoundCreate(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.soundboardSoundCreate) return

--- a/packages/bot/src/handlers/soundboard/GUILD_SOUNDBOARD_SOUND_DELETE.ts
+++ b/packages/bot/src/handlers/soundboard/GUILD_SOUNDBOARD_SOUND_DELETE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordSoundboardSoundDelete } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleGuildSoundboardSoundDelete(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.soundboardSoundDelete) return

--- a/packages/bot/src/handlers/soundboard/GUILD_SOUNDBOARD_SOUND_UPDATE.ts
+++ b/packages/bot/src/handlers/soundboard/GUILD_SOUNDBOARD_SOUND_UPDATE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordSoundboardSound } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleGuildSoundboardSoundUpdate(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.soundboardSoundUpdate) return

--- a/packages/bot/src/handlers/soundboard/SOUNDBOARD_SOUNDS.ts
+++ b/packages/bot/src/handlers/soundboard/SOUNDBOARD_SOUNDS.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordSoundboardSounds } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleSoundboardSounds(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.soundboardSounds) return

--- a/packages/bot/src/handlers/voice/VOICE_CHANNEL_EFFECT_SEND.ts
+++ b/packages/bot/src/handlers/voice/VOICE_CHANNEL_EFFECT_SEND.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordVoiceChannelEffectSend } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleVoiceChannelEffectSend(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.voiceChannelEffectSend) return

--- a/packages/bot/src/handlers/voice/VOICE_SERVER_UPDATE.ts
+++ b/packages/bot/src/handlers/voice/VOICE_SERVER_UPDATE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordVoiceServerUpdate } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleVoiceServerUpdate(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.voiceServerUpdate) return

--- a/packages/bot/src/handlers/voice/VOICE_STATE_UPDATE.ts
+++ b/packages/bot/src/handlers/voice/VOICE_STATE_UPDATE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordVoiceState } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleVoiceStateUpdate(bot: Bot, data: DiscordGatewayPayload): Promise<void> {
   if (!bot.events.voiceStateUpdate) return

--- a/packages/bot/src/handlers/webhooks/WEBHOOKS_UPDATE.ts
+++ b/packages/bot/src/handlers/webhooks/WEBHOOKS_UPDATE.ts
@@ -1,5 +1,5 @@
 import type { DiscordGatewayPayload, DiscordWebhookUpdate } from '@discordeno/types'
-import type { Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
 
 export async function handleWebhooksUpdate(bot: Bot, data: DiscordGatewayPayload, _shardId: number): Promise<void> {
   if (!bot.events.webhooksUpdate) return

--- a/packages/bot/src/helpers.ts
+++ b/packages/bot/src/helpers.ts
@@ -109,6 +109,7 @@ import type {
 import { snakelize } from '@discordeno/utils'
 import type { Bot } from './bot.js'
 import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from './desiredProperties.js'
+import type { ThreadMemberTransformerExtra } from './transformers/threadMember.js'
 import type {
   Application,
   ApplicationCommand,
@@ -139,12 +140,11 @@ import type {
   Subscription,
   Template,
   ThreadMember,
-  ThreadMemberTransformerExtra,
   User,
   VoiceState,
   Webhook,
   WelcomeScreen,
-} from './transformers/index.js'
+} from './transformers/types.js'
 
 export function createBotHelpers<TProps extends TransformersDesiredProperties, TBehavior extends DesiredPropertiesBehavior>(
   bot: Bot<TProps, TBehavior>,

--- a/packages/bot/src/transformers.ts
+++ b/packages/bot/src/transformers.ts
@@ -86,169 +86,154 @@ import {
   type TransformersDesiredProperties,
   type TransformProperty,
 } from './desiredProperties.js'
+import { transformActivity, transformActivityInstance, transformActivityLocation } from './transformers/activity.js'
+import { transformApplication } from './transformers/application.js'
+import { transformApplicationCommand } from './transformers/applicationCommand.js'
+import { transformApplicationCommandOption } from './transformers/applicationCommandOption.js'
+import { transformApplicationCommandOptionChoice } from './transformers/applicationCommandOptionChoice.js'
+import { transformApplicationCommandPermission } from './transformers/applicationCommandPermission.js'
+import { transformAttachment } from './transformers/attachment.js'
+import { transformAuditLogEntry } from './transformers/auditLogEntry.js'
+import { transformAutoModerationActionExecution } from './transformers/automodActionExecution.js'
+import { transformAutoModerationRule } from './transformers/automodRule.js'
+import { transformAvatarDecorationData } from './transformers/avatarDecorationData.js'
+import { transformChannel, transformForumTag } from './transformers/channel.js'
+import { transformComponent, transformMediaGalleryItem, transformUnfurledMediaItem } from './transformers/component.js'
+import { transformEmbed } from './transformers/embed.js'
+import { transformDefaultReactionEmoji, transformEmoji } from './transformers/emoji.js'
+import { transformEntitlement } from './transformers/entitlement.js'
+import { transformGatewayBot } from './transformers/gatewayBot.js'
+import { transformGuild } from './transformers/guild.js'
 import { transformIncidentsData } from './transformers/incidentsData.js'
+import { transformIntegration } from './transformers/integration.js'
 import {
-  type Activity,
-  type ActivityInstance,
-  type ActivityLocation,
-  type Application,
-  type ApplicationCommand,
-  type ApplicationCommandOption,
-  type ApplicationCommandOptionChoice,
-  type Attachment,
-  type AuditLogEntry,
-  type AutoModerationActionExecution,
-  type AutoModerationRule,
-  type AvatarDecorationData,
-  type Channel,
-  type Collectibles,
-  type Component,
-  type DefaultReactionEmoji,
-  type Embed,
-  type Emoji,
-  type Entitlement,
-  type ForumTag,
-  type GetGatewayBot,
-  type Guild,
-  type GuildApplicationCommandPermissions,
-  type GuildOnboarding,
-  type GuildOnboardingPrompt,
-  type GuildOnboardingPromptOption,
-  type GuildWidget,
-  type GuildWidgetSettings,
-  type IncidentsData,
-  type Integration,
-  type Interaction,
-  type InteractionCallback,
-  type InteractionCallbackResponse,
-  type InteractionDataOption,
-  type InteractionDataResolved,
-  type InteractionResource,
-  type Invite,
-  type InviteStageInstance,
-  type Lobby,
-  type LobbyMember,
-  type MediaGalleryItem,
-  type Member,
-  type Message,
-  type MessageCall,
-  type MessageInteractionMetadata,
-  type MessagePin,
-  type MessageSnapshot,
-  type Nameplate,
-  type Poll,
-  type PollMedia,
-  type PresenceUpdate,
-  type Role,
-  type RoleColors,
-  type ScheduledEvent,
-  type ScheduledEventRecurrenceRule,
-  type Sku,
-  type SoundboardSound,
-  type StageInstance,
-  type Sticker,
-  type StickerPack,
-  type Subscription,
-  type Team,
-  type Template,
-  type ThreadMember,
-  type ThreadMemberGuildCreate,
-  type ThreadMemberTransformerExtra,
-  transformActivity,
-  transformActivityInstance,
-  transformActivityLocation,
-  transformActivityToDiscordActivity,
-  transformApplication,
-  transformApplicationCommand,
-  transformApplicationCommandOption,
-  transformApplicationCommandOptionChoice,
-  transformApplicationCommandOptionChoiceToDiscordApplicationCommandOptionChoice,
-  transformApplicationCommandOptionToDiscordApplicationCommandOption,
-  transformApplicationCommandPermission,
-  transformApplicationCommandToDiscordApplicationCommand,
-  transformApplicationToDiscordApplication,
-  transformAttachment,
-  transformAttachmentToDiscordAttachment,
-  transformAuditLogEntry,
-  transformAutoModerationActionExecution,
-  transformAutoModerationRule,
-  transformAvatarDecorationData,
-  transformChannel,
-  transformCollectibles,
-  transformComponent,
-  transformComponentToDiscordComponent,
-  transformDefaultReactionEmoji,
-  transformEmbed,
-  transformEmbedToDiscordEmbed,
-  transformEmoji,
-  transformEntitlement,
-  transformForumTag,
-  transformGatewayBot,
-  transformGuild,
-  transformGuildOnboarding,
-  transformGuildOnboardingPrompt,
-  transformGuildOnboardingPromptOption,
-  transformIntegration,
   transformInteraction,
   transformInteractionCallback,
   transformInteractionCallbackResponse,
   transformInteractionDataOption,
   transformInteractionDataResolved,
   transformInteractionResource,
-  transformInvite,
-  transformInviteStageInstance,
-  transformLobby,
-  transformLobbyMember,
-  transformMediaGalleryItem,
-  transformMember,
-  transformMemberToDiscordMember,
+} from './transformers/interaction.js'
+import { transformInvite } from './transformers/invite.js'
+import { transformLobby, transformLobbyMember } from './transformers/lobby.js'
+import { transformMember } from './transformers/member.js'
+import {
   transformMessage,
   transformMessageCall,
   transformMessageInteractionMetadata,
   transformMessagePin,
   transformMessageSnapshot,
-  transformNameplate,
-  transformPoll,
-  transformPollMedia,
-  transformPresence,
-  transformRole,
-  transformRoleColors,
-  transformScheduledEvent,
-  transformScheduledEventRecurrenceRule,
-  transformSku,
-  transformSoundboardSound,
-  transformStageInstance,
-  transformSticker,
-  transformStickerPack,
-  transformSubscription,
-  transformTeam,
-  transformTeamToDiscordTeam,
-  transformTemplate,
-  transformThreadMember,
-  transformThreadMemberGuildCreate,
-  transformUnfurledMediaItem,
-  transformUser,
-  transformUserPrimaryGuild,
-  transformUserToDiscordUser,
-  transformVoiceRegion,
-  transformVoiceState,
-  transformWebhook,
-  transformWelcomeScreen,
-  transformWidget,
-  transformWidgetSettings,
-  type UnfurledMediaItem,
-  type User,
-  type UserPrimaryGuild,
-  type VoiceRegion,
-  type VoiceState,
-  type Webhook,
-  type WelcomeScreen,
-} from './transformers/index.js'
+} from './transformers/message.js'
+import { transformGuildOnboarding, transformGuildOnboardingPrompt, transformGuildOnboardingPromptOption } from './transformers/onboarding.js'
+import { transformPoll, transformPollMedia } from './transformers/poll.js'
+import { transformPresence } from './transformers/presence.js'
+import { transformActivityToDiscordActivity } from './transformers/reverse/activity.js'
+import { transformAllowedMentionsToDiscordAllowedMentions } from './transformers/reverse/allowedMentions.js'
+import { transformApplicationToDiscordApplication } from './transformers/reverse/application.js'
+import { transformApplicationCommandToDiscordApplicationCommand } from './transformers/reverse/applicationCommand.js'
+import { transformApplicationCommandOptionToDiscordApplicationCommandOption } from './transformers/reverse/applicationCommandOption.js'
+import { transformApplicationCommandOptionChoiceToDiscordApplicationCommandOptionChoice } from './transformers/reverse/applicationCommandOptionChoice.js'
+import { transformAttachmentToDiscordAttachment } from './transformers/reverse/attachment.js'
 import {
-  transformAllowedMentionsToDiscordAllowedMentions,
+  transformComponentToDiscordComponent,
   transformMediaGalleryItemToDiscordMediaGalleryItem,
   transformUnfurledMediaItemToDiscordUnfurledMediaItem,
-} from './transformers/reverse/index.js'
+} from './transformers/reverse/component.js'
+import { transformEmbedToDiscordEmbed } from './transformers/reverse/embed.js'
+import { transformMemberToDiscordMember, transformUserToDiscordUser } from './transformers/reverse/member.js'
+import { transformTeamToDiscordTeam } from './transformers/reverse/team.js'
+import { transformRole, transformRoleColors } from './transformers/role.js'
+import { transformScheduledEvent, transformScheduledEventRecurrenceRule } from './transformers/scheduledEvent.js'
+import { transformSku } from './transformers/sku.js'
+import { transformSoundboardSound } from './transformers/soundboardSound.js'
+import { transformStageInstance } from './transformers/stageInstance.js'
+import { transformInviteStageInstance } from './transformers/stageInviteInstance.js'
+import { transformSticker, transformStickerPack } from './transformers/sticker.js'
+import { transformSubscription } from './transformers/subscription.js'
+import { transformTeam } from './transformers/team.js'
+import { transformTemplate } from './transformers/template.js'
+import { type ThreadMemberTransformerExtra, transformThreadMember, transformThreadMemberGuildCreate } from './transformers/threadMember.js'
+import type {
+  Activity,
+  ActivityInstance,
+  ActivityLocation,
+  Application,
+  ApplicationCommand,
+  ApplicationCommandOption,
+  ApplicationCommandOptionChoice,
+  Attachment,
+  AuditLogEntry,
+  AutoModerationActionExecution,
+  AutoModerationRule,
+  AvatarDecorationData,
+  Channel,
+  Collectibles,
+  Component,
+  DefaultReactionEmoji,
+  Embed,
+  Emoji,
+  Entitlement,
+  ForumTag,
+  GetGatewayBot,
+  Guild,
+  GuildApplicationCommandPermissions,
+  GuildOnboarding,
+  GuildOnboardingPrompt,
+  GuildOnboardingPromptOption,
+  GuildWidget,
+  GuildWidgetSettings,
+  IncidentsData,
+  Integration,
+  Interaction,
+  InteractionCallback,
+  InteractionCallbackResponse,
+  InteractionDataOption,
+  InteractionDataResolved,
+  InteractionResource,
+  Invite,
+  InviteStageInstance,
+  Lobby,
+  LobbyMember,
+  MediaGalleryItem,
+  Member,
+  Message,
+  MessageCall,
+  MessageInteractionMetadata,
+  MessagePin,
+  MessageSnapshot,
+  Nameplate,
+  Poll,
+  PollMedia,
+  PresenceUpdate,
+  Role,
+  RoleColors,
+  ScheduledEvent,
+  ScheduledEventRecurrenceRule,
+  Sku,
+  SoundboardSound,
+  StageInstance,
+  Sticker,
+  StickerPack,
+  Subscription,
+  Team,
+  Template,
+  ThreadMember,
+  ThreadMemberGuildCreate,
+  UnfurledMediaItem,
+  User,
+  UserPrimaryGuild,
+  VoiceRegion,
+  VoiceState,
+  Webhook,
+  WelcomeScreen,
+} from './transformers/types.js'
+import { transformCollectibles, transformNameplate, transformUser, transformUserPrimaryGuild } from './transformers/user.js'
+import { transformVoiceRegion } from './transformers/voiceRegion.js'
+import { transformVoiceState } from './transformers/voiceState.js'
+import { transformWebhook } from './transformers/webhook.js'
+import { transformWelcomeScreen } from './transformers/welcomeScreen.js'
+import { transformWidget } from './transformers/widget.js'
+import { transformWidgetSettings } from './transformers/widgetSettings.js'
 
 export type Transformers<TProps extends TransformersDesiredProperties, TBehavior extends DesiredPropertiesBehavior> = {
   customizers: {

--- a/packages/bot/src/transformers/activity.ts
+++ b/packages/bot/src/transformers/activity.ts
@@ -1,15 +1,7 @@
-import type {
-  Activity,
-  ActivityInstance,
-  ActivityLocation,
-  Bot,
-  DesiredPropertiesBehavior,
-  DiscordActivity,
-  DiscordActivityInstance,
-  DiscordActivityLocation,
-  SetupDesiredProps,
-  TransformersDesiredProperties,
-} from '../index.js'
+import type { DiscordActivity, DiscordActivityInstance, DiscordActivityLocation } from '@discordeno/types'
+import type { Bot } from '../bot.js'
+import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../desiredProperties.js'
+import type { Activity, ActivityInstance, ActivityLocation } from './types.js'
 
 export function transformActivity(bot: Bot, payload: DiscordActivity): Activity {
   const activity = {

--- a/packages/bot/src/transformers/application.ts
+++ b/packages/bot/src/transformers/application.ts
@@ -1,11 +1,7 @@
-import {
-  type Application,
-  type Bot,
-  type DiscordApplication,
-  DiscordApplicationIntegrationType,
-  type DiscordUser,
-  iconHashToBigInt,
-} from '../index.js'
+import { type DiscordApplication, DiscordApplicationIntegrationType, type DiscordUser } from '@discordeno/types'
+import { iconHashToBigInt } from '@discordeno/utils'
+import type { Bot } from '../bot.js'
+import type { Application } from './types.js'
 
 export function transformApplication(bot: Bot, payload: DiscordApplication, extra?: { shardId?: number }): Application {
   const application = {

--- a/packages/bot/src/transformers/applicationCommand.ts
+++ b/packages/bot/src/transformers/applicationCommand.ts
@@ -1,5 +1,6 @@
 import type { DiscordApplicationCommand } from '@discordeno/types'
-import type { ApplicationCommand, Bot } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { ApplicationCommand } from './types.js'
 
 export function transformApplicationCommand(bot: Bot, payload: DiscordApplicationCommand): ApplicationCommand {
   const applicationCommand = {

--- a/packages/bot/src/transformers/applicationCommandOption.ts
+++ b/packages/bot/src/transformers/applicationCommandOption.ts
@@ -1,5 +1,6 @@
 import type { DiscordApplicationCommandOption } from '@discordeno/types'
-import type { ApplicationCommandOption, Bot } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { ApplicationCommandOption } from './types.js'
 
 export function transformApplicationCommandOption(bot: Bot, payload: DiscordApplicationCommandOption): ApplicationCommandOption {
   const applicationCommandOption = {

--- a/packages/bot/src/transformers/applicationCommandOptionChoice.ts
+++ b/packages/bot/src/transformers/applicationCommandOptionChoice.ts
@@ -1,5 +1,6 @@
 import type { DiscordApplicationCommandOptionChoice } from '@discordeno/types'
-import type { ApplicationCommandOptionChoice, Bot } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { ApplicationCommandOptionChoice } from './types.js'
 
 export function transformApplicationCommandOptionChoice(bot: Bot, payload: DiscordApplicationCommandOptionChoice): ApplicationCommandOptionChoice {
   const applicationCommandOptionChoice = {

--- a/packages/bot/src/transformers/applicationCommandPermission.ts
+++ b/packages/bot/src/transformers/applicationCommandPermission.ts
@@ -1,5 +1,6 @@
 import type { DiscordGuildApplicationCommandPermissions } from '@discordeno/types'
-import type { Bot, GuildApplicationCommandPermissions } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { GuildApplicationCommandPermissions } from './types.js'
 
 export function transformApplicationCommandPermission(
   bot: Bot,

--- a/packages/bot/src/transformers/attachment.ts
+++ b/packages/bot/src/transformers/attachment.ts
@@ -1,5 +1,7 @@
 import type { DiscordAttachment } from '@discordeno/types'
-import type { Attachment, Bot, DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../desiredProperties.js'
+import type { Attachment } from './types.js'
 
 export function transformAttachment(bot: Bot, payload: DiscordAttachment): typeof bot.transformers.$inferredTypes.attachment {
   const props = bot.transformers.desiredProperties.attachment

--- a/packages/bot/src/transformers/auditLogEntry.ts
+++ b/packages/bot/src/transformers/auditLogEntry.ts
@@ -1,5 +1,6 @@
 import type { DiscordAuditLogEntry } from '@discordeno/types'
-import type { AuditLogEntry, Bot } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { AuditLogEntry } from './types.js'
 
 export function transformAuditLogEntry(bot: Bot, payload: DiscordAuditLogEntry): AuditLogEntry {
   const auditLogEntry = {

--- a/packages/bot/src/transformers/automodActionExecution.ts
+++ b/packages/bot/src/transformers/automodActionExecution.ts
@@ -1,5 +1,6 @@
 import type { DiscordAutoModerationActionExecution } from '@discordeno/types'
-import type { AutoModerationActionExecution, Bot } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { AutoModerationActionExecution } from './types.js'
 
 export function transformAutoModerationActionExecution(bot: Bot, payload: DiscordAutoModerationActionExecution): AutoModerationActionExecution {
   const rule = {

--- a/packages/bot/src/transformers/automodRule.ts
+++ b/packages/bot/src/transformers/automodRule.ts
@@ -1,5 +1,6 @@
 import type { DiscordAutoModerationRule } from '@discordeno/types'
-import type { AutoModerationRule, Bot } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { AutoModerationRule } from './types.js'
 
 export function transformAutoModerationRule(bot: Bot, payload: DiscordAutoModerationRule): AutoModerationRule {
   const rule = {

--- a/packages/bot/src/transformers/avatarDecorationData.ts
+++ b/packages/bot/src/transformers/avatarDecorationData.ts
@@ -1,4 +1,7 @@
-import { type AvatarDecorationData, type Bot, type DiscordAvatarDecorationData, iconHashToBigInt } from '../index.js'
+import type { DiscordAvatarDecorationData } from '@discordeno/types'
+import { iconHashToBigInt } from '@discordeno/utils'
+import type { Bot } from '../bot.js'
+import type { AvatarDecorationData } from './types.js'
 
 export function transformAvatarDecorationData(bot: Bot, payload: DiscordAvatarDecorationData): AvatarDecorationData {
   const data = {} as AvatarDecorationData

--- a/packages/bot/src/transformers/channel.ts
+++ b/packages/bot/src/transformers/channel.ts
@@ -1,16 +1,10 @@
 import type { BigString, DiscordChannel, DiscordForumTag } from '@discordeno/types'
-import {
-  type Bot,
-  type Channel,
-  calculatePermissions,
-  type DesiredPropertiesBehavior,
-  type ForumTag,
-  iconHashToBigInt,
-  type SetupDesiredProps,
-  type TransformersDesiredProperties,
-} from '../index.js'
+import { calculatePermissions, iconHashToBigInt } from '@discordeno/utils'
+import type { Bot } from '../bot.js'
+import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../desiredProperties.js'
 import { ChannelToggles } from './toggles/channel.js'
 import { Permissions } from './toggles/Permissions.js'
+import type { Channel, ForumTag } from './types.js'
 
 const Mask = (1n << 64n) - 1n
 

--- a/packages/bot/src/transformers/component.ts
+++ b/packages/bot/src/transformers/component.ts
@@ -1,8 +1,10 @@
 import {
   type DiscordActionRow,
   type DiscordButtonComponent,
+  type DiscordContainerComponent,
   type DiscordFileComponent,
   type DiscordMediaGalleryComponent,
+  type DiscordMediaGalleryItem,
   type DiscordMessageComponent,
   type DiscordSectionComponent,
   type DiscordSelectMenuComponent,
@@ -10,17 +12,11 @@ import {
   type DiscordTextDisplayComponent,
   type DiscordTextInputComponent,
   type DiscordThumbnailComponent,
+  type DiscordUnfurledMediaItem,
   MessageComponentTypes,
 } from '@discordeno/types'
-import type {
-  Bot,
-  Component,
-  DiscordContainerComponent,
-  DiscordMediaGalleryItem,
-  DiscordUnfurledMediaItem,
-  MediaGalleryItem,
-  UnfurledMediaItem,
-} from '../index.js'
+import type { Bot } from '../bot.js'
+import type { Component, MediaGalleryItem, UnfurledMediaItem } from './types.js'
 
 export function transformComponent(bot: Bot, payload: DiscordMessageComponent): Component {
   let component: Component

--- a/packages/bot/src/transformers/embed.ts
+++ b/packages/bot/src/transformers/embed.ts
@@ -1,5 +1,6 @@
 import type { DiscordEmbed } from '@discordeno/types'
-import type { Bot, Embed } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { Embed } from './types.js'
 
 export function transformEmbed(bot: Bot, payload: DiscordEmbed): Embed {
   const embed = {

--- a/packages/bot/src/transformers/emoji.ts
+++ b/packages/bot/src/transformers/emoji.ts
@@ -1,6 +1,8 @@
 import type { DiscordDefaultReactionEmoji, DiscordEmoji } from '@discordeno/types'
-import type { Bot, DefaultReactionEmoji, DesiredPropertiesBehavior, Emoji, SetupDesiredProps, TransformersDesiredProperties } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../desiredProperties.js'
 import { EmojiToggles } from './toggles/emoji.js'
+import type { DefaultReactionEmoji, Emoji } from './types.js'
 
 export const baseEmoji: Emoji = {
   // This allows typescript to still check for type errors on functions below

--- a/packages/bot/src/transformers/entitlement.ts
+++ b/packages/bot/src/transformers/entitlement.ts
@@ -1,5 +1,7 @@
 import type { DiscordEntitlement } from '@discordeno/types'
-import type { Bot, DesiredPropertiesBehavior, Entitlement, SetupDesiredProps, TransformersDesiredProperties } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../desiredProperties.js'
+import type { Entitlement } from './types.js'
 
 export function transformEntitlement(bot: Bot, payload: DiscordEntitlement): Entitlement {
   const props = bot.transformers.desiredProperties.entitlement

--- a/packages/bot/src/transformers/gatewayBot.ts
+++ b/packages/bot/src/transformers/gatewayBot.ts
@@ -1,5 +1,6 @@
 import type { DiscordGetGatewayBot } from '@discordeno/types'
-import type { Bot, GetGatewayBot } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { GetGatewayBot } from './types.js'
 
 export function transformGatewayBot(bot: Bot, payload: DiscordGetGatewayBot): GetGatewayBot {
   const gatewayBot = {

--- a/packages/bot/src/transformers/guild.ts
+++ b/packages/bot/src/transformers/guild.ts
@@ -1,7 +1,9 @@
 import { ChannelTypes, type DiscordGuild, type DiscordPresenceUpdate } from '@discordeno/types'
 import { Collection, iconHashToBigInt } from '@discordeno/utils'
-import type { Bot, Channel, DesiredPropertiesBehavior, Guild, SetupDesiredProps, TransformersDesiredProperties } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../desiredProperties.js'
 import { GuildToggles } from './toggles/guild.js'
+import type { Channel, Guild } from './types.js'
 
 export const baseGuild: Guild = {
   // This allows typescript to still check for type errors on functions below

--- a/packages/bot/src/transformers/incidentsData.ts
+++ b/packages/bot/src/transformers/incidentsData.ts
@@ -1,5 +1,7 @@
 import type { DiscordIncidentsData } from '@discordeno/types'
-import type { Bot, DesiredPropertiesBehavior, IncidentsData, SetupDesiredProps, TransformersDesiredProperties } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../desiredProperties.js'
+import type { IncidentsData } from './types.js'
 
 export function transformIncidentsData(bot: Bot, payload: DiscordIncidentsData): IncidentsData {
   const props = bot.transformers.desiredProperties.incidentsData

--- a/packages/bot/src/transformers/integration.ts
+++ b/packages/bot/src/transformers/integration.ts
@@ -1,5 +1,7 @@
 import type { DiscordIntegrationCreateUpdate } from '@discordeno/types'
-import { type Bot, type Integration, iconHashToBigInt } from '../index.js'
+import { iconHashToBigInt } from '@discordeno/utils'
+import type { Bot } from '../bot.js'
+import type { Integration } from './types.js'
 
 export function transformIntegration(bot: Bot, payload: DiscordIntegrationCreateUpdate): Integration {
   const integration = {

--- a/packages/bot/src/transformers/interaction.ts
+++ b/packages/bot/src/transformers/interaction.ts
@@ -1,4 +1,5 @@
 import {
+  type BigString,
   DiscordApplicationIntegrationType,
   type DiscordInteraction,
   type DiscordInteractionCallback,
@@ -11,27 +12,26 @@ import {
   MessageFlags,
 } from '@discordeno/types'
 import { Collection } from '@discordeno/utils'
+import type { Bot } from '../bot.js'
+import type { InteractionResolvedDataChannel, InteractionResolvedDataMember } from '../commandOptionsParser.js'
 import type {
-  Attachment,
-  BigString,
-  Bot,
   CompleteDesiredProperties,
   DesiredPropertiesBehavior,
+  SetupDesiredProps,
+  TransformersDesiredProperties,
+  TransformProperty,
+} from '../desiredProperties.js'
+import type {
+  Attachment,
   Interaction,
   InteractionCallback,
   InteractionCallbackResponse,
   InteractionDataOption,
   InteractionDataResolved,
-  InteractionResolvedDataChannel,
-  InteractionResolvedDataMember,
   InteractionResource,
-  Message,
   Role,
-  SetupDesiredProps,
-  TransformersDesiredProperties,
-  TransformProperty,
   User,
-} from '../index.js'
+} from './types.js'
 
 // Assume we have all desired properties for this or else typescript will get very confused for the return types of these functions.
 // This is used as a prototype, so the actual type with the user desired properties will be set later.

--- a/packages/bot/src/transformers/invite.ts
+++ b/packages/bot/src/transformers/invite.ts
@@ -1,13 +1,9 @@
 import type { DiscordInviteCreate, DiscordInviteMetadata } from '@discordeno/types'
-import {
-  type Bot,
-  type DesiredPropertiesBehavior,
-  type Invite,
-  isInviteWithMetadata,
-  type SetupDesiredProps,
-  ToggleBitfield,
-  type TransformersDesiredProperties,
-} from '../index.js'
+import { isInviteWithMetadata } from '@discordeno/utils'
+import type { Bot } from '../bot.js'
+import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../desiredProperties.js'
+import { ToggleBitfield } from './toggles/ToggleBitfield.js'
+import type { Invite } from './types.js'
 
 export function transformInvite(bot: Bot, payload: DiscordInviteCreate | DiscordInviteMetadata, extra?: { shardId?: number }): Invite {
   const props = bot.transformers.desiredProperties.invite

--- a/packages/bot/src/transformers/lobby.ts
+++ b/packages/bot/src/transformers/lobby.ts
@@ -1,13 +1,8 @@
 import type { DiscordLobby, DiscordLobbyMember } from '@discordeno/types'
-import {
-  type Bot,
-  type DesiredPropertiesBehavior,
-  type Lobby,
-  type LobbyMember,
-  type SetupDesiredProps,
-  ToggleBitfield,
-  type TransformersDesiredProperties,
-} from '../index.js'
+import type { Bot } from '../bot.js'
+import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../desiredProperties.js'
+import { ToggleBitfield } from './toggles/ToggleBitfield.js'
+import type { Lobby, LobbyMember } from './types.js'
 
 export function transformLobby(bot: Bot, payload: DiscordLobby): Lobby {
   const props = bot.transformers.desiredProperties.lobby

--- a/packages/bot/src/transformers/member.ts
+++ b/packages/bot/src/transformers/member.ts
@@ -1,7 +1,7 @@
 import type { BigString, DiscordMember } from '@discordeno/types'
 import { iconHashToBigInt } from '@discordeno/utils'
 import type { Bot } from '../bot.js'
-import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../index.js'
+import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../desiredProperties.js'
 import { MemberToggles } from './toggles/member.js'
 import { Permissions } from './toggles/Permissions.js'
 import type { Member } from './types.js'

--- a/packages/bot/src/transformers/message.ts
+++ b/packages/bot/src/transformers/message.ts
@@ -7,21 +7,12 @@ import {
   type DiscordMessageSnapshot,
   MessageFlags,
 } from '@discordeno/types'
+import { snowflakeToTimestamp } from '@discordeno/utils'
+import type { Bot } from '../bot.js'
 import { CHANNEL_MENTION_REGEX } from '../constants.js'
-import {
-  type Bot,
-  type DesiredPropertiesBehavior,
-  type Message,
-  type MessageCall,
-  type MessageInteraction,
-  type MessageInteractionMetadata,
-  type MessagePin,
-  type MessageSnapshot,
-  type SetupDesiredProps,
-  snowflakeToTimestamp,
-  type TransformersDesiredProperties,
-} from '../index.js'
+import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../desiredProperties.js'
 import { ToggleBitfield } from './toggles/ToggleBitfield.js'
+import type { Message, MessageCall, MessageInteraction, MessageInteractionMetadata, MessagePin, MessageSnapshot } from './types.js'
 
 const EMPTY_STRING = ''
 

--- a/packages/bot/src/transformers/onboarding.ts
+++ b/packages/bot/src/transformers/onboarding.ts
@@ -1,13 +1,7 @@
 import type { DiscordGuildOnboarding, DiscordGuildOnboardingPrompt, DiscordGuildOnboardingPromptOption } from '@discordeno/types'
-import type {
-  Bot,
-  DesiredPropertiesBehavior,
-  GuildOnboarding,
-  GuildOnboardingPrompt,
-  GuildOnboardingPromptOption,
-  SetupDesiredProps,
-  TransformersDesiredProperties,
-} from '../index.js'
+import type { Bot } from '../bot.js'
+import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../desiredProperties.js'
+import type { GuildOnboarding, GuildOnboardingPrompt, GuildOnboardingPromptOption } from './types.js'
 
 export function transformGuildOnboarding(bot: Bot, payload: DiscordGuildOnboarding): GuildOnboarding {
   const props = bot.transformers.desiredProperties.guildOnboarding

--- a/packages/bot/src/transformers/poll.ts
+++ b/packages/bot/src/transformers/poll.ts
@@ -1,5 +1,7 @@
 import type { DiscordEmoji, DiscordPoll, DiscordPollMedia } from '@discordeno/types'
-import type { Bot, DesiredPropertiesBehavior, Poll, PollMedia, PollResult, SetupDesiredProps, TransformersDesiredProperties } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../desiredProperties.js'
+import type { Poll, PollMedia, PollResult } from './types.js'
 
 export function transformPoll(bot: Bot, payload: DiscordPoll): Poll {
   const props = bot.transformers.desiredProperties.poll

--- a/packages/bot/src/transformers/presence.ts
+++ b/packages/bot/src/transformers/presence.ts
@@ -1,5 +1,6 @@
 import { type DiscordPresenceUpdate, PresenceStatus } from '@discordeno/types'
-import type { Bot, PresenceUpdate, User } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { PresenceUpdate, User } from './types.js'
 
 export function transformPresence(bot: Bot, payload: DiscordPresenceUpdate): PresenceUpdate {
   const presence = {} as PresenceUpdate

--- a/packages/bot/src/transformers/reverse/activity.ts
+++ b/packages/bot/src/transformers/reverse/activity.ts
@@ -1,4 +1,6 @@
-import type { Activity, Bot, DiscordActivity } from '../../index.js'
+import type { DiscordActivity } from '@discordeno/types'
+import type { Bot } from '../../bot.js'
+import type { Activity } from '../types.js'
 
 export function transformActivityToDiscordActivity(_bot: Bot, payload: Activity): DiscordActivity {
   return {

--- a/packages/bot/src/transformers/reverse/allowedMentions.ts
+++ b/packages/bot/src/transformers/reverse/allowedMentions.ts
@@ -1,4 +1,5 @@
-import type { AllowedMentions, Bot, DiscordAllowedMentions } from '../../index.js'
+import type { AllowedMentions, DiscordAllowedMentions } from '@discordeno/types'
+import type { Bot } from '../../bot.js'
 
 export function transformAllowedMentionsToDiscordAllowedMentions(_bot: Bot, mentions: AllowedMentions): DiscordAllowedMentions {
   return {

--- a/packages/bot/src/transformers/reverse/application.ts
+++ b/packages/bot/src/transformers/reverse/application.ts
@@ -1,4 +1,7 @@
-import { type Application, type Bot, type DiscordApplication, iconBigintToHash } from '../../index.js'
+import type { DiscordApplication } from '@discordeno/types'
+import { iconBigintToHash } from '@discordeno/utils'
+import type { Bot } from '../../bot.js'
+import type { Application } from '../types.js'
 
 export function transformApplicationToDiscordApplication(bot: Bot, payload: Application): DiscordApplication {
   return {

--- a/packages/bot/src/transformers/reverse/applicationCommand.ts
+++ b/packages/bot/src/transformers/reverse/applicationCommand.ts
@@ -1,4 +1,6 @@
-import type { ApplicationCommand, Bot, DiscordApplicationCommand } from '../../index.js'
+import type { DiscordApplicationCommand } from '@discordeno/types'
+import type { Bot } from '../../bot.js'
+import type { ApplicationCommand } from '../types.js'
 
 export function transformApplicationCommandToDiscordApplicationCommand(bot: Bot, payload: ApplicationCommand): DiscordApplicationCommand {
   return {

--- a/packages/bot/src/transformers/reverse/applicationCommandOption.ts
+++ b/packages/bot/src/transformers/reverse/applicationCommandOption.ts
@@ -1,4 +1,6 @@
-import type { ApplicationCommandOption, Bot, DiscordApplicationCommandOption } from '../../index.js'
+import type { DiscordApplicationCommandOption } from '@discordeno/types'
+import type { Bot } from '../../bot.js'
+import type { ApplicationCommandOption } from '../types.js'
 
 export function transformApplicationCommandOptionToDiscordApplicationCommandOption(
   bot: Bot,

--- a/packages/bot/src/transformers/reverse/applicationCommandOptionChoice.ts
+++ b/packages/bot/src/transformers/reverse/applicationCommandOptionChoice.ts
@@ -1,4 +1,6 @@
-import type { ApplicationCommandOptionChoice, Bot, Camelize, DiscordApplicationCommandOptionChoice } from '../../index.js'
+import type { Camelize, DiscordApplicationCommandOptionChoice } from '@discordeno/types'
+import type { Bot } from '../../bot.js'
+import type { ApplicationCommandOptionChoice } from '../types.js'
 
 export function transformApplicationCommandOptionChoiceToDiscordApplicationCommandOptionChoice(
   _bot: Bot,

--- a/packages/bot/src/transformers/reverse/applicationCommandPermission.ts
+++ b/packages/bot/src/transformers/reverse/applicationCommandPermission.ts
@@ -1,4 +1,6 @@
-import type { Bot, DiscordGuildApplicationCommandPermissions, GuildApplicationCommandPermissions } from '../../index.js'
+import type { DiscordGuildApplicationCommandPermissions } from '@discordeno/types'
+import type { Bot } from '../../bot.js'
+import type { GuildApplicationCommandPermissions } from '../types.js'
 
 export function transformApplicationCommandPermissionToDiscordApplicationCommandPermission(
   bot: Bot,

--- a/packages/bot/src/transformers/reverse/attachment.ts
+++ b/packages/bot/src/transformers/reverse/attachment.ts
@@ -1,4 +1,6 @@
-import type { Attachment, Bot, DiscordAttachment } from '../../index.js'
+import type { DiscordAttachment } from '@discordeno/types'
+import type { Bot } from '../../bot.js'
+import type { Attachment } from '../types.js'
 
 export function transformAttachmentToDiscordAttachment(bot: Bot, payload: typeof bot.transformers.$inferredTypes.attachment): DiscordAttachment {
   const _payload = payload as Partial<Attachment>

--- a/packages/bot/src/transformers/reverse/auditLogEntry.ts
+++ b/packages/bot/src/transformers/reverse/auditLogEntry.ts
@@ -1,5 +1,6 @@
 import type { DiscordAuditLogEntry } from '@discordeno/types'
-import type { AuditLogEntry, Bot } from '../../index.js'
+import type { Bot } from '../../bot.js'
+import type { AuditLogEntry } from '../types.js'
 
 export function transformAuditLogEntryToDiscordAuditLogEntry(bot: Bot, payload: AuditLogEntry): DiscordAuditLogEntry {
   return {

--- a/packages/bot/src/transformers/reverse/component.ts
+++ b/packages/bot/src/transformers/reverse/component.ts
@@ -1,22 +1,23 @@
-import { type DiscordButtonComponent, type DiscordMessageComponent, MessageComponentTypes, type TextStyles } from '@discordeno/types'
-import type {
-  Bot,
-  ButtonStyles,
-  Component,
-  DiscordActionRow,
-  DiscordContainerComponent,
-  DiscordFileComponent,
-  DiscordMediaGalleryComponent,
-  DiscordMediaGalleryItem,
-  DiscordSectionComponent,
-  DiscordSelectMenuComponent,
-  DiscordTextDisplayComponent,
-  DiscordTextInputComponent,
-  DiscordThumbnailComponent,
-  DiscordUnfurledMediaItem,
-  MediaGalleryItem,
-  UnfurledMediaItem,
-} from '../../index.js'
+import {
+  type ButtonStyles,
+  type DiscordActionRow,
+  type DiscordButtonComponent,
+  type DiscordContainerComponent,
+  type DiscordFileComponent,
+  type DiscordMediaGalleryComponent,
+  type DiscordMediaGalleryItem,
+  type DiscordMessageComponent,
+  type DiscordSectionComponent,
+  type DiscordSelectMenuComponent,
+  type DiscordTextDisplayComponent,
+  type DiscordTextInputComponent,
+  type DiscordThumbnailComponent,
+  type DiscordUnfurledMediaItem,
+  MessageComponentTypes,
+  type TextStyles,
+} from '@discordeno/types'
+import type { Bot } from '../../bot.js'
+import type { Component, MediaGalleryItem, UnfurledMediaItem } from '../types.js'
 
 export function transformComponentToDiscordComponent(bot: Bot, payload: Component): DiscordMessageComponent {
   // This switch should include all cases

--- a/packages/bot/src/transformers/reverse/embed.ts
+++ b/packages/bot/src/transformers/reverse/embed.ts
@@ -1,5 +1,6 @@
 import type { DiscordEmbed } from '@discordeno/types'
-import type { Bot, Embed } from '../../index.js'
+import type { Bot } from '../../bot.js'
+import type { Embed } from '../types.js'
 
 export function transformEmbedToDiscordEmbed(_bot: Bot, payload: Embed): DiscordEmbed {
   return {

--- a/packages/bot/src/transformers/reverse/emoji.ts
+++ b/packages/bot/src/transformers/reverse/emoji.ts
@@ -1,5 +1,6 @@
 import type { DiscordEmoji } from '@discordeno/types'
-import type { Bot, Emoji } from '../../index.js'
+import type { Bot } from '../../bot.js'
+import type { Emoji } from '../types.js'
 
 export function transformEmojiToDiscordEmoji(bot: Bot, payload: Emoji): DiscordEmoji {
   return {

--- a/packages/bot/src/transformers/reverse/presence.ts
+++ b/packages/bot/src/transformers/reverse/presence.ts
@@ -1,5 +1,6 @@
 import { type DiscordPresenceUpdate, PresenceStatus } from '@discordeno/types'
-import type { Bot, PresenceUpdate } from '../../index.js'
+import type { Bot } from '../../bot.js'
+import type { PresenceUpdate } from '../types.js'
 
 export const reverseStatusTypes = Object.freeze({
   0: 'online',

--- a/packages/bot/src/transformers/reverse/team.ts
+++ b/packages/bot/src/transformers/reverse/team.ts
@@ -1,5 +1,7 @@
 import type { DiscordTeam } from '@discordeno/types'
-import { type Bot, iconBigintToHash, type Team } from '../../index.js'
+import { iconBigintToHash } from '@discordeno/utils'
+import type { Bot } from '../../bot.js'
+import type { Team } from '../types.js'
 
 export function transformTeamToDiscordTeam(bot: Bot, payload: Team): DiscordTeam {
   const id = payload.id.toString()

--- a/packages/bot/src/transformers/reverse/widgetSettings.ts
+++ b/packages/bot/src/transformers/reverse/widgetSettings.ts
@@ -1,5 +1,6 @@
 import type { DiscordGuildWidgetSettings } from '@discordeno/types'
-import type { Bot, GuildWidgetSettings } from '../../index.js'
+import type { Bot } from '../../bot.js'
+import type { GuildWidgetSettings } from '../types.js'
 
 export function transformWidgetSettingsToDiscordWidgetSettings(_bot: Bot, payload: GuildWidgetSettings): DiscordGuildWidgetSettings {
   return {

--- a/packages/bot/src/transformers/role.ts
+++ b/packages/bot/src/transformers/role.ts
@@ -1,15 +1,10 @@
 import type { BigString, DiscordRole, DiscordRoleColors } from '@discordeno/types'
-import {
-  type Bot,
-  type DesiredPropertiesBehavior,
-  iconHashToBigInt,
-  type Role,
-  type RoleColors,
-  type SetupDesiredProps,
-  type TransformersDesiredProperties,
-} from '../index.js'
+import { iconHashToBigInt } from '@discordeno/utils'
+import type { Bot } from '../bot.js'
+import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../desiredProperties.js'
 import { Permissions } from './toggles/Permissions.js'
 import { RoleToggles } from './toggles/role.js'
+import type { Role, RoleColors } from './types.js'
 
 export const baseRole: Role = {
   // This allows typescript to still check for type errors on functions below

--- a/packages/bot/src/transformers/scheduledEvent.ts
+++ b/packages/bot/src/transformers/scheduledEvent.ts
@@ -1,13 +1,8 @@
 import type { DiscordScheduledEvent, DiscordScheduledEventRecurrenceRule } from '@discordeno/types'
-import {
-  type Bot,
-  type DesiredPropertiesBehavior,
-  iconHashToBigInt,
-  type ScheduledEvent,
-  type ScheduledEventRecurrenceRule,
-  type SetupDesiredProps,
-  type TransformersDesiredProperties,
-} from '../index.js'
+import { iconHashToBigInt } from '@discordeno/utils'
+import type { Bot } from '../bot.js'
+import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../desiredProperties.js'
+import type { ScheduledEvent, ScheduledEventRecurrenceRule } from './types.js'
 
 export function transformScheduledEvent(bot: Bot, payload: DiscordScheduledEvent): ScheduledEvent {
   const props = bot.transformers.desiredProperties.scheduledEvent

--- a/packages/bot/src/transformers/sku.ts
+++ b/packages/bot/src/transformers/sku.ts
@@ -1,5 +1,7 @@
 import type { DiscordSku } from '@discordeno/types'
-import type { Bot, DesiredPropertiesBehavior, SetupDesiredProps, Sku, TransformersDesiredProperties } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../desiredProperties.js'
+import type { Sku } from './types.js'
 
 export function transformSku(bot: Bot, payload: DiscordSku): Sku {
   const props = bot.transformers.desiredProperties.sku

--- a/packages/bot/src/transformers/soundboardSound.ts
+++ b/packages/bot/src/transformers/soundboardSound.ts
@@ -1,5 +1,7 @@
 import type { DiscordSoundboardSound } from '@discordeno/types'
-import type { Bot, DesiredPropertiesBehavior, SetupDesiredProps, SoundboardSound, TransformersDesiredProperties } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../desiredProperties.js'
+import type { SoundboardSound } from './types.js'
 
 export function transformSoundboardSound(bot: Bot, payload: DiscordSoundboardSound): SoundboardSound {
   const props = bot.transformers.desiredProperties.soundboardSound

--- a/packages/bot/src/transformers/stageInstance.ts
+++ b/packages/bot/src/transformers/stageInstance.ts
@@ -1,5 +1,7 @@
 import type { DiscordStageInstance } from '@discordeno/types'
-import type { Bot, DesiredPropertiesBehavior, SetupDesiredProps, StageInstance, TransformersDesiredProperties } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../desiredProperties.js'
+import type { StageInstance } from './types.js'
 
 export function transformStageInstance(bot: Bot, payload: DiscordStageInstance): StageInstance {
   const props = bot.transformers.desiredProperties.stageInstance

--- a/packages/bot/src/transformers/stageInviteInstance.ts
+++ b/packages/bot/src/transformers/stageInviteInstance.ts
@@ -1,5 +1,7 @@
 import type { BigString, DiscordInviteStageInstance } from '@discordeno/types'
-import type { Bot, DesiredPropertiesBehavior, InviteStageInstance, SetupDesiredProps, TransformersDesiredProperties } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../desiredProperties.js'
+import type { InviteStageInstance } from './types.js'
 
 export function transformInviteStageInstance(bot: Bot, payload: DiscordInviteStageInstance, extra?: { guildId?: BigString }): InviteStageInstance {
   const props = bot.transformers.desiredProperties.inviteStageInstance

--- a/packages/bot/src/transformers/sticker.ts
+++ b/packages/bot/src/transformers/sticker.ts
@@ -1,5 +1,7 @@
 import type { DiscordSticker, DiscordStickerPack } from '@discordeno/types'
-import type { Bot, DesiredPropertiesBehavior, SetupDesiredProps, Sticker, StickerPack, TransformersDesiredProperties } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../desiredProperties.js'
+import type { Sticker, StickerPack } from './types.js'
 
 export function transformSticker(bot: Bot, payload: DiscordSticker): Sticker {
   const props = bot.transformers.desiredProperties.sticker

--- a/packages/bot/src/transformers/subscription.ts
+++ b/packages/bot/src/transformers/subscription.ts
@@ -1,5 +1,7 @@
 import type { DiscordSubscription } from '@discordeno/types'
-import type { Bot, DesiredPropertiesBehavior, SetupDesiredProps, Subscription, TransformersDesiredProperties } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../desiredProperties.js'
+import type { Subscription } from './types.js'
 
 export function transformSubscription(bot: Bot, payload: DiscordSubscription): Subscription {
   const props = bot.transformers.desiredProperties.subscription

--- a/packages/bot/src/transformers/team.ts
+++ b/packages/bot/src/transformers/team.ts
@@ -1,5 +1,7 @@
 import type { DiscordTeam } from '@discordeno/types'
-import { type Bot, iconHashToBigInt, type Team } from '../index.js'
+import { iconHashToBigInt } from '@discordeno/utils'
+import type { Bot } from '../bot.js'
+import type { Team } from './types.js'
 
 export function transformTeam(bot: Bot, payload: DiscordTeam): Team {
   const id = bot.transformers.snowflake(payload.id)

--- a/packages/bot/src/transformers/template.ts
+++ b/packages/bot/src/transformers/template.ts
@@ -1,6 +1,6 @@
 import type { DiscordTemplate } from '@discordeno/types'
-import type { Bot, Template } from '../index.js'
-
+import type { Bot } from '../bot.js'
+import type { Template } from './types.js'
 export function transformTemplate(bot: Bot, payload: DiscordTemplate): Template {
   const template = {
     code: payload.code,

--- a/packages/bot/src/transformers/threadMember.ts
+++ b/packages/bot/src/transformers/threadMember.ts
@@ -1,5 +1,6 @@
 import type { BigString, DiscordThreadMember, DiscordThreadMemberGuildCreate } from '@discordeno/types'
-import type { Bot, ThreadMember, ThreadMemberGuildCreate } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { ThreadMember, ThreadMemberGuildCreate } from './types.js'
 
 export function transformThreadMember(bot: Bot, payload: DiscordThreadMember, extra?: ThreadMemberTransformerExtra): ThreadMember {
   const threadMember = {

--- a/packages/bot/src/transformers/types.ts
+++ b/packages/bot/src/transformers/types.ts
@@ -71,23 +71,18 @@ import type {
   WebhookTypes,
 } from '@discordeno/types'
 import type { Collection } from '@discordeno/utils'
-import type {
-  Bot,
-  ChannelToggles,
-  DesiredPropertiesBehavior,
-  EmojiToggles,
-  GuildFeatureKeys,
-  GuildToggles,
-  InteractionResolvedDataChannel,
-  InteractionResolvedDataMember,
-  MemberToggles,
-  Permissions,
-  RoleToggles,
-  ToggleBitfield,
-  TransformersDesiredProperties,
-  UserToggles,
-  VoiceStateToggles,
-} from '../index.js'
+import type { Bot } from '../bot.js'
+import type { InteractionResolvedDataChannel, InteractionResolvedDataMember } from '../commandOptionsParser.js'
+import type { DesiredPropertiesBehavior, TransformersDesiredProperties } from '../desiredProperties.js'
+import type { ChannelToggles } from './toggles/channel.js'
+import type { EmojiToggles } from './toggles/emoji.js'
+import type { GuildFeatureKeys, GuildToggles } from './toggles/guild.js'
+import type { MemberToggles } from './toggles/member.js'
+import type { Permissions } from './toggles/Permissions.js'
+import type { RoleToggles } from './toggles/role.js'
+import type { ToggleBitfield } from './toggles/ToggleBitfield.js'
+import type { UserToggles } from './toggles/user.js'
+import type { VoiceStateToggles } from './toggles/voice.js'
 
 export interface Activity {
   join?: string

--- a/packages/bot/src/transformers/user.ts
+++ b/packages/bot/src/transformers/user.ts
@@ -1,17 +1,10 @@
 import type { DiscordCollectibles, DiscordNameplate, DiscordUser, DiscordUserPrimaryGuild } from '@discordeno/types'
 import { iconHashToBigInt } from '@discordeno/utils'
-import {
-  type Bot,
-  type Collectibles,
-  type DesiredPropertiesBehavior,
-  type Nameplate,
-  type SetupDesiredProps,
-  ToggleBitfield,
-  type TransformersDesiredProperties,
-  type User,
-  type UserPrimaryGuild,
-  UserToggles,
-} from '../index.js'
+import type { Bot } from '../bot.js'
+import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../desiredProperties.js'
+import { ToggleBitfield } from './toggles/ToggleBitfield.js'
+import { UserToggles } from './toggles/user.js'
+import type { Collectibles, Nameplate, User, UserPrimaryGuild } from './types.js'
 
 export const baseUser: User = {
   // This allows typescript to still check for type errors on functions below

--- a/packages/bot/src/transformers/voiceRegion.ts
+++ b/packages/bot/src/transformers/voiceRegion.ts
@@ -1,5 +1,6 @@
 import type { DiscordVoiceRegion } from '@discordeno/types'
-import type { Bot, VoiceRegion } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { VoiceRegion } from './types.js'
 
 export function transformVoiceRegion(bot: Bot, payload: DiscordVoiceRegion): VoiceRegion {
   const voiceRegion = {

--- a/packages/bot/src/transformers/voiceState.ts
+++ b/packages/bot/src/transformers/voiceState.ts
@@ -1,6 +1,8 @@
 import type { BigString, DiscordVoiceState } from '@discordeno/types'
-import type { Bot, DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties, VoiceState } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../desiredProperties.js'
 import { VoiceStateToggles } from './toggles/voice.js'
+import type { VoiceState } from './types.js'
 
 export function transformVoiceState(bot: Bot, payload: DiscordVoiceState, extra?: { guildId?: BigString }): VoiceState {
   const props = bot.transformers.desiredProperties.voiceState

--- a/packages/bot/src/transformers/webhook.ts
+++ b/packages/bot/src/transformers/webhook.ts
@@ -1,12 +1,8 @@
 import type { DiscordWebhook } from '@discordeno/types'
-import {
-  type Bot,
-  type DesiredPropertiesBehavior,
-  iconHashToBigInt,
-  type SetupDesiredProps,
-  type TransformersDesiredProperties,
-  type Webhook,
-} from '../index.js'
+import { iconHashToBigInt } from '@discordeno/utils'
+import type { Bot } from '../bot.js'
+import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../desiredProperties.js'
+import type { Webhook } from './types.js'
 
 export function transformWebhook(bot: Bot, payload: DiscordWebhook): typeof bot.transformers.$inferredTypes.webhook {
   const props = bot.transformers.desiredProperties.webhook

--- a/packages/bot/src/transformers/welcomeScreen.ts
+++ b/packages/bot/src/transformers/welcomeScreen.ts
@@ -1,5 +1,6 @@
 import type { DiscordWelcomeScreen } from '@discordeno/types'
-import type { Bot, WelcomeScreen } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { WelcomeScreen } from './types.js'
 
 export function transformWelcomeScreen(bot: Bot, payload: DiscordWelcomeScreen): WelcomeScreen {
   const welcomeScreen = {

--- a/packages/bot/src/transformers/widget.ts
+++ b/packages/bot/src/transformers/widget.ts
@@ -1,5 +1,6 @@
 import type { DiscordGuildWidget } from '@discordeno/types'
-import type { Bot, GuildWidget } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { GuildWidget } from './types.js'
 
 export function transformWidget(bot: Bot, payload: DiscordGuildWidget): GuildWidget {
   const widget = {

--- a/packages/bot/src/transformers/widgetSettings.ts
+++ b/packages/bot/src/transformers/widgetSettings.ts
@@ -1,5 +1,6 @@
 import type { DiscordGuildWidgetSettings } from '@discordeno/types'
-import type { Bot, GuildWidgetSettings } from '../index.js'
+import type { Bot } from '../bot.js'
+import type { GuildWidgetSettings } from './types.js'
 
 export function transformWidgetSettings(bot: Bot, payload: DiscordGuildWidgetSettings): GuildWidgetSettings {
   const widget = {

--- a/packages/bot/tests/unit/desiredProprieties.spec.ts
+++ b/packages/bot/tests/unit/desiredProprieties.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import { describe, it } from 'mocha'
-import { createDesiredPropertiesObject } from '../../src/index.js'
+import { createDesiredPropertiesObject } from '../../src/desiredProperties.js'
 
 describe('desired properties', () => {
   it('fills defaults', () => {

--- a/packages/gateway/tests/integration/connection.spec.ts
+++ b/packages/gateway/tests/integration/connection.spec.ts
@@ -1,5 +1,6 @@
 import { GatewayOpcodes, Intents } from '@discordeno/types'
-import { createGatewayManager, type GatewayManager, ShardSocketCloseCodes } from '../../src/index.js'
+import { createGatewayManager, type GatewayManager } from '../../src/manager.js'
+import { ShardSocketCloseCodes } from '../../src/types.js'
 import { creatWSServer, heartbeatInterval } from './websocket.js'
 
 describe('Gateway Integration', () => {


### PR DESCRIPTION
Currently we import from `index.js` files where we could simply import the actual file(s) or module we need.

This also creates a bit of confusion since it isn't obvious from where stuff is coming from, especially when we are importing types such as `Discord<XYZ>` types both from `@discordeno/types` and a `index.js` in the same file, one such example is `transformers/reverse/component.ts`.

As far as I can tell, this does not have any specific advantage beside readability, maybe something with tree-shaking. (and for us, tree-shaking doesn't really matter)

The only files that still import index.js files are:
- index.js files themself
- bot/src/handlers.js since it does a `import * as handlers from './handlers/index.js'` and the alternative is like 90 lines of imports
