### PR TITLE
fix(bot): use bigint instead of PermissionStrings[] for allow and deny in channel.permissionOverwrites to match Overwrite type

### DIFF
--- a/packages/bot/src/transformers/channel.ts
+++ b/packages/bot/src/transformers/channel.ts
@@ -1,5 +1,5 @@
 import type { BigString, DiscordChannel, DiscordForumTag } from '@discordeno/types';
-import { calculatePermissions, iconHashToBigInt } from '@discordeno/utils';
+import { iconHashToBigInt } from '@discordeno/utils';
 import type { Bot } from '../bot.js';
 import type { DesiredPropertiesBehavior, SetupDesiredProps, TransformersDesiredProperties } from '../desiredProperties.js';
 import { ChannelToggles } from './toggles/channel.js';
@@ -52,8 +52,8 @@ export const baseChannel: Channel = {
         return {
           type,
           id,
-          allow: calculatePermissions(allow),
-          deny: calculatePermissions(deny),
+          allow,
+          deny,
         };
       }) ?? []
     );

--- a/packages/bot/src/transformers/types.ts
+++ b/packages/bot/src/transformers/types.ts
@@ -51,7 +51,6 @@ import type {
   MfaLevels,
   OAuth2Scope,
   OverwriteTypes,
-  PermissionStrings,
   PremiumTiers,
   PremiumTypes,
   PresenceStatus,
@@ -517,9 +516,9 @@ export interface Channel {
     /** Either 0 (role) or 1 (member) */
     type: OverwriteTypes;
     /** Permission bit set */
-    allow: PermissionStrings[];
+    allow: bigint;
     /** Permission bit set */
-    deny: PermissionStrings[];
+    deny: bigint;
   }[];
 }
 

--- a/packages/types/src/discordeno/channel.ts
+++ b/packages/types/src/discordeno/channel.ts
@@ -18,9 +18,9 @@ export interface Overwrite {
   // NOTE:
   // - Discord says that these are always present, we keep them as optional (and allow for null) because when it is sent it can be null / not present, https://discord.com/developers/docs/resources/guild#create-guild-channel-json-params, specificly the **
   /** Permission bit set */
-  allow?: string | null;
+  allow?: BigString | null;
   /** Permission bit set */
-  deny?: string | null;
+  deny?: BigString | null;
 }
 
 // This needs the prefix Discordeno to avoid conflicts with the @discordeno/bot types.


### PR DESCRIPTION
Keeping `channel.permissionOverwrites`'s `allow` and `deny` to `PermissionStrings[]` while `Overwrite`'s to `string | null` causes mismatch between the two, resulting in the following code not working and needing conversion:

```js
bot.helpers.editChannel(channel.id, { permissionOverwrites: channel.permissionOverwrites });
```

This PR fixes this issue