### PR TITLE
feat(rest): strip trailing slash from proxy baseUrl if present in createRestManager()

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -90,7 +90,7 @@ export const RATE_LIMIT_SCOPE_HEADER = 'x-ratelimit-scope';
 export function createRestManager(options: CreateRestManagerOptions): RestManager {
   const applicationId = options.applicationId ? BigInt(options.applicationId) : getBotIdFromToken(options.token);
 
-  const baseUrl = options.proxy?.baseUrl ?? DISCORD_API_URL;
+  const baseUrl = (options.proxy?.baseUrl ?? DISCORD_API_URL).replace(/\/$/, '');
   // Discord error can get nested a lot, so we use a custom inspect to change the depth to Infinity
   const baseErrorPrototype = {
     [inspect.custom](_depth: number, options: InspectOptions, _inspect: typeof inspect) {

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -169,7 +169,6 @@ export interface CreateRestManagerOptions {
   proxy?: {
     /**
      * The base url to connect to. If you create a proxy rest, that url would go here.
-     * IT SHOULD NOT END WITH A /
      * @default https://discord.com/api
      */
     baseUrl: string;
@@ -235,7 +234,6 @@ export interface RestManager {
   version: ApiVersions;
   /**
    * The base url to connect to. If you create a proxy rest, that url would go here.
-   * IT SHOULD NOT END WITH A /
    * @default https://discord.com/api
    */
   baseUrl: string;

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -234,6 +234,7 @@ export interface RestManager {
   version: ApiVersions;
   /**
    * The base url to connect to. If you create a proxy rest, that url would go here.
+   * IT SHOULD NOT END WITH A /
    * @default https://discord.com/api
    */
   baseUrl: string;

--- a/packages/rest/tests/unit/manager.spec.ts
+++ b/packages/rest/tests/unit/manager.spec.ts
@@ -44,9 +44,9 @@ describe('[rest] manager', () => {
       expect(rest.isProxied).to.be.equal(true);
     });
 
-it('With an application id', () => {
-const rest = createRestManager({ ...options, applicationId: '130136895395987456' });
-expect(rest.applicationId).to.be.equal(130136895395987456n);
+    it('With an application id', () => {
+      const rest = createRestManager({ ...options, applicationId: '130136895395987456' });
+      expect(rest.applicationId).to.be.equal(130136895395987456n);
     });
   });
 

--- a/packages/rest/tests/unit/manager.spec.ts
+++ b/packages/rest/tests/unit/manager.spec.ts
@@ -39,15 +39,8 @@ describe('[rest] manager', () => {
     });
 
     it('Strips a trailing slash from proxy base urls', () => {
-      const rest = createRestManager({
-        token,
-        proxy: {
-          baseUrl: 'http://microservices_bot-gateway:6001/',
-          authorization: token,
-        },
-      });
-
-      expect(rest.baseUrl).to.be.equal('http://microservices_bot-gateway:6001');
+      const rest = createRestManager({ ...options, proxy: { ...options.proxy, baseUrl: 'https://localhost:8000/' } });
+      expect(rest.baseUrl).to.be.equal('https://localhost:8000');
       expect(rest.isProxied).to.be.equal(true);
     });
 

--- a/packages/rest/tests/unit/manager.spec.ts
+++ b/packages/rest/tests/unit/manager.spec.ts
@@ -44,9 +44,9 @@ describe('[rest] manager', () => {
       expect(rest.isProxied).to.be.equal(true);
     });
 
-    it('With an application id', () => {
-      const subrest = createRestManager({ ...options, applicationId: '130136895395987456' });
-      expect(subrest.applicationId).to.be.equal(130136895395987456n);
+it('With an application id', () => {
+const rest = createRestManager({ ...options, applicationId: '130136895395987456' });
+expect(rest.applicationId).to.be.equal(130136895395987456n);
     });
   });
 

--- a/packages/rest/tests/unit/manager.spec.ts
+++ b/packages/rest/tests/unit/manager.spec.ts
@@ -38,6 +38,19 @@ describe('[rest] manager', () => {
       expect(rest.baseUrl).to.be.equal(options.proxy.baseUrl);
     });
 
+    it('Strips a trailing slash from proxy base urls', () => {
+      const rest = createRestManager({
+        token,
+        proxy: {
+          baseUrl: 'http://microservices_bot-gateway:6001/',
+          authorization: token,
+        },
+      });
+
+      expect(rest.baseUrl).to.be.equal('http://microservices_bot-gateway:6001');
+      expect(rest.isProxied).to.be.equal(true);
+    });
+
     it('With an application id', () => {
       const subrest = createRestManager({ ...options, applicationId: '130136895395987456' });
       expect(subrest.applicationId).to.be.equal(130136895395987456n);


### PR DESCRIPTION
this is a pretty simple pr. just gets rid of the trailing slash.