### PR TITLE
fix(rest): re-send a request when a gateway in front of the api answered

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -573,6 +573,22 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
         rest.logger.debug(`Request to ${url} failed.`);
 
         if (response.status !== HttpResponseCode.TooManyRequests) {
+          // A gateway in front of the api answered instead of the api itself, so the request never got to run and re-sending it cannot
+          // execute anything twice. `retryCount` is shared with the rate limit path below, and the extra cap keeps a Discord outage from
+          // keeping every request alive, since `maxRetryCount` is Infinity by default.
+          if (
+            retryableServerErrors.has(response.status) &&
+            options.retryCount < rest.maxRetryCount &&
+            options.retryCount < maxServerErrorRetryCount
+          ) {
+            options.retryCount += 1;
+            rest.logger.debug(`Request to ${url} got a ${response.status}, retrying.`);
+            // Discord sends no retry-after with these, so back off a little further on every attempt.
+            await delay(serverErrorRetryDelay * options.retryCount);
+
+            return await options.retryRequest?.(options);
+          }
+
           options.reject({ ok: false, status: response.status, statusText: response.statusText, body });
           return;
         }
@@ -2128,6 +2144,25 @@ enum HttpResponseCode {
   /** This request got rate limited. */
   TooManyRequests = 429,
 }
+
+/**
+ * The server errors a request is re-sent on.
+ *
+ * @remarks
+ * Both of these come from a gateway sitting in front of the api rather than from the api itself, so the request never reached anything that
+ * could act on it and re-sending it cannot execute it twice.
+ *
+ * `500` and `504` are deliberately not here. A `500` came from the api, which means it did get the request and may have carried part of it
+ * out before failing, and a `504` means the api was handed the request and did not answer in time, so it may well have run. Re-sending
+ * either could create a second channel for one call.
+ */
+const retryableServerErrors = new Set([502, 503]);
+
+/** How many times a request is re-sent on one of {@link retryableServerErrors}, on top of `rest.maxRetryCount`. */
+const maxServerErrorRetryCount = 3;
+
+/** How much longer to wait before each further attempt, in milliseconds. Discord sends no `retry-after` with a server error. */
+const serverErrorRetryDelay = 1000;
 
 /** Whether an error is the `TimeoutError` thrown by `AbortSignal.timeout()`. */
 function isTimeoutError(error: unknown): boolean {

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -91,6 +91,19 @@ export const RATE_LIMIT_BUCKET_HEADER = 'x-ratelimit-bucket';
 export const RATE_LIMIT_LIMIT_HEADER = 'x-ratelimit-limit';
 export const RATE_LIMIT_SCOPE_HEADER = 'x-ratelimit-scope';
 
+/**
+ * The server errors a request is re-sent on.
+ *
+ * @remarks
+ * Both of these come from a gateway sitting in front of the api rather than from the api itself, so the request never reached anything that
+ * could act on it and re-sending it cannot execute it twice.
+ *
+ * `500` and `504` are deliberately not here. A `500` came from the api, which means it did get the request and may have carried part of it
+ * out before failing, and a `504` means the api was handed the request and did not answer in time, so it may well have run. Re-sending
+ * either could create a second channel for one call.
+ */
+export const RETRYABLE_SERVER_ERRORS: ReadonlySet<number> = new Set([502, 503]);
+
 export function createRestManager(options: CreateRestManagerOptions): RestManager {
   const applicationId = options.applicationId ? BigInt(options.applicationId) : getBotIdFromToken(options.token);
 
@@ -121,6 +134,8 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
     maxRetryCount: Infinity,
     maxProxyRetryCount: 15,
     proxyRetryDelayStep: 250,
+    maxServerErrorRetryCount: 3,
+    serverErrorRetryDelayStep: 1000,
     requestTimeout: options.requestTimeout ?? 30000,
     processingRateLimitedPaths: false,
     queues: new Map(),
@@ -577,14 +592,14 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
           // execute anything twice. `retryCount` is shared with the rate limit path below, and the extra cap keeps a Discord outage from
           // keeping every request alive, since `maxRetryCount` is Infinity by default.
           if (
-            retryableServerErrors.has(response.status) &&
+            RETRYABLE_SERVER_ERRORS.has(response.status) &&
             options.retryCount < rest.maxRetryCount &&
-            options.retryCount < maxServerErrorRetryCount
+            options.retryCount < rest.maxServerErrorRetryCount
           ) {
             options.retryCount += 1;
             rest.logger.debug(`Request to ${url} got a ${response.status}, retrying.`);
             // Discord sends no retry-after with these, so back off a little further on every attempt.
-            await delay(serverErrorRetryDelay * options.retryCount);
+            await delay(rest.serverErrorRetryDelayStep * options.retryCount);
 
             return await options.retryRequest?.(options);
           }
@@ -2144,25 +2159,6 @@ enum HttpResponseCode {
   /** This request got rate limited. */
   TooManyRequests = 429,
 }
-
-/**
- * The server errors a request is re-sent on.
- *
- * @remarks
- * Both of these come from a gateway sitting in front of the api rather than from the api itself, so the request never reached anything that
- * could act on it and re-sending it cannot execute it twice.
- *
- * `500` and `504` are deliberately not here. A `500` came from the api, which means it did get the request and may have carried part of it
- * out before failing, and a `504` means the api was handed the request and did not answer in time, so it may well have run. Re-sending
- * either could create a second channel for one call.
- */
-const retryableServerErrors = new Set([502, 503]);
-
-/** How many times a request is re-sent on one of {@link retryableServerErrors}, on top of `rest.maxRetryCount`. */
-const maxServerErrorRetryCount = 3;
-
-/** How much longer to wait before each further attempt, in milliseconds. Discord sends no `retry-after` with a server error. */
-const serverErrorRetryDelay = 1000;
 
 /** Whether an error is the `TimeoutError` thrown by `AbortSignal.timeout()`. */
 function isTimeoutError(error: unknown): boolean {

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -312,6 +312,26 @@ export interface RestManager {
    * Only used when {@link RestManager.retryProxiedRequests} is enabled.
    */
   proxyRetryDelayStep: number;
+  /**
+   * The maximum amount of times a request should be re-sent after a server error. Defaults to 3.
+   *
+   * @remarks
+   * Only the statuses in `RETRYABLE_SERVER_ERRORS` are re-sent, the ones a gateway in front of the api answers with rather than the api
+   * itself.
+   *
+   * This has its own limit because {@link RestManager.maxRetryCount} is Infinity by default, which would keep every request alive for as
+   * long as a Discord outage lasts.
+   *
+   * Whichever of the two is lower applies.
+   */
+  maxServerErrorRetryCount: number;
+  /**
+   * How much longer to wait before each further re-send after a server error, in milliseconds. Defaults to 1000.
+   *
+   * @remarks
+   * Discord sends no `retry-after` with a server error, so the nth attempt waits n times this (1s, then 2s, then 3s, ...) instead.
+   */
+  serverErrorRetryDelayStep: number;
   /** The maximum time in milliseconds a single request attempt may take before it is aborted. Timed-out attempts are only retried when talking to Discord directly, or through a proxy when `retryProxiedRequests` is enabled. Defaults to 30000 (30 seconds). Set to 0 to disable. */
   requestTimeout: number;
   /** Whether or not the manager is rate limited globally across all requests. Defaults to false. */

--- a/packages/rest/tests/unit/manager.spec.ts
+++ b/packages/rest/tests/unit/manager.spec.ts
@@ -526,4 +526,60 @@ describe('[rest] manager', () => {
       expect(error.message).to.be.equal('[999] The request was aborted.');
     });
   });
+
+  describe('rest.sendRequest with a server error', () => {
+    let rest: RestManager;
+    let fetchStub: sinon.SinonStub;
+
+    const jsonHeaders = { 'Content-Type': 'application/json' };
+    const gatewayResponse = () => new Response(JSON.stringify({ url: 'wss://gateway.discord.gg' }), { headers: jsonHeaders });
+
+    beforeEach(() => {
+      rest = createRestManager({ token });
+      // Re-sending is checked by counting the calls to fetch, never by timing, so the backoff between them is turned off to keep the suite fast
+      // and free of a wait that could get flaky under load.
+      rest.serverErrorRetryDelayStep = 0;
+      fetchStub = sinon.stub(globalThis, 'fetch');
+    });
+
+    afterEach(() => {
+      fetchStub.restore();
+    });
+
+    for (const status of [502, 503]) {
+      it(`Will re-send the request when a gateway in front of the api answered (${status})`, async () => {
+        fetchStub.onFirstCall().resolves(new Response('{}', { status, headers: jsonHeaders }));
+        fetchStub.onSecondCall().resolves(gatewayResponse());
+
+        expect(await rest.makeRequest('GET', '/gateway/bot')).to.be.deep.equal({ url: 'wss://gateway.discord.gg' });
+        expect(fetchStub.callCount).to.be.equal(2);
+      });
+    }
+
+    // These two reached the api, so it may have carried the request out before it failed or ran out of time
+    for (const status of [500, 504]) {
+      it(`Will not re-send the request when the api itself answered (${status})`, async () => {
+        fetchStub.resolves(new Response('{}', { status, headers: jsonHeaders }));
+
+        await expect(rest.makeRequest('GET', '/gateway/bot')).to.eventually.be.rejectedWith(Error);
+        expect(fetchStub.callCount).to.be.equal(1);
+      });
+    }
+
+    it('Will stop re-sending once maxRetryCount is exhausted', async () => {
+      rest.maxRetryCount = 0;
+      fetchStub.resolves(new Response('{}', { status: 502, headers: jsonHeaders }));
+
+      await expect(rest.makeRequest('GET', '/gateway/bot')).to.eventually.be.rejectedWith(Error);
+      expect(fetchStub.callCount).to.be.equal(1);
+    });
+
+    it('Will stop re-sending once maxServerErrorRetryCount is exhausted', async () => {
+      rest.maxServerErrorRetryCount = 2;
+      fetchStub.resolves(new Response('{}', { status: 502, headers: jsonHeaders }));
+
+      await expect(rest.makeRequest('GET', '/gateway/bot')).to.eventually.be.rejectedWith(Error);
+      expect(fetchStub.callCount).to.be.equal(3);
+    });
+  });
 });


### PR DESCRIPTION
Split out of #5158, which is about not re-sending requests that may already have run. This is the other side of it: there is a case we currently do not re-send where we safely could.

`sendRequest` only retries a 429. Every other error status rejects right away, server errors included, so a bot gets a failed call whenever Discord has a wobble.

Discord gives a 502 its own row in the [http response codes table](https://docs.discord.com/developers/topics/opcodes-and-status-codes), separate from the generic 5xx one, and it reads "There was not a gateway available to process your request. Wait a bit and retry." That sentence is already in the library, it is the message we build for a 502 in `sendRequest`, and then nothing waits or retries.

A 502 comes from a gateway sitting in front of the api rather than from the api itself. The request never reached anything that could act on it, so re-sending it cannot execute it twice. A 503 is not in Discord's table but is the same shape, the server is not taking requests, so it is re-sent too.

500 and 504 are deliberately left out. Both mean the api did get the request: a 500 is it failing while handling it, and a 504 is it not answering in time, so either may have carried the request out. Re-sending those is how you end up with two channels for one call, which is the thing #5158 exists to prevent.

Discord sends no `retry-after` with a server error, so it backs off a little further on each attempt. The counter is the one the rate limit path already uses, and there is a small cap on top of it because `maxRetryCount` is Infinity by default and an outage would otherwise keep every request alive for as long as it lasts. Happy to promote that cap to an option if you would rather have it configurable, I left it as a constant to avoid adding a knob for something that has a sensible answer.

Tests cover all four statuses and the retry cap.
