### PR TITLE
feat(rest): add request timeout to manage stalled requests

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -87,6 +87,13 @@ export const RATE_LIMIT_BUCKET_HEADER = 'x-ratelimit-bucket';
 export const RATE_LIMIT_LIMIT_HEADER = 'x-ratelimit-limit';
 export const RATE_LIMIT_SCOPE_HEADER = 'x-ratelimit-scope';
 
+/** Calls `.unref()` on a timer if the runtime's `setTimeout` returns an object supporting it (Node, Bun), so the timer doesn't keep the process alive. Browsers and Deno return a plain number and have no equivalent. */
+function unrefTimer(timer: unknown): void {
+  if (typeof timer === 'object' && timer !== null && 'unref' in timer && typeof (timer as { unref: unknown }).unref === 'function') {
+    (timer as { unref: () => void }).unref();
+  }
+}
+
 export function createRestManager(options: CreateRestManagerOptions): RestManager {
   const applicationId = options.applicationId ? BigInt(options.applicationId) : getBotIdFromToken(options.token);
 
@@ -465,8 +472,9 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
           ? setTimeout(() => {
               timedOut = true;
               controller.abort();
-            }, rest.requestTimeout).unref()
+            }, rest.requestTimeout)
           : undefined;
+      unrefTimer(timeoutId);
 
       const request = new Request(url, { ...payload, signal: controller.signal });
       rest.events.request(request, {
@@ -663,7 +671,8 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
 
         // Give the request to the proxy a hard deadline too, so a stalled proxy can't hang the caller forever.
         const controller = new AbortController();
-        const timeoutId = rest.requestTimeout > 0 ? setTimeout(() => controller.abort(), rest.requestTimeout).unref() : undefined;
+        const timeoutId = rest.requestTimeout > 0 ? setTimeout(() => controller.abort(), rest.requestTimeout) : undefined;
+        unrefTimer(timeoutId);
 
         const request = new Request(`${rest.baseUrl}/v${rest.version}${route}`, {
           ...rest.createRequestBody(method, options),

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -114,6 +114,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
     isProxied: !baseUrl.startsWith(DISCORD_API_URL),
     updateBearerTokenEndpoint: options.proxy?.updateBearerTokenEndpoint,
     maxRetryCount: Infinity,
+    requestTimeout: options.requestTimeout ?? 30000,
     processingRateLimitedPaths: false,
     queues: new Map(),
     rateLimitedPaths: new Map(),
@@ -428,6 +429,25 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       const url = `${rest.baseUrl}/v${rest.version}${options.route}`;
       const payload = rest.createRequestBody(options.method, options.requestBodyOptions);
 
+      // Retries a request that was aborted because it hit `rest.requestTimeout`, or rejects it once the retry
+      // budget is exhausted. The caller is responsible for the `invalidBucket`/event bookkeeping beforehand.
+      const handleTimeout = async (options: SendRequestOptions, error: Error): Promise<void> => {
+        if (options.retryCount >= rest.maxRetryCount) {
+          rest.logger.debug(`request to ${url} timed out and exceeded the maximum allowed retries.`);
+          options.reject({
+            ok: false,
+            status: 999,
+            error: 'The request timed out and it maxed out the retries limit.',
+            errorObject: error,
+          });
+          return;
+        }
+
+        rest.logger.debug(`request to ${url} timed out after ${rest.requestTimeout}ms, retrying.`, error);
+        options.retryCount += 1;
+        await options.retryRequest?.(options);
+      };
+
       const loggingHeaders = { ...payload.headers };
 
       if (payload.headers.authorization) {
@@ -435,17 +455,37 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
         loggingHeaders.authorization = `${authorizationScheme} tokenhere`;
       }
 
-      const request = new Request(url, payload);
+      // Set up a hard deadline for this attempt. When it fires we abort the fetch (and any in-progress body
+      // read), which forces the awaited fetch below to reject so a stalled connection can never keep this
+      // queue's `processPending` loop (and therefore the whole queue) wedged forever.
+      let timedOut = false;
+      const controller = new AbortController();
+      const timeoutId =
+        rest.requestTimeout > 0
+          ? setTimeout(() => {
+              timedOut = true;
+              controller.abort();
+            }, rest.requestTimeout).unref()
+          : undefined;
+
+      const request = new Request(url, { ...payload, signal: controller.signal });
       rest.events.request(request, {
         body: options.requestBodyOptions?.body,
       });
 
       rest.logger.debug(`sending request to ${url}`, 'with payload:', { ...payload, headers: loggingHeaders });
       const response = await fetch(request).catch(async (error) => {
-        rest.logger.debug(`request fetch to ${url} failed.`, error);
+        if (timeoutId) clearTimeout(timeoutId);
+
         rest.events.requestError(request, error, { body: options.requestBodyOptions?.body });
         // Mark request as completed
         rest.invalidBucket.handleCompletedRequest(999, false);
+
+        // The attempt exceeded `rest.requestTimeout` and was aborted. Treat it like a transient failure and
+        // retry it through the queue, so a single stalled connection doesn't permanently fail the request.
+        if (timedOut) return await handleTimeout(options, error);
+
+        rest.logger.debug(`request fetch to ${url} failed.`, error);
         options.reject({
           ok: false,
           status: 999,
@@ -461,6 +501,17 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
 
       // Sometimes the Content-Type may be "application/json; charset=utf-8", for this reason, we need to check the start of the header
       const body = await (response.headers.get('Content-Type')?.startsWith('application/json') ? response.json() : response.text()).catch(() => null);
+
+      // The attempt is complete now that the body has been read, so cancel the deadline.
+      if (timeoutId) clearTimeout(timeoutId);
+
+      // The deadline fired while reading the response body (the `.catch` above swallowed the abort as a null
+      // body). Retry it like any other timeout instead of treating it as an empty response.
+      if (timedOut) {
+        rest.events.requestError(request, new Error('Request timed out while reading the response body'), { body: options.requestBodyOptions?.body });
+        rest.invalidBucket.handleCompletedRequest(999, false);
+        return await handleTimeout(options, new Error('Request timed out while reading the response body'));
+      }
 
       rest.events.response(request, response, {
         requestBody: options.requestBodyOptions?.body,
@@ -610,15 +661,29 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
           options.headers[rest.authorizationHeader] = rest.authorization;
         }
 
-        const request = new Request(`${rest.baseUrl}/v${rest.version}${route}`, rest.createRequestBody(method, options));
+        // Give the request to the proxy a hard deadline too, so a stalled proxy can't hang the caller forever.
+        const controller = new AbortController();
+        const timeoutId = rest.requestTimeout > 0 ? setTimeout(() => controller.abort(), rest.requestTimeout).unref() : undefined;
+
+        const request = new Request(`${rest.baseUrl}/v${rest.version}${route}`, {
+          ...rest.createRequestBody(method, options),
+          signal: controller.signal,
+        });
         rest.events.request(request, {
           body: options?.body,
         });
 
-        const result = await fetch(request);
+        let result: Response;
+        // biome-ignore lint/suspicious/noExplicitAny: matches the previous inferred type from `response.json()`
+        let body: any;
+        try {
+          result = await fetch(request);
 
-        // Sometimes the Content-Type may be "application/json; charset=utf-8", for this reason, we need to check the start of the header
-        const body = await (result.headers.get('Content-Type')?.startsWith('application/json') ? result.json() : result.text()).catch(() => null);
+          // Sometimes the Content-Type may be "application/json; charset=utf-8", for this reason, we need to check the start of the header
+          body = await (result.headers.get('Content-Type')?.startsWith('application/json') ? result.json() : result.text()).catch(() => null);
+        } finally {
+          if (timeoutId) clearTimeout(timeoutId);
+        }
 
         rest.events.response(request, result, {
           requestBody: options?.body,

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -87,11 +87,6 @@ export const RATE_LIMIT_BUCKET_HEADER = 'x-ratelimit-bucket';
 export const RATE_LIMIT_LIMIT_HEADER = 'x-ratelimit-limit';
 export const RATE_LIMIT_SCOPE_HEADER = 'x-ratelimit-scope';
 
-/** Whether an error is the `TimeoutError` thrown by `AbortSignal.timeout()`. */
-function isTimeoutError(error: unknown): boolean {
-  return error instanceof DOMException && error.name === 'TimeoutError';
-}
-
 export function createRestManager(options: CreateRestManagerOptions): RestManager {
   const applicationId = options.applicationId ? BigInt(options.applicationId) : getBotIdFromToken(options.token);
 
@@ -1971,4 +1966,9 @@ enum HttpResponseCode {
   Error = 400,
   /** This request got rate limited. */
   TooManyRequests = 429,
+}
+
+/** Whether an error is the `TimeoutError` thrown by `AbortSignal.timeout()`. */
+function isTimeoutError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'TimeoutError';
 }

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -482,7 +482,11 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       });
 
       rest.logger.debug(`sending request to ${url}`, 'with payload:', { ...payload, headers: loggingHeaders });
-      const response = await fetch(request).catch(async (error) => {
+
+      let response: Response;
+      try {
+        response = await fetch(request);
+      } catch (error) {
         if (timeoutId) clearTimeout(timeoutId);
 
         rest.events.requestError(request, error, { body: options.requestBodyOptions?.body });
@@ -491,19 +495,17 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
 
         // The attempt exceeded `rest.requestTimeout` and was aborted. Treat it like a transient failure and
         // retry it through the queue, so a single stalled connection doesn't permanently fail the request.
-        if (timedOut) return await handleTimeout(options, error);
+        if (timedOut) return await handleTimeout(options, error as Error);
 
         rest.logger.debug(`request fetch to ${url} failed.`, error);
         options.reject({
           ok: false,
           status: 999,
           error: 'Possible network or request shape issue occurred. If this is rare, its a network glitch. If it occurs a lot something is wrong.',
-          errorObject: error,
+          errorObject: error as Error,
         });
-      });
-
-      // If response is undefined, the error has been handled in the catch block above
-      if (!response) return;
+        return;
+      }
 
       rest.logger.debug(`request fetched from ${url} with status ${response.status} & ${response.statusText}`);
 

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -87,9 +87,9 @@ export const RATE_LIMIT_BUCKET_HEADER = 'x-ratelimit-bucket';
 export const RATE_LIMIT_LIMIT_HEADER = 'x-ratelimit-limit';
 export const RATE_LIMIT_SCOPE_HEADER = 'x-ratelimit-scope';
 
-/** Whether an error is an `AbortSignal.timeout()` abort (a `TimeoutError` `DOMException`). Checked by name so it works across runtimes without depending on `DOMException`/`instanceof`. */
+/** Whether an error is the `TimeoutError` thrown by `AbortSignal.timeout()`. */
 function isTimeoutError(error: unknown): boolean {
-  return typeof error === 'object' && error !== null && (error as { name?: unknown }).name === 'TimeoutError';
+  return error instanceof DOMException && error.name === 'TimeoutError';
 }
 
 export function createRestManager(options: CreateRestManagerOptions): RestManager {
@@ -657,20 +657,20 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
             body: options?.body,
           });
 
-          let result: Response;
-          try {
-            result = await fetch(request);
-          } catch (fetchError) {
+          const result = await fetch(request).catch((fetchError) => {
             rest.events.requestError(request, fetchError, { body: options?.body });
 
             // The attempt hit `rest.requestTimeout` and was aborted; retry it until the budget is exhausted.
             if (isTimeoutError(fetchError) && retryCount < rest.maxRetryCount) {
               rest.logger.debug(`request to proxy ${url} timed out after ${rest.requestTimeout}ms, retrying.`, fetchError);
-              continue;
+              return undefined;
             }
 
             throw fetchError;
-          }
+          });
+
+          // If result is undefined, the attempt timed out and is being retried.
+          if (!result) continue;
 
           // Sometimes the Content-Type may be "application/json; charset=utf-8", for this reason, we need to check the start of the header
           const body = await (result.headers.get('Content-Type')?.startsWith('application/json') ? result.json() : result.text()).catch(() => null);

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -87,11 +87,9 @@ export const RATE_LIMIT_BUCKET_HEADER = 'x-ratelimit-bucket';
 export const RATE_LIMIT_LIMIT_HEADER = 'x-ratelimit-limit';
 export const RATE_LIMIT_SCOPE_HEADER = 'x-ratelimit-scope';
 
-/** Calls `.unref()` on a timer if the runtime's `setTimeout` returns an object supporting it (Node, Bun), so the timer doesn't keep the process alive. Browsers and Deno return a plain number and have no equivalent. */
-function unrefTimer(timer: unknown): void {
-  if (typeof timer === 'object' && timer !== null && 'unref' in timer && typeof (timer as { unref: unknown }).unref === 'function') {
-    (timer as { unref: () => void }).unref();
-  }
+/** Whether an error is an `AbortSignal.timeout()` abort (a `TimeoutError` `DOMException`). Checked by name so it works across runtimes without depending on `DOMException`/`instanceof`. */
+function isTimeoutError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && (error as { name?: unknown }).name === 'TimeoutError';
 }
 
 export function createRestManager(options: CreateRestManagerOptions): RestManager {
@@ -462,66 +460,40 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
         loggingHeaders.authorization = `${authorizationScheme} tokenhere`;
       }
 
-      // Set up a hard deadline for this attempt. When it fires we abort the fetch (and any in-progress body
-      // read), which forces the awaited fetch below to reject so a stalled connection can never keep this
-      // queue's `processPending` loop (and therefore the whole queue) wedged forever.
-      let timedOut = false;
-      const controller = new AbortController();
-      const timeoutId =
-        rest.requestTimeout > 0
-          ? setTimeout(() => {
-              timedOut = true;
-              controller.abort();
-            }, rest.requestTimeout)
-          : undefined;
-      unrefTimer(timeoutId);
-
-      const request = new Request(url, { ...payload, signal: controller.signal });
+      // Give this attempt a hard deadline. `AbortSignal.timeout` aborts the fetch (and any in-progress body
+      // read) once it fires, which makes the awaited fetch reject so a stalled connection can never keep this
+      // queue's `processPending` loop (and therefore the whole queue) wedged forever. Omitted when disabled.
+      const request = new Request(url, { ...payload, signal: rest.requestTimeout > 0 ? AbortSignal.timeout(rest.requestTimeout) : undefined });
       rest.events.request(request, {
         body: options.requestBodyOptions?.body,
       });
 
       rest.logger.debug(`sending request to ${url}`, 'with payload:', { ...payload, headers: loggingHeaders });
-
-      let response: Response;
-      try {
-        response = await fetch(request);
-      } catch (error) {
-        if (timeoutId) clearTimeout(timeoutId);
-
+      const response = await fetch(request).catch(async (error) => {
         rest.events.requestError(request, error, { body: options.requestBodyOptions?.body });
         // Mark request as completed
         rest.invalidBucket.handleCompletedRequest(999, false);
 
-        // The attempt exceeded `rest.requestTimeout` and was aborted. Treat it like a transient failure and
-        // retry it through the queue, so a single stalled connection doesn't permanently fail the request.
-        if (timedOut) return await handleTimeout(options, error as Error);
+        // The attempt hit `rest.requestTimeout` and was aborted. Treat it like a transient failure and retry
+        // it through the queue, so a single stalled connection doesn't permanently fail the request.
+        if (isTimeoutError(error)) return await handleTimeout(options, error);
 
         rest.logger.debug(`request fetch to ${url} failed.`, error);
         options.reject({
           ok: false,
           status: 999,
           error: 'Possible network or request shape issue occurred. If this is rare, its a network glitch. If it occurs a lot something is wrong.',
-          errorObject: error as Error,
+          errorObject: error,
         });
-        return;
-      }
+      });
+
+      // If response is undefined, the error has been handled in the catch block above
+      if (!response) return;
 
       rest.logger.debug(`request fetched from ${url} with status ${response.status} & ${response.statusText}`);
 
       // Sometimes the Content-Type may be "application/json; charset=utf-8", for this reason, we need to check the start of the header
       const body = await (response.headers.get('Content-Type')?.startsWith('application/json') ? response.json() : response.text()).catch(() => null);
-
-      // The attempt is complete now that the body has been read, so cancel the deadline.
-      if (timeoutId) clearTimeout(timeoutId);
-
-      // The deadline fired while reading the response body (the `.catch` above swallowed the abort as a null
-      // body). Retry it like any other timeout instead of treating it as an empty response.
-      if (timedOut) {
-        rest.events.requestError(request, new Error('Request timed out while reading the response body'), { body: options.requestBodyOptions?.body });
-        rest.invalidBucket.handleCompletedRequest(999, false);
-        return await handleTimeout(options, new Error('Request timed out while reading the response body'));
-      }
 
       rest.events.response(request, response, {
         requestBody: options.requestBodyOptions?.body,
@@ -671,47 +643,55 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
           options.headers[rest.authorizationHeader] = rest.authorization;
         }
 
-        // Give the request to the proxy a hard deadline too, so a stalled proxy can't hang the caller forever.
-        const controller = new AbortController();
-        const timeoutId = rest.requestTimeout > 0 ? setTimeout(() => controller.abort(), rest.requestTimeout) : undefined;
-        unrefTimer(timeoutId);
+        const url = `${rest.baseUrl}/v${rest.version}${route}`;
 
-        const request = new Request(`${rest.baseUrl}/v${rest.version}${route}`, {
-          ...rest.createRequestBody(method, options),
-          signal: controller.signal,
-        });
-        rest.events.request(request, {
-          body: options?.body,
-        });
-
-        let result: Response;
-        // biome-ignore lint/suspicious/noExplicitAny: matches the previous inferred type from `response.json()`
-        let body: any;
-        try {
-          result = await fetch(request);
-
-          // Sometimes the Content-Type may be "application/json; charset=utf-8", for this reason, we need to check the start of the header
-          body = await (result.headers.get('Content-Type')?.startsWith('application/json') ? result.json() : result.text()).catch(() => null);
-        } finally {
-          if (timeoutId) clearTimeout(timeoutId);
-        }
-
-        rest.events.response(request, result, {
-          requestBody: options?.body,
-          responseBody: body,
-        });
-
-        if (!result.ok) {
-          error.cause = Object.assign(Object.create(baseErrorPrototype), {
-            ok: false,
-            status: result.status,
-            body,
+        // Retry on timeout up to `maxRetryCount`, mirroring the queued `sendRequest` path, so a stalled proxy
+        // connection doesn't permanently fail the request (and can never hang the caller forever).
+        for (let retryCount = 0; ; retryCount++) {
+          // Give the request to the proxy a hard deadline too via `AbortSignal.timeout` (omitted when disabled).
+          const request = new Request(url, {
+            ...rest.createRequestBody(method, options),
+            signal: rest.requestTimeout > 0 ? AbortSignal.timeout(rest.requestTimeout) : undefined,
+          });
+          rest.events.request(request, {
+            body: options?.body,
           });
 
-          throw error;
-        }
+          let result: Response;
+          try {
+            result = await fetch(request);
+          } catch (fetchError) {
+            rest.events.requestError(request, fetchError, { body: options?.body });
 
-        return result.status !== 204 ? (typeof body === 'string' ? JSON.parse(body) : body) : undefined;
+            // The attempt hit `rest.requestTimeout` and was aborted; retry it until the budget is exhausted.
+            if (isTimeoutError(fetchError) && retryCount < rest.maxRetryCount) {
+              rest.logger.debug(`request to proxy ${url} timed out after ${rest.requestTimeout}ms, retrying.`, fetchError);
+              continue;
+            }
+
+            throw fetchError;
+          }
+
+          // Sometimes the Content-Type may be "application/json; charset=utf-8", for this reason, we need to check the start of the header
+          const body = await (result.headers.get('Content-Type')?.startsWith('application/json') ? result.json() : result.text()).catch(() => null);
+
+          rest.events.response(request, result, {
+            requestBody: options?.body,
+            responseBody: body,
+          });
+
+          if (!result.ok) {
+            error.cause = Object.assign(Object.create(baseErrorPrototype), {
+              ok: false,
+              status: result.status,
+              body,
+            });
+
+            throw error;
+          }
+
+          return result.status !== 204 ? (typeof body === 'string' ? JSON.parse(body) : body) : undefined;
+        }
       }
 
       return await new Promise(async (resolve, reject) => {

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -207,6 +207,23 @@ export interface CreateRestManagerOptions {
   logger?: Pick<typeof logger, 'debug' | 'info' | 'warn' | 'error' | 'fatal'>;
   /** Events for the rest manager */
   events?: Partial<RestManagerEvents>;
+  /**
+   * The maximum time in milliseconds a single request attempt may take before it is aborted.
+   *
+   * @remarks
+   * This is a total deadline for each attempt (it also covers reading the response body), not a per-chunk timeout.
+   * When an attempt times out it is retried through the queue up to {@link RestManager.maxRetryCount} times before failing.
+   * Without it, a connection that stalls after connecting could keep a queue from ever progressing.
+   *
+   * Because it is a total deadline rather than a per-chunk one, a slow but healthy request (e.g. uploading a
+   * large attachment over a slow connection) can legitimately exceed it and be aborted/retried. Raise this value
+   * for upload-heavy bots if you see such requests timing out.
+   *
+   * Set to `0` to disable it and rely on the runtime's default fetch timeouts.
+   *
+   * @default 30000 // 30 seconds
+   */
+  requestTimeout?: number;
 }
 
 export interface RestManager {
@@ -236,6 +253,8 @@ export interface RestManager {
   updateBearerTokenEndpoint?: string;
   /** The maximum amount of times a request should be retried. Defaults to Infinity */
   maxRetryCount: number;
+  /** The maximum time in milliseconds a single request attempt may take before it is aborted and retried. Defaults to 30000 (30 seconds). Set to 0 to disable. */
+  requestTimeout: number;
   /** Whether or not the manager is rate limited globally across all requests. Defaults to false. */
   globallyRateLimited: boolean;
   /** Whether or not the rate limited paths are being processed to allow requests to be made once time is up. Defaults to false. */


### PR DESCRIPTION
Summary
- Adds a configurable `requestTimeout` option (default 30s) to `CreateRestManagerOptions`/`RestManager` that aborts a single request attempt if it stalls.
- A timed-out attempt is retried through the queue like other failures, up to `maxRetryCount`.
- Set `requestTimeout: 0` to disable and fall back to the runtime's default fetch timeouts.