### PR TITLE
chore(gateway)!: Remove Shard forwardToBot

### DIFF
--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -63,7 +63,6 @@ export function createBot<
   }
 
   options.gateway.intents = options.intents
-  options.gateway.preferSnakeCase = true
 
   const id = getBotIdFromToken(options.token)
 

--- a/packages/gateway/src/Shard.ts
+++ b/packages/gateway/src/Shard.ts
@@ -2,7 +2,7 @@ import { Buffer } from 'node:buffer'
 import zlib from 'node:zlib'
 import type { DiscordGatewayPayload, DiscordHello, DiscordReady, DiscordUpdatePresence } from '@discordeno/types'
 import { GatewayCloseEventCodes, GatewayOpcodes } from '@discordeno/types'
-import { camelize, delay, LeakyBucket, logger } from '@discordeno/utils'
+import { delay, LeakyBucket, logger } from '@discordeno/utils'
 import type { Decompress as FZstdDecompress } from 'fzstd'
 import NodeWebSocket from 'ws'
 import {
@@ -759,13 +759,7 @@ export class DiscordenoShard {
       this.previousSequenceNumber = packet.s
     }
 
-    this.forwardToBot(packet)
-  }
-
-  forwardToBot(packet: DiscordGatewayPayload): void {
-    // The necessary handling required for the Shards connection has been finished.
-    // Now the event can be safely forwarded.
-    this.events.message?.(this, camelize(packet))
+    this.events.message?.(this, packet)
   }
 
   /**

--- a/packages/gateway/src/manager.ts
+++ b/packages/gateway/src/manager.ts
@@ -48,7 +48,6 @@ export function createGatewayManager(options: CreateGatewayManagerOptions): Gate
     shardsPerWorker: options.shardsPerWorker ?? 25,
     spawnShardDelay: options.spawnShardDelay ?? 5300,
     spreadShardsInRoundRobin: options.spreadShardsInRoundRobin ?? false,
-    preferSnakeCase: options.preferSnakeCase ?? false,
     shards: new Map(),
     buckets: new Map(),
     cache: {
@@ -175,12 +174,6 @@ export function createGatewayManager(options: CreateGatewayManagerOptions): Gate
           requestIdentify: async () => await gateway.requestIdentify(shardId),
           makePresence: gateway.makePresence,
         })
-
-        if (gateway.preferSnakeCase) {
-          shard.forwardToBot = async (payload) => {
-            shard.events?.message?.(shard, payload)
-          }
-        }
 
         gateway.resharding.shards.set(shardId, shard)
 
@@ -366,12 +359,6 @@ export function createGatewayManager(options: CreateGatewayManagerOptions): Gate
           requestIdentify: async () => await gateway.requestIdentify(shardId),
           makePresence: gateway.makePresence,
         })
-
-        if (this.preferSnakeCase) {
-          shard.forwardToBot = async (payload) => {
-            shard!.events.message?.(shard!, payload)
-          }
-        }
 
         this.shards.set(shardId, shard)
       }
@@ -582,11 +569,6 @@ export interface CreateGatewayManagerOptions {
    * @default 5300
    */
   spawnShardDelay?: number
-  /**
-   * Whether to send the discord packets in snake case form.
-   * @default false
-   */
-  preferSnakeCase?: boolean
   /**
    * Total amount of shards your bot uses. Useful for zero-downtime updates or resharding.
    * @default 1

--- a/packages/gateway/src/types.ts
+++ b/packages/gateway/src/types.ts
@@ -1,4 +1,4 @@
-import type { Camelize, DiscordGatewayPayload, GatewayOpcodes } from '@discordeno/types'
+import type { DiscordGatewayPayload, GatewayOpcodes } from '@discordeno/types'
 import type Shard from './Shard.js'
 
 export enum ShardState {
@@ -149,7 +149,7 @@ export interface ShardEvents {
   /** The shard has successfully been identified itself with Discord. */
   ready?: (shard: Shard) => unknown
   /** The shard has received a message from Discord. */
-  message?: (shard: Shard, payload: Camelize<DiscordGatewayPayload>) => unknown
+  message?: (shard: Shard, payload: DiscordGatewayPayload) => unknown
 }
 
 export enum ShardSocketCloseCodes {


### PR DESCRIPTION
forwardToBot has been removed in favor of directly using the events.message.

the default implementation for forwardToBot used to camelize the packet, however in most cases you want to preserve the snake_case, and for those that need camelCase it can be easly done in the message event function.

This also removes the gateway.preferSnakeCase option as it no longer has a use
