### PR TITLE
chore: Put biome in a separate group for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
     groups:
       library-bumps:
         patterns: ['*']
+        exclude-patterns: ['@biomejs/*']
+      biome-bump:
+        patterns: ['@biomejs/*']
   - package-ecosystem: 'github-actions'
     directory: '/'
     labels: ['dependencies', 't-ci']
@@ -24,6 +27,9 @@ updates:
     groups:
       website-bumps:
         patterns: ['*']
+        exclude-patterns: ['@biomejs/*']
+      biome-bump:
+        patterns: ['@biomejs/*']
   - package-ecosystem: 'npm'
     directories: ['examples/*']
     labels: ['dependencies', 't-build', 'template']


### PR DESCRIPTION
Since biome shares the same config between library and website, it is better if we update them together as if we add a new feature to the biome.jsonc file for the library and the website lags behind, biome will error out as it doesn't support the new configuration.
