### PR TITLE
api-docs: Update relationships.read scope description

### DIFF
--- a/packages/types/src/discord/oauth2.ts
+++ b/packages/types/src/discord/oauth2.ts
@@ -80,10 +80,11 @@ export enum OAuth2Scope {
    */
   MessagesRead = 'messages.read',
   /**
-   * Allows your app to know a user's friends and implicit relationships
+   * Allows your app to access a user's Discord Friends list, their pending requests, and blocked users.
    *
    * @remarks
-   * This scope requires Discord approval to be used
+   * This scope is part of the Social SDK.
+   * You need to submit for access in the dev portal to use this scope.
    */
   RelationshipsRead = 'relationships.read',
   /** Allows your app to update a user's connection and metadata for the app */


### PR DESCRIPTION
This now reflects the updated information about the scope, we do not include the links to the form nor the TOS & privacy policy note as those are better suited for the dev docs instead.

- upstream: https://github.com/discord/discord-api-docs/pull/8088
- fixes: #4705
