### PR TITLE
fix!: Accept only raw data uri schemes in rest

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -73,7 +73,6 @@ import {
   logger,
   processReactionString,
   snowflakeToTimestamp,
-  urlToBase64,
 } from '@discordeno/utils';
 import { createInvalidRequestBucket } from './invalidBucket.js';
 import { Queue } from './queue.js';
@@ -992,10 +991,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
 
     async createWebhook(channelId, options, reason) {
       return await rest.post<DiscordWebhook>(rest.routes.channels.webhooks(channelId), {
-        body: {
-          name: options.name,
-          avatar: options.avatar ? await urlToBase64(options.avatar) : undefined,
-        },
+        body: options,
         reason,
       });
     },
@@ -1147,15 +1143,8 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
     },
 
     async editBotProfile(options) {
-      const avatar = options?.botAvatarURL ? await urlToBase64(options?.botAvatarURL) : options?.botAvatarURL;
-      const banner = options?.botBannerURL ? await urlToBase64(options?.botBannerURL) : options?.botBannerURL;
-
       return await rest.patch<DiscordUser>(rest.routes.currentUser(), {
-        body: {
-          username: options.username?.trim(),
-          avatar,
-          banner,
-        },
+        body: options,
       });
     },
 

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -161,7 +161,7 @@ import type {
   UpsertGlobalApplicationCommandOptions,
   UpsertGuildApplicationCommandOptions,
 } from '@discordeno/types';
-import type { logger } from '@discordeno/utils';
+import type { logger, urlToBase64 } from '@discordeno/utils';
 import type { InvalidRequestBucket } from './invalidBucket.js';
 import type { Queue } from './queue.js';
 import type { RestRoutes } from './typings/routes.js';
@@ -1166,9 +1166,18 @@ export interface RestManager {
   ) => Promise<Camelize<DiscordAutoModerationRule>>;
   /**
    * Modifies the bot's username, avatar or banner.
-   * NOTE: username: if changed may cause the bot's discriminator to be randomized.
+   *
+   * @param options - The parameters for the edit of the bot's profile.
+   * @returns An instance of the edited {@link DiscordUser}.
+   *
+   * @remarks
+   * Editing the `username` may cause the bot's discriminator to be randomized.
+   *
+   * `avatar` and `banner` must to be a Data URI scheme. {@link urlToBase64} from `@discordeno/utils` can be used to convert a URL to a Data URI scheme.
+   *
+   * @see {@link https://docs.discord.com/developers/resources/user#modify-current-user}
    */
-  editBotProfile: (options: { username?: string; botAvatarURL?: string | null; botBannerURL?: string | null }) => Promise<Camelize<DiscordUser>>;
+  editBotProfile: (options: { username?: string; avatar?: string | null; banner?: string | null }) => Promise<Camelize<DiscordUser>>;
   /**
    * Edits a channel's settings.
    *

--- a/packages/types/src/discordeno/webhook.ts
+++ b/packages/types/src/discordeno/webhook.ts
@@ -11,7 +11,11 @@ import type { FileContent } from './reference.js';
 export interface CreateWebhook {
   /** Name of the webhook (1-80 characters) */
   name: string;
-  /** Image url for the default webhook avatar */
+  /**
+   * Image data for the default webhook avatar
+   *
+   * This needs to be a Data URI scheme.
+   */
   avatar?: string | null;
 }
 


### PR DESCRIPTION
Some endpoints allowed for URLs to be passed in and converted to base64 data uri schemes.
Now the user should call urlToBase64 if they were using this
