### PR TITLE
feat(rest): Add snake methods to the RestManager.

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -815,7 +815,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
     snake: Object.fromEntries(
       Object.entries(restEndpoints).map(([key, endpointFunc]) => {
         const func = endpointFunc as (rest: RestManager, ...args: unknown[]) => unknown;
-        return [key, func.bind(undefined, rest)];
+        return [key, async (...args: unknown[]) => await func(rest, ...args)];
       }),
     ) as RestEndpoints,
 

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -9,7 +9,7 @@ import {
   logger,
   snowflakeToTimestamp,
 } from '@discordeno/utils';
-import { type CamelizedRestEndpoints, restEndpoints } from './endpoints.js';
+import { type CamelizedRestEndpoints, type RestEndpoints, restEndpoints } from './endpoints.js';
 import { createInvalidRequestBucket } from './invalidBucket.js';
 import { Queue } from './queue.js';
 import { createRoutes } from './routes.js';
@@ -809,6 +809,15 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
         return [key, async (...args: unknown[]) => camelize(await func(rest, ...args))];
       }),
     ) as CamelizedRestEndpoints),
+
+    // Same as above: this time since we don't need to camelize we can use .bind
+    // undefined is used as the this because it will be the values for this in the functions above too since it isn't called with a this context
+    snake: Object.fromEntries(
+      Object.entries(restEndpoints).map(([key, endpointFunc]) => {
+        const func = endpointFunc as (rest: RestManager, ...args: unknown[]) => unknown;
+        return [key, func.bind(undefined, rest)];
+      }),
+    ) as RestEndpoints,
 
     preferSnakeCase(enabled: boolean) {
       const camelizer = enabled ? (x: any) => x : camelize;

--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -810,8 +810,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       }),
     ) as CamelizedRestEndpoints),
 
-    // Same as above: this time since we don't need to camelize we can use .bind
-    // undefined is used as the this because it will be the values for this in the functions above too since it isn't called with a this context
+    // Same as above
     snake: Object.fromEntries(
       Object.entries(restEndpoints).map(([key, endpointFunc]) => {
         const func = endpointFunc as (rest: RestManager, ...args: unknown[]) => unknown;

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -1,6 +1,6 @@
 import type { BigString, FileContent } from '@discordeno/types';
 import type { logger } from '@discordeno/utils';
-import type { CamelizedRestEndpoints } from './endpoints.js';
+import type { CamelizedRestEndpoints, RestEndpoints } from './endpoints.js';
 import type { InvalidRequestBucket } from './invalidBucket.js';
 import type { Queue } from './queue.js';
 import type { RestRoutes } from './typings/routes.js';
@@ -207,6 +207,8 @@ export interface RestManager extends CamelizedRestEndpoints {
   delete: (url: string, options?: Omit<MakeRequestOptions, 'body'>) => Promise<void>;
   /** Make a patch request to the api. */
   patch: <T = void>(url: string, options?: MakeRequestOptions) => Promise<T>;
+  /** The functions to call the endpoints but without the response body being camelized. */
+  snake: RestEndpoints;
 }
 
 export type RequestMethods = 'GET' | 'POST' | 'DELETE' | 'PATCH' | 'PUT';


### PR DESCRIPTION
Add a `snake` object with all the rest endpoints but without the camelize. This is useful if the raw snake_case content is required (e.g. bot helpers, see pr above in the stack)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>