### PR TITLE
fix!: Riot Games deprecation for DiscordConnectionServiceType

### DIFF
--- a/packages/types/src/discord/user.ts
+++ b/packages/types/src/discord/user.ts
@@ -156,7 +156,6 @@ export enum DiscordConnectionServiceType {
   PayPal = 'paypal',
   PlayStationNetwork = 'playstation',
   Reddit = 'reddit',
-  RiotGames = 'riotgames',
   Roblox = 'roblox',
   Spotify = 'spotify',
   Skype = 'skype',


### PR DESCRIPTION
- Upstream: https://github.com/discord/discord-api-docs/pull/8452
- Fixes #5137