### PR TITLE
ci: fix codecov upload for forks

### DIFF
--- a/.github/workflows/lib-check.yml
+++ b/.github/workflows/lib-check.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Upload coverage report to codecov
         shell: bash
         run: |
-          CC_FLAGS="--disable-search --fail-on-error --git-service github"
+          CC_FLAGS="--disable-search --git-service github"
 
           if [ -n "${{ github.event.pull_request.head.sha }}" ]; then
             CC_FLAGS+=" --sha ${{ github.event.pull_request.head.sha }}"
@@ -212,7 +212,7 @@ jobs:
       - name: Upload coverage report to codecov
         shell: bash
         run: |
-          CC_FLAGS="--disable-search --fail-on-error --git-service github"
+          CC_FLAGS="--disable-search --git-service github"
 
           if [ -n "${{ github.event.pull_request.head.sha }}" ]; then
             CC_FLAGS+=" --sha ${{ github.event.pull_request.head.sha }}"
@@ -281,7 +281,7 @@ jobs:
       - name: Upload coverage report to codecov
         shell: bash
         run: |
-          CC_FLAGS="--disable-search --fail-on-error --git-service github"
+          CC_FLAGS="--disable-search --git-service github"
 
           if [ -n "${{ github.event.pull_request.head.sha }}" ]; then
             CC_FLAGS+=" --sha ${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/lib-check.yml
+++ b/.github/workflows/lib-check.yml
@@ -108,14 +108,38 @@ jobs:
           shasum -a 256 -c codecov.SHA256SUM
           sudo chmod +x codecov
       - name: Upload coverage report to codecov
+        shell: bash
         run: |
+          CC_FLAGS="--disable-search --fail-on-error --git-service github"
+
+          if [ -n "${{ github.event.pull_request.head.sha }}" ]; then
+            CC_FLAGS+=" --sha ${{ github.event.pull_request.head.sha }}"
+          fi
+
+          if [ -n "${{ github.event.pull_request.head.repo.full_name }}" ] && [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ];
+          then
+            echo "Fork detected"
+            CC_FLAGS+=" --branch ${{ github.event.pull_request.head.label }} --pr ${{ github.event.number }}"
+          fi
+
+          CC_TOKEN=""
+          CC_LOG_TOKEN=""
+          if [ -n "${{ secrets.CODECOV_TOKEN }}" ]; then
+            echo "CODECOV_TOKEN is set, adding to codecov upload-process command"
+            CC_TOKEN+=" --token ${{ secrets.CODECOV_TOKEN }}"
+            CC_LOG_TOKEN+=" --token ***"
+          fi
+
           find packages/ -name "lcov.info" -type f | awk -F'/' '{ print $2 }' | while read -r package; do
             sed -i "s|SF:src|SF:packages/${package}/src|g" "packages/$package/coverage/lcov.info"
 
+            CC_FLAGS+=" --file packages/$package/coverage/lcov.info --flag $package-unit --flag $package"
+
+
             echo "Uploading $package converage/lcov.info file"
-            ./codecov upload-process --disable-search --token ${{ secrets.CODECOV_TOKEN }} \
-              --fail-on-error --git-service github --sha $(git rev-parse HEAD) \
-              --file packages/$package/coverage/lcov.info --flag $package-unit --flag $package
+            echo "Running \"./codecov upload-process $CC_LOG_TOKEN $CC_FLAGS\""
+
+            ./codecov upload-process $CC_TOKEN $CC_FLAGS
           done
 
   unit-tests-deno:
@@ -186,14 +210,38 @@ jobs:
           shasum -a 256 -c codecov.SHA256SUM
           sudo chmod +x codecov
       - name: Upload coverage report to codecov
+        shell: bash
         run: |
+          CC_FLAGS="--disable-search --fail-on-error --git-service github"
+
+          if [ -n "${{ github.event.pull_request.head.sha }}" ]; then
+            CC_FLAGS+=" --sha ${{ github.event.pull_request.head.sha }}"
+          fi
+
+          if [ -n "${{ github.event.pull_request.head.repo.full_name }}" ] && [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ];
+          then
+            echo "Fork detected"
+            CC_FLAGS+=" --branch ${{ github.event.pull_request.head.label }} --pr ${{ github.event.number }}"
+          fi
+
+          CC_TOKEN=""
+          CC_LOG_TOKEN=""
+          if [ -n "${{ secrets.CODECOV_TOKEN }}" ]; then
+            echo "CODECOV_TOKEN is set, adding to codecov upload-process command"
+            CC_TOKEN+=" --token ${{ secrets.CODECOV_TOKEN }}"
+            CC_LOG_TOKEN+=" --token ***"
+          fi
+
           find packages/ -name "lcov.info" -type f | awk -F'/' '{ print $2 }' | while read -r package; do
             sed -i "s|SF:src|SF:packages/${package}/src|g" "packages/$package/coverage/lcov.info"
 
+            CC_FLAGS+=" --file packages/$package/coverage/lcov.info --flag $package-integration --flag $package"
+
+
             echo "Uploading $package converage/lcov.info file"
-            ./codecov upload-process --disable-search --token ${{ secrets.CODECOV_TOKEN }} \
-              --fail-on-error --git-service github --sha $(git rev-parse HEAD) \
-              --file packages/$package/coverage/lcov.info --flag $package-integration --flag $package
+            echo "Running \"./codecov upload-process $CC_LOG_TOKEN $CC_FLAGS\""
+
+            ./codecov upload-process $CC_TOKEN $CC_FLAGS
           done
 
   e2e-tests:
@@ -231,12 +279,36 @@ jobs:
           shasum -a 256 -c codecov.SHA256SUM
           sudo chmod +x codecov
       - name: Upload coverage report to codecov
+        shell: bash
         run: |
+          CC_FLAGS="--disable-search --fail-on-error --git-service github"
+
+          if [ -n "${{ github.event.pull_request.head.sha }}" ]; then
+            CC_FLAGS+=" --sha ${{ github.event.pull_request.head.sha }}"
+          fi
+
+          if [ -n "${{ github.event.pull_request.head.repo.full_name }}" ] && [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ];
+          then
+            echo "Fork detected"
+            CC_FLAGS+=" --branch ${{ github.event.pull_request.head.label }} --pr ${{ github.event.number }}"
+          fi
+
+          CC_TOKEN=""
+          CC_LOG_TOKEN=""
+          if [ -n "${{ secrets.CODECOV_TOKEN }}" ]; then
+            echo "CODECOV_TOKEN is set, adding to codecov upload-process command"
+            CC_TOKEN+=" --token ${{ secrets.CODECOV_TOKEN }}"
+            CC_LOG_TOKEN+=" --token ***"
+          fi
+
           find packages/ -name "lcov.info" -type f | awk -F'/' '{ print $2 }' | while read -r package; do
             sed -i "s|SF:src|SF:packages/${package}/src|g" "packages/$package/coverage/lcov.info"
 
+            CC_FLAGS+=" --file packages/$package/coverage/lcov.info --flag $package-e2e --flag $package"
+
+
             echo "Uploading $package converage/lcov.info file"
-            ./codecov upload-process --disable-search --token ${{ secrets.CODECOV_TOKEN }} \
-              --fail-on-error --git-service github --sha $(git rev-parse HEAD) \
-              --file packages/$package/coverage/lcov.info --flag $package-e2e --flag $package
+            echo "Running \"./codecov upload-process $CC_LOG_TOKEN $CC_FLAGS\""
+
+            ./codecov upload-process $CC_TOKEN $CC_FLAGS
           done


### PR DESCRIPTION
Most of the added code is copied from the codecov github action.

We can't use it as we need separate flags for each package and the github action doesn't allow that