### PR TITLE
feat(components): File upload component for modals

### DIFF
--- a/packages/bot/src/transformers/component.ts
+++ b/packages/bot/src/transformers/component.ts
@@ -3,6 +3,8 @@ import {
   type DiscordButtonComponent,
   type DiscordContainerComponent,
   type DiscordFileComponent,
+  type DiscordFileUploadComponent,
+  type DiscordFileUploadInteractionResponse,
   type DiscordLabelComponent,
   type DiscordLabelInteractionResponse,
   type DiscordMediaGalleryComponent,
@@ -68,6 +70,9 @@ export function transformComponent(bot: Bot, payload: DiscordMessageComponent | 
       break
     case MessageComponentTypes.Label:
       component = transformLabelComponent(bot, payload)
+      break
+    case MessageComponentTypes.FileUpload:
+      component = transformFileUploadComponent(bot, payload)
       break
   }
 
@@ -293,4 +298,24 @@ function transformLabelComponent(bot: Bot, payload: DiscordLabelComponent | Disc
   if (props.component && payload.component) label.component = bot.transformers.component(bot, payload.component)
 
   return label
+}
+
+function transformFileUploadComponent(bot: Bot, payload: DiscordFileUploadComponent | DiscordFileUploadInteractionResponse): Component {
+  const props = bot.transformers.desiredProperties.component
+  const fileUpload = {} as Component
+
+  if (props.type && payload.type) fileUpload.type = payload.type
+  if (props.id && payload.id) fileUpload.id = payload.id
+  if (props.customId && payload.custom_id) fileUpload.customId = payload.custom_id
+
+  // Check that this is a response
+  if ('values' in payload) {
+    if (props.values && payload.values) fileUpload.values = payload.values
+  } else {
+    if (props.minValues && payload.min_values) fileUpload.minValues = payload.min_values
+    if (props.maxValues && payload.max_values) fileUpload.maxValues = payload.max_values
+    if (props.required && payload.required) fileUpload.required = payload.required
+  }
+
+  return fileUpload
 }

--- a/packages/bot/src/transformers/reverse/component.ts
+++ b/packages/bot/src/transformers/reverse/component.ts
@@ -55,8 +55,9 @@ export function transformComponentToDiscordComponent(
       return transformLabelComponent(bot, payload)
     case MessageComponentTypes.Separator:
     case MessageComponentTypes.TextDisplay:
+    case MessageComponentTypes.FileUpload:
       // As of now they are compatible
-      return payload as DiscordMessageComponent
+      return payload as DiscordMessageComponent | DiscordMessageComponentFromModalInteractionResponse
   }
 }
 

--- a/packages/types/src/discord/components.ts
+++ b/packages/types/src/discord/components.ts
@@ -39,6 +39,9 @@ export enum MessageComponentTypes {
   Container = 17,
   /** Container associating a label and description with a component */
   Label,
+  // TODO(file-uploads-modal): Change description when file uploads in modals is live
+  /** A component for uploading files in modals */
+  FileUpload,
 }
 
 export type DiscordMessageComponents = DiscordMessageComponent[]
@@ -55,6 +58,7 @@ export type DiscordMessageComponent =
   | DiscordContainerComponent
   | DiscordFileComponent
   | DiscordLabelComponent
+  | DiscordFileUploadComponent
 
 export type DiscordMessageComponentFromModalInteractionResponse =
   | DiscordTextInputInteractionResponse
@@ -547,7 +551,7 @@ export interface DiscordLabelComponent extends DiscordBaseComponent {
    */
   description?: string
   /** The component within the label */
-  component: DiscordTextInputComponent | DiscordSelectMenuComponent
+  component: DiscordTextInputComponent | DiscordSelectMenuComponent | DiscordFileUploadComponent
 }
 
 /** https://discord.com/developers/docs/components/reference#label-label-interaction-response-structure */
@@ -563,6 +567,48 @@ export interface DiscordLabelInteractionResponse {
     | DiscordRoleSelectInteractionResponseFromModal
     | DiscordMentionableSelectInteractionResponseFromModal
     | DiscordChannelSelectInteractionResponseFromModal
+    | DiscordFileUploadInteractionResponse
+}
+
+// TODO(file-uploads-modal): Update when file uploads in modals is live
+/** https://discord.com/developers/docs/components/reference#?????????? */
+export interface DiscordFileUploadComponent extends DiscordBaseComponent {
+  type: MessageComponentTypes.FileUpload
+
+  /** The custom id for the channel select */
+  custom_id: string
+  /**
+   * The minimum number of files that must be uploaded
+   *
+   * @remarks
+   * Between 0-10
+   */
+  min_values?: number
+  /** The maximum number of files that can be uploaded
+   *
+   * @remarks
+   * Between 1-10
+   */
+  max_values?: number
+  /**
+   * Whether this component is required to be filled
+   *
+   * @default true
+   */
+  required?: boolean
+}
+
+// TODO(file-uploads-modal): Update when file uploads in modals is live
+/** https://discord.com/developers/docs/components/reference#???? */
+export interface DiscordFileUploadInteractionResponse {
+  type: MessageComponentTypes.FileUpload
+
+  /** 32 bit integer used as an optional identifier for component */
+  id: number
+  /** The custom id for the file upload */
+  custom_id: string
+  /** IDs of the uploaded files */
+  values: string[]
 }
 
 /** https://discord.com/developers/docs/components/reference#unfurled-media-item-structure */

--- a/packages/types/src/discordeno/components.ts
+++ b/packages/types/src/discordeno/components.ts
@@ -29,6 +29,7 @@ export type MessageComponent =
   | ContainerComponent
   | FileComponent
   | LabelComponent
+  | FileUploadComponent
 
 /** https://discord.com/developers/docs/components/reference#anatomy-of-a-component */
 export interface BaseComponent {
@@ -439,4 +440,33 @@ export interface LabelComponent extends BaseComponent {
     | RoleSelectComponent
     | MentionableSelectComponent
     | ChannelSelectComponent
+    | FileUploadComponent
+}
+
+// TODO(file-uploads-modal): Update when file uploads in modals is live
+/** https://discord.com/developers/docs/components/reference#?????????? */
+export interface FileUploadComponent extends BaseComponent {
+  type: MessageComponentTypes.FileUpload
+
+  /** The custom id for the channel select */
+  customId: string
+  /**
+   * The minimum number of files that must be uploaded
+   *
+   * @remarks
+   * Between 0-10
+   */
+  minValues?: number
+  /** The maximum number of files that can be uploaded
+   *
+   * @remarks
+   * Between 1-10
+   */
+  maxValues?: number
+  /**
+   * Whether this component is required to be filled
+   *
+   * @default true
+   */
+  required?: boolean
 }


### PR DESCRIPTION
Add support for file uploads in modals

> [!IMPORTANT]
> This is in private preview: Until this is public and available in discord/discord-api-docs this pr should not be merged, reviews are fine

> [!IMPORTANT]
> This is on top of https://github.com/discordeno/discordeno/pull/4467 as it relies on some changes done in that pr (mainly the label interaction response type)
