### PR TITLE
fix(types,docs): Update documentation for component Select Menu types to reflect minValue and maxValue of 0-25, max 25

### DIFF
--- a/packages/types/src/discord/components.ts
+++ b/packages/types/src/discord/components.ts
@@ -157,9 +157,9 @@ export interface DiscordSelectMenuComponent extends DiscordBaseComponent {
   options?: DiscordSelectOption[]
   /** A custom placeholder text if nothing is selected. Maximum 150 characters. */
   placeholder?: string
-  /** The minimum number of items that must be selected. Default 1. Between 1-25. */
+  /** The minimum number of items that must be selected. Default 1. Between 0-25. */
   min_values?: number
-  /** The maximum number of items that can be selected. Default 1. Between 1-25. */
+  /** The maximum number of items that can be selected. Default 1. Max 25. */
   max_values?: number
   /**
    * Whether select menu is disabled

--- a/packages/types/src/discordeno/components.ts
+++ b/packages/types/src/discordeno/components.ts
@@ -102,9 +102,9 @@ export interface StringSelectComponent extends BaseComponent {
   options: SelectOption[]
   /** A custom placeholder text if nothing is selected. Maximum 150 characters. */
   placeholder?: string
-  /** The minimum number of items that must be selected. Default 1. Between 1-25. */
+  /** The minimum number of items that must be selected. Default 1. Between 0-25. */
   minValues?: number
-  /** The maximum number of items that can be selected. Default 1. Between 1-25. */
+  /** The maximum number of items that can be selected. Default 1. Max 25. */
   maxValues?: number
   /** Whether or not this select is disabled */
   disabled?: boolean
@@ -167,9 +167,9 @@ export interface UserSelectComponent extends BaseComponent {
    * The number of default values must be in the range defined by minValues and maxValues
    */
   defaultValues?: SelectMenuDefaultValue[]
-  /** The minimum number of items that must be selected. Default 1. Between 1-25. */
+  /** The minimum number of items that must be selected. Default 1. Between 0-25. */
   minValues?: number
-  /** The maximum number of items that can be selected. Default 1. Between 1-25. */
+  /** The maximum number of items that can be selected. Default 1. Max 25. */
   maxValues?: number
   /** Whether or not this select is disabled */
   disabled?: boolean
@@ -196,9 +196,9 @@ export interface RoleSelectComponent extends BaseComponent {
    * The number of default values must be in the range defined by minValues and maxValues
    */
   defaultValues?: SelectMenuDefaultValue[]
-  /** The minimum number of items that must be selected. Default 1. Between 1-25. */
+  /** The minimum number of items that must be selected. Default 1. Between 0-25. */
   minValues?: number
-  /** The maximum number of items that can be selected. Default 1. Between 1-25. */
+  /** The maximum number of items that can be selected. Default 1. Max 25. */
   maxValues?: number
   /** Whether or not this select is disabled */
   disabled?: boolean
@@ -217,9 +217,9 @@ export interface MentionableSelectComponent extends BaseComponent {
    * The number of default values must be in the range defined by minValues and maxValues
    */
   defaultValues?: SelectMenuDefaultValue[]
-  /** The minimum number of items that must be selected. Default 1. Between 1-25. */
+  /** The minimum number of items that must be selected. Default 1. Between 0-25. */
   minValues?: number
-  /** The maximum number of items that can be selected. Default 1. Between 1-25. */
+  /** The maximum number of items that can be selected. Default 1. Max 25. */
   maxValues?: number
   /** Whether or not this select is disabled */
   disabled?: boolean
@@ -240,9 +240,9 @@ export interface ChannelSelectComponent extends BaseComponent {
    * The number of default values must be in the range defined by minValues and maxValues
    */
   defaultValues?: SelectMenuDefaultValue[]
-  /** The minimum number of items that must be selected. Default 1. Between 1-25. */
+  /** The minimum number of items that must be selected. Default 1. Between 0-25. */
   minValues?: number
-  /** The maximum number of items that can be selected. Default 1. Between 1-25. */
+  /** The maximum number of items that can be selected. Default 1. Max 25. */
   maxValues?: number
   /** Whether or not this select is disabled */
   disabled?: boolean


### PR DESCRIPTION
Noticed that the type hints noted 1-25 when 0 is an accepted value used to be able to "clear" a dropdown select menu.

Ref to String Select: https://discord.com/developers/docs/components/reference#string-select