### PR TITLE
chore(rest)!: Remove preferSnakeCase

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -817,32 +817,6 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
         return [key, async (...args: unknown[]) => await func(rest, ...args)];
       }),
     ) as RestEndpoints,
-
-    preferSnakeCase(enabled: boolean) {
-      const camelizer = enabled ? (x: any) => x : camelize;
-
-      rest.get = async (url, options) => {
-        return camelizer(await rest.makeRequest('GET', url, options));
-      };
-
-      rest.post = async (url: string, options?: Omit<CreateRequestBodyOptions, 'body' | 'method'>) => {
-        return camelizer(await rest.makeRequest('POST', url, options));
-      };
-
-      rest.delete = async (url: string, options?: Omit<CreateRequestBodyOptions, 'body' | 'method'>) => {
-        camelizer(await rest.makeRequest('DELETE', url, options));
-      };
-
-      rest.patch = async (url: string, options?: Omit<CreateRequestBodyOptions, 'body' | 'method'>) => {
-        return camelizer(await rest.makeRequest('PATCH', url, options));
-      };
-
-      rest.put = async (url: string, options?: Omit<CreateRequestBodyOptions, 'body' | 'method'>) => {
-        return camelizer(await rest.makeRequest('PUT', url, options));
-      };
-
-      return rest;
-    },
   } satisfies RestManager;
 
   return rest;

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -173,8 +173,6 @@ export interface RestManager extends CamelizedRestEndpoints {
   events: RestManagerEvents;
   /** Allows the user to inject custom headers that will be sent with every request. */
   createBaseHeaders: () => Record<string, string>;
-  /** Whether or not the rest manager should keep objects in raw snake case from discord. */
-  preferSnakeCase: (enabled: boolean) => RestManager;
   /** Check the rate limits for a url or a bucket. */
   checkRateLimits: (url: string, identifier: string) => number | false;
   /* Update the queues and ratelimit information to adapt to the new token */


### PR DESCRIPTION
This method changes the return type without changing the types, making it very inconvenient to use.
Now that get/post/put/patch use snake_case and there are snake versions of the endpoints, this method could be removed.

This is removed mainly as it is type unsafe, breaks discordeno/bot code while looking ok, makes it very easy to break user code due to looking like the camelCase variant of the methods (there is not way to check). This is basically a footgun.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>