### PR TITLE
feat: Add channel obfuscation support to the Gateway

### DIFF
--- a/packages/gateway/src/Shard.ts
+++ b/packages/gateway/src/Shard.ts
@@ -273,6 +273,7 @@ export class DiscordenoShard {
           intents: this.gatewayConfig.intents,
           shard: [this.id, this.gatewayConfig.totalShards],
           presence: await this.makePresence(),
+          capabilities: this.gatewayConfig.capabilities,
         },
       },
       true,

--- a/packages/gateway/src/types.ts
+++ b/packages/gateway/src/types.ts
@@ -1,4 +1,4 @@
-import type { DiscordGatewayPayload, GatewayOpcodes } from '@discordeno/types';
+import type { DiscordGatewayPayload, GatewayCapabilities, GatewayOpcodes } from '@discordeno/types';
 import type Shard from './Shard.js';
 
 export enum ShardState {
@@ -101,6 +101,14 @@ export interface ShardGatewayConfig {
    * @default 1
    */
   totalShards: number;
+  /**
+   * Bitfield rapresenting the capabilities of the client.
+   *
+   * @default 0
+   *
+   * @see {@link GatewayCapabilities}
+   */
+  capabilities?: number;
 }
 
 export interface ShardHeart {

--- a/packages/types/src/discord/channel.ts
+++ b/packages/types/src/discord/channel.ts
@@ -191,6 +191,13 @@ export enum ChannelFlags {
   /** When set hides the embedded media download options. Available only for media channels. */
   HideMediaDownloadOptions = 1 << 15,
   /**
+   * This channel's metadata has been obfuscated because the current user cannot view it.
+   *
+   * @remarks
+   * Only ever set on channels received over the Gateway; the HTTP API never sets this flag.
+   */
+  ChannelObfuscated = 1 << 17,
+  /**
    * This channel is a Spoiler Channel i.e. users must opt in to view its contents.
    *
    * @remarks

--- a/packages/types/src/discord/gateway.ts
+++ b/packages/types/src/discord/gateway.ts
@@ -291,6 +291,25 @@ export interface DiscordGatewayPayload {
 }
 
 // TODO: Add Identify: https://docs.discord.com/developers/events/gateway-events#identify-identify-structure
+
+/**
+ * https://docs.discord.com/developers/events/gateway-events#identify-gateway-capabilities
+ *
+ * This differs from intents in that intents control which events your bot client receives, while capabilities affects gateway behaviors.
+ */
+export enum GatewayCapabilities {
+  /**
+   * Opts the client into receiving obfuscated channel metadata over the Gateway for channels it can't view
+   *
+   * @experimental
+   * This is a temporary flag for opt-in testing for channel obfuscation. This opt-in mechanism will change before the feature reaches general availability.
+   * Obfuscation is then planned to apply to all bots automatically, even when they don't provide this capability.
+   *
+   * As this is temporary, removing this won't be followed by a semver major when discord deprecates it.
+   */
+  ChannelObfuscasation = 1 << 15,
+}
+
 // TODO: Add Identify Connection Properties: https://docs.discord.com/developers/events/gateway-events#identify-identify-connection-properties
 // TODO: Add Resume: https://docs.discord.com/developers/events/gateway-events#resume-resume-structure
 // TODO: Add Request Guild Members: https://docs.discord.com/developers/events/gateway-events#request-guild-members-request-guild-members-structure


### PR DESCRIPTION
- Upstream: https://github.com/discord/discord-api-docs/pull/8454
- Fixes #5306

ChannelObfuscasation is marked as experimental as that's the best fit for a Typedoc tag, and since it's a temporary flag it will be removed without a major semver
<sub>By November witch is the planned general release of channel obfuscation where the flag will be removed, i hope we will have proper releases</sub>