### PR TITLE
feat(bot)!: make desiredProperties generic in transformers

### DIFF
--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -41,7 +41,6 @@ export function createBot<
   type TypedBot = Bot<CompleteProps, TBehavior>
 
   if (!options.transformers) options.transformers = {}
-  if (!options.transformers.desiredProperties) options.transformers.desiredProperties = options.desiredProperties
   if (!options.rest) options.rest = { token: options.token, applicationId: options.applicationId }
   if (!options.rest.token) options.rest.token = options.token
   if (!options.rest.logger && options.loggerFactory) options.rest.logger = options.loggerFactory('REST')
@@ -63,6 +62,7 @@ export function createBot<
   }
 
   options.gateway.intents = options.intents
+  ;(options.transformers as Transformers<CompleteProps, TBehavior>).desiredProperties = options.desiredProperties as CompleteProps
 
   const id = getBotIdFromToken(options.token)
 
@@ -123,7 +123,7 @@ export interface CreateBotOptions<TProps extends RecursivePartial<TransformersDe
   /** The event handlers. */
   events?: Partial<EventHandlers<CompleteDesiredProperties<NoInfer<TProps>>, TBehavior>>
   /** The functions that should transform discord objects to discordeno shaped objects. */
-  transformers?: RecursivePartial<Transformers<CompleteDesiredProperties<NoInfer<TProps>>, TBehavior>>
+  transformers?: RecursivePartial<Omit<Transformers<CompleteDesiredProperties<NoInfer<TProps>>, TBehavior>, 'desiredProperties'>>
   /** The handler functions that should handle incoming discord payloads from gateway and call an event. */
   handlers?: Partial<Record<GatewayDispatchEventNames, BotGatewayHandler<CompleteDesiredProperties<NoInfer<TProps>>, TBehavior>>>
   /**

--- a/packages/bot/src/transformers.ts
+++ b/packages/bot/src/transformers.ts
@@ -351,7 +351,7 @@ export type Transformers<TProps extends TransformersDesiredProperties, TBehavior
   TBehavior
 > & {
   customizers: TransformerCustomizers<TProps, TBehavior>
-  desiredProperties: TransformersDesiredProperties
+  desiredProperties: TProps
   reverse: {
     activity: (bot: Bot<TProps, TBehavior>, payload: Activity) => DiscordActivity
     allowedMentions: (bot: Bot<TProps, TBehavior>, payload: AllowedMentions) => DiscordAllowedMentions


### PR DESCRIPTION
Updated desiredProperties in transformers to be generic so that it can be used to retrive the bot desired properties, and removed the option from `CreateBotOptions.transformers.desiredProperties` as that would cause the typings for the bot to be incorrect
