### PR TITLE
ci: Improve caching for Docusaurus build

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -20,26 +20,30 @@ jobs:
         with:
           node-version: 22
           cache: yarn
-          cache-dependency-path: |
-            yarn.lock
-            website/yarn.lock
+          cache-dependency-path: yarn.lock
+      - uses: actions/setup-node@v7
+        with:
+          cache: yarn
+          cache-dependency-path: website/yarn.lock
       - name: yarn install (root)
         run: yarn install --immutable
+        # Root turbo cache
       - name: Cache for Turbo
         uses: rharkor/caching-for-turbo@v2.5.1
         with:
           cache-prefix: turbo-cache-
-      - name: Cache for Turbo
-        uses: rharkor/caching-for-turbo@v2.5.1
-        with:
-          cache-prefix: turbo-cache-website-
-          server-port: 41231 # The default is 41230, but we use a different cache key so we need a different port
       - name: Build all pkg
-        run: yarn release-build
+        run: yarn build:type
       - name: Build docs
         run: yarn turbo build:doc --single-package
       - run: yarn install --immutable
         working-directory: ./website
+        # Website turbo cache
+      - name: Cache for Turbo
+        uses: rharkor/caching-for-turbo@v2.5.1
+        with:
+          cache-prefix: turbo-cache-website-
+          server-port: 41231
       - name: Restore bundler cache
         uses: actions/cache@v6
         with:
@@ -50,8 +54,6 @@ jobs:
       - name: Build website
         run: yarn turbo build
         working-directory: ./website
-        env:
-          TURBO_API: http://localhost:41231
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:
@@ -62,21 +64,8 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
           cache: yarn
-          cache-dependency-path: |
-            yarn.lock
-            website/yarn.lock
-      - name: yarn install (root)
-        run: yarn install --immutable
-      - name: Cache for Turbo
-        uses: rharkor/caching-for-turbo@v2.5.1
-        with:
-          cache-prefix: turbo-cache-
-      - name: Build all pkg
-        run: yarn release-build
-      - name: Build docs
-        run: yarn turbo build:doc --single-package
+          cache-dependency-path: website/yarn.lock
       - run: yarn install --immutable
         working-directory: ./website
       - run: yarn typecheck


### PR DESCRIPTION
Update the CI for the website to optimize it a bit:
- Cache separately the root deps and the website deps
- Don't build the .js files for the packages, typedoc only needs the .d.ts files
- Move the creation of the second actions/cache backed turbo remote cache to remove the need to manually specify the turbo server
- Don't install root deps on website typecheck: it's not needed

From the CI in this pr it looks like that yarn install is the longest step, so not much we can do there