### PR TITLE
feat(oauth2): PKCE support

### DIFF
--- a/packages/types/src/discord/oauth2.ts
+++ b/packages/types/src/discord/oauth2.ts
@@ -141,6 +141,8 @@ export interface DiscordTokenExchangeAuthorizationCode {
   code: string
   /** The redirect_uri associated with this authorization */
   redirect_uri: string
+  /** The code verifier for the token exchange if one was sent during the authorization request */
+  code_verifier: string
 }
 
 /** https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-access-token-response */

--- a/packages/utils/src/base64.ts
+++ b/packages/utils/src/base64.ts
@@ -5,27 +5,42 @@
  */
 export function encode(data: Uint8Array | ArrayBuffer | string): string {
   const uint8 = typeof data === 'string' ? new TextEncoder().encode(data) : data instanceof Uint8Array ? data : new Uint8Array(data)
+  return _encode(uint8, base64abc, false)
+}
+
+/**
+ * Encodes a given Uint8Array, ArrayBuffer or string into RFC4648 base64url representation
+ * @param data The data to encode
+ * @returns The base64url encoded string
+ */
+export function encodeBase64Url(data: Uint8Array | ArrayBuffer | string): string {
+  const uint8 = typeof data === 'string' ? new TextEncoder().encode(data) : data instanceof Uint8Array ? data : new Uint8Array(data)
+  return _encode(uint8, base64urlAbc, true)
+}
+
+/** @private */
+function _encode(data: Uint8Array, alpha: string[], skipPadding: boolean): string {
   let result = ''
   let i
-  const l = uint8.length
+  const l = data.length
   for (i = 2; i < l; i += 3) {
-    result += base64abc[uint8[i - 2] >> 2]
-    result += base64abc[((uint8[i - 2] & 0x03) << 4) | (uint8[i - 1] >> 4)]
-    result += base64abc[((uint8[i - 1] & 0x0f) << 2) | (uint8[i] >> 6)]
-    result += base64abc[uint8[i] & 0x3f]
+    result += alpha[data[i - 2] >> 2]
+    result += alpha[((data[i - 2] & 0x03) << 4) | (data[i - 1] >> 4)]
+    result += alpha[((data[i - 1] & 0x0f) << 2) | (data[i] >> 6)]
+    result += alpha[data[i] & 0x3f]
   }
   if (i === l + 1) {
     // 1 octet yet to write
-    result += base64abc[uint8[i - 2] >> 2]
-    result += base64abc[(uint8[i - 2] & 0x03) << 4]
-    result += '=='
+    result += alpha[data[i - 2] >> 2]
+    result += alpha[(data[i - 2] & 0x03) << 4]
+    if (!skipPadding) result += '=='
   }
   if (i === l) {
     // 2 octets yet to write
-    result += base64abc[uint8[i - 2] >> 2]
-    result += base64abc[((uint8[i - 2] & 0x03) << 4) | (uint8[i - 1] >> 4)]
-    result += base64abc[(uint8[i - 1] & 0x0f) << 2]
-    result += '='
+    result += alpha[data[i - 2] >> 2]
+    result += alpha[((data[i - 2] & 0x03) << 4) | (data[i - 1] >> 4)]
+    result += alpha[(data[i - 1] & 0x0f) << 2]
+    if (!skipPadding) result += '='
   }
   return result
 }
@@ -141,6 +156,73 @@ const base64abc = [
   '9',
   '+',
   '/',
+]
+
+const base64urlAbc = [
+  'A',
+  'B',
+  'C',
+  'D',
+  'E',
+  'F',
+  'G',
+  'H',
+  'I',
+  'J',
+  'K',
+  'L',
+  'M',
+  'N',
+  'O',
+  'P',
+  'Q',
+  'R',
+  'S',
+  'T',
+  'U',
+  'V',
+  'W',
+  'X',
+  'Y',
+  'Z',
+  'a',
+  'b',
+  'c',
+  'd',
+  'e',
+  'f',
+  'g',
+  'h',
+  'i',
+  'j',
+  'k',
+  'l',
+  'm',
+  'n',
+  'o',
+  'p',
+  'q',
+  'r',
+  's',
+  't',
+  'u',
+  'v',
+  'w',
+  'x',
+  'y',
+  'z',
+  '0',
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+  '-',
+  '_',
 ]
 
 // CREDIT: https://gist.github.com/enepomnyaschih/72c423f727d395eeaa09697058238727

--- a/packages/utils/tests/base64.spec.ts
+++ b/packages/utils/tests/base64.spec.ts
@@ -1,7 +1,7 @@
 import { Buffer } from 'node:buffer'
 import { expect } from 'chai'
 import { describe, it } from 'mocha'
-import { decode, encode } from '../src/base64.js'
+import { decode, encode, encodeBase64Url } from '../src/base64.js'
 
 describe('base64.ts', () => {
   describe('encode', () => {
@@ -12,11 +12,67 @@ describe('base64.ts', () => {
       expect(encode(new Uint8Array([77, 97, 110, 32, 208, 129, 240, 164, 173, 162]))).to.be.equal('TWFuINCB8KStog==')
       expect(encode(new Uint8Array([77, 97, 110, 32, 208, 129, 240, 164, 173]))).to.be.equal('TWFuINCB8KSt')
       expect(encode(new Uint8Array([77, 97, 110, 32, 208, 129, 240, 164, 173, 162, 63]))).to.be.equal('TWFuINCB8KStoj8=')
+      expect(encode(new Uint8Array([199, 239, 242]))).to.be.equal('x+/y')
+
+      // From https://datatracker.ietf.org/doc/html/rfc4648#section-10
+      expect(encode(new Uint8Array([]))).to.be.equal('')
+      expect(encode(new Uint8Array([102]))).to.be.equal('Zg==')
+      expect(encode(new Uint8Array([102, 111]))).to.be.equal('Zm8=')
+      expect(encode(new Uint8Array([102, 111, 111]))).to.be.equal('Zm9v')
+      expect(encode(new Uint8Array([102, 111, 111, 98]))).to.be.equal('Zm9vYg==')
+      expect(encode(new Uint8Array([102, 111, 111, 98, 97]))).to.be.equal('Zm9vYmE=')
+      expect(encode(new Uint8Array([102, 111, 111, 98, 97, 114]))).to.be.equal('Zm9vYmFy')
     })
     it('can encode Buffer to base64', () => {
       expect(encode(Buffer.from([77, 97, 110, 32, 208, 129, 240, 164, 173, 162]))).to.be.equal('TWFuINCB8KStog==')
       expect(encode(Buffer.from([77, 97, 110, 32, 208, 129, 240, 164, 173]))).to.be.equal('TWFuINCB8KSt')
       expect(encode(Buffer.from([77, 97, 110, 32, 208, 129, 240, 164, 173, 162, 63]))).to.be.equal('TWFuINCB8KStoj8=')
+      expect(encode(Buffer.from([199, 239, 242]))).to.be.equal('x+/y')
+
+      // From https://datatracker.ietf.org/doc/html/rfc4648#section-10
+      expect(encode(Buffer.from([]))).to.be.equal('')
+      expect(encode(Buffer.from([102]))).to.be.equal('Zg==')
+      expect(encode(Buffer.from([102, 111]))).to.be.equal('Zm8=')
+      expect(encode(Buffer.from([102, 111, 111]))).to.be.equal('Zm9v')
+      expect(encode(Buffer.from([102, 111, 111, 98]))).to.be.equal('Zm9vYg==')
+      expect(encode(Buffer.from([102, 111, 111, 98, 97]))).to.be.equal('Zm9vYmE=')
+      expect(encode(Buffer.from([102, 111, 111, 98, 97, 114]))).to.be.equal('Zm9vYmFy')
+    })
+  })
+
+  describe('encode base64 url', () => {
+    it('can encode string to base64 url', () => {
+      expect(encodeBase64Url('Man Ё𤭢')).to.be.equal('TWFuINCB8KStog')
+    })
+    it('can encode Uint8Array to base64 url', () => {
+      expect(encodeBase64Url(new Uint8Array([77, 97, 110, 32, 208, 129, 240, 164, 173, 162]))).to.be.equal('TWFuINCB8KStog')
+      expect(encodeBase64Url(new Uint8Array([77, 97, 110, 32, 208, 129, 240, 164, 173]))).to.be.equal('TWFuINCB8KSt')
+      expect(encodeBase64Url(new Uint8Array([77, 97, 110, 32, 208, 129, 240, 164, 173, 162, 63]))).to.be.equal('TWFuINCB8KStoj8')
+      expect(encodeBase64Url(new Uint8Array([199, 239, 242]))).to.be.equal('x-_y')
+
+      // From https://datatracker.ietf.org/doc/html/rfc4648#section-10
+      expect(encodeBase64Url(new Uint8Array([]))).to.be.equal('')
+      expect(encodeBase64Url(new Uint8Array([102]))).to.be.equal('Zg')
+      expect(encodeBase64Url(new Uint8Array([102, 111]))).to.be.equal('Zm8')
+      expect(encodeBase64Url(new Uint8Array([102, 111, 111]))).to.be.equal('Zm9v')
+      expect(encodeBase64Url(new Uint8Array([102, 111, 111, 98]))).to.be.equal('Zm9vYg')
+      expect(encodeBase64Url(new Uint8Array([102, 111, 111, 98, 97]))).to.be.equal('Zm9vYmE')
+      expect(encodeBase64Url(new Uint8Array([102, 111, 111, 98, 97, 114]))).to.be.equal('Zm9vYmFy')
+    })
+    it('can encode Buffer to base64 url', () => {
+      expect(encodeBase64Url(Buffer.from([77, 97, 110, 32, 208, 129, 240, 164, 173, 162]))).to.be.equal('TWFuINCB8KStog')
+      expect(encodeBase64Url(Buffer.from([77, 97, 110, 32, 208, 129, 240, 164, 173]))).to.be.equal('TWFuINCB8KSt')
+      expect(encodeBase64Url(Buffer.from([77, 97, 110, 32, 208, 129, 240, 164, 173, 162, 63]))).to.be.equal('TWFuINCB8KStoj8')
+      expect(encodeBase64Url(Buffer.from([199, 239, 242]))).to.be.equal('x-_y')
+
+      // From https://datatracker.ietf.org/doc/html/rfc4648#section-10
+      expect(encodeBase64Url(Buffer.from([]))).to.be.equal('')
+      expect(encodeBase64Url(Buffer.from([102]))).to.be.equal('Zg')
+      expect(encodeBase64Url(Buffer.from([102, 111]))).to.be.equal('Zm8')
+      expect(encodeBase64Url(Buffer.from([102, 111, 111]))).to.be.equal('Zm9v')
+      expect(encodeBase64Url(Buffer.from([102, 111, 111, 98]))).to.be.equal('Zm9vYg')
+      expect(encodeBase64Url(Buffer.from([102, 111, 111, 98, 97]))).to.be.equal('Zm9vYmE')
+      expect(encodeBase64Url(Buffer.from([102, 111, 111, 98, 97, 114]))).to.be.equal('Zm9vYmFy')
     })
   })
 


### PR DESCRIPTION
Add support for PKCE in the OAuth2 flow ([RFC 7636](https://datatracker.ietf.org/doc/html/rfc7636))

Testing code:
```ts
import { createInterface } from 'node:readline/promises'
import { createBot, createCodeChallenge, createOAuth2Link, generateCodeVerifier, OAuth2Scope } from '@discordeno/bot'

const CLIENT_SECRET = '<client secret here>'

const intf = createInterface(process.stdin, process.stdout)

const bot = createBot({
  token: '<token here>',
  desiredProperties: {},
})

const verifier = generateCodeVerifier()
const challenge = await createCodeChallenge(verifier)

const url = createOAuth2Link({
  clientId: bot.applicationId,
  responseType: 'code',
  scope: [OAuth2Scope.Identify],
  // Remember to add the redirect url to the application
  redirectUri: 'https://example.com',
  codeChallenge: challenge,
  codeChallengeMethod: 'S256',
})

const code = await intf.question(
  `Open this URL in your browser:\n\n${url}\n\nAfter accepting the authorization, paste the "code" query parameter value here: `,
)

const exchange = await bot.helpers.exchangeToken(bot.applicationId, CLIENT_SECRET, {
  code,
  codeVerifier: verifier,
  grantType: 'authorization_code',
  redirectUri: 'https://example.com',
})

console.log('The token exchange was successful:')
console.dir(exchange, { depth: Infinity })
```
