### PR TITLE
feat: add error code 50278 to HTTPJsonErrorCodes enum

### DIFF
--- a/packages/types/src/discord/opcodes.ts
+++ b/packages/types/src/discord/opcodes.ts
@@ -445,6 +445,8 @@ export enum HTTPJsonErrorCodes {
   AccountNotVerified = 50178,
   /** The provided file does not have a valid duration. */
   InvalidFileDuration = 50192,
+  /** Cannot send messages to this user due to having no mutual guilds */
+  CantMessageUserNoMutualGuilds = 50278,
   /** You do not have permission to send this sticker. */
   NoStickerPermission = 50600,
 


### PR DESCRIPTION
- Upstream: https://github.com/discord/discord-api-docs/pull/8212
- Upstream: https://github.com/discord/discord-api-docs/pull/8244
- Fixes #4878
- Fixes #4887