### PR TITLE
fix(types): Fix bounds for ApplicationCommandOptionTypes.Integer

### DIFF
--- a/packages/types/src/discord/interactions.ts
+++ b/packages/types/src/discord/interactions.ts
@@ -462,7 +462,7 @@ export enum ApplicationCommandOptionTypes {
   SubCommand = 1,
   SubCommandGroup,
   String,
-  /** Any integer between -2^53 and 2^53 */
+  /** Any integer between -2^53+1 and 2^53-1 */
   Integer,
   Boolean,
   User,


### PR DESCRIPTION
- upstream: https://github.com/discord/discord-api-docs/pull/7458
- fixes #4507