### PR TITLE
chore: Update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,34 @@
-# Basic `dependabot.yml` file with
-# minimum configuration for two package managers
-
 version: 2
 updates:
-  # Enable version updates for npm
   - package-ecosystem: 'npm'
-    # Look for `package.json` and `lock` files in the `root` directory
     directory: '/'
-    # Check the npm registry for updates every month
+    labels: ['dependencies', 't-build']
     schedule:
       interval: 'weekly'
+    groups:
+      library-bumps:
+        group-by: '*'
   - package-ecosystem: 'github-actions'
     directory: '/'
+    labels: ['dependencies', 't-ci']
     schedule:
-      # Check for updates to GitHub Actions every month
       interval: 'weekly'
+    groups:
+      ci-bumps:
+        group-by: '*'
   - package-ecosystem: 'npm'
     directory: '/website'
+    labels: ['dependencies', 't-build', 'website']
     schedule:
       interval: 'weekly'
+    groups:
+      website-bumps:
+        group-by: '*'
+  - package-ecosystem: 'npm'
+    directories: ['examples/*']
+    labels: ['dependencies', 't-build', 'template']
+    schedule:
+      interval: 'monthly'
+    groups:
+      example-deps:
+        group-by: '*'


### PR DESCRIPTION
- remove the usage of `javascript` and `github_actions` labels, they are redundant with pkg-*/t-build and t-ci
- Enable PR grouping
- Add examples to the config (if monthly is too much we could use `quarterly`/`semiannually`/`yearly` based on what we find is better) 