### PR TITLE
fix: Don't create a new bucket on HELLO 

### DIFF
--- a/packages/gateway/src/Shard.ts
+++ b/packages/gateway/src/Shard.ts
@@ -552,20 +552,16 @@ export class DiscordenoShard {
         this.logger.debug(`[Shard] Shard #${this.id} received Hello`);
         this.startHeartbeating(interval);
 
+        // We need to recalculate the safe requests here, since the heartbeat interval could have changed
+        this.bucket.max = this.calculateSafeRequests();
+        this.bucket.refillAmount = this.calculateSafeRequests();
+
         if (this.state !== ShardState.Resuming) {
-          const currentQueue = [...this.bucket.queue];
           // HELLO has been send on a non resume action.
           // This means that the shard starts a new session,
           // therefore the rate limit interval has been reset too.
-          this.bucket = new LeakyBucket({
-            max: this.calculateSafeRequests(),
-            refillInterval: 60000,
-            refillAmount: this.calculateSafeRequests(),
-            logger: this.logger,
-          });
-
-          // Queue should not be lost on a re-identify.
-          this.bucket.queue.unshift(...currentQueue);
+          this.bucket.used = 0;
+          this.bucket.refillBucket();
         }
 
         this.events.hello?.(this);

--- a/packages/gateway/tests/integration/connection.spec.ts
+++ b/packages/gateway/tests/integration/connection.spec.ts
@@ -3,7 +3,9 @@ import { createGatewayManager, type GatewayManager } from '../../src/manager.js'
 import { ShardSocketCloseCodes } from '../../src/types.js';
 import { creatWSServer, heartbeatInterval } from './websocket.js';
 
-describe('Gateway Integration', () => {
+describe('Gateway Integration', function () {
+  this.slow('1s');
+
   it('Can connect to server', async () => {
     const { promise: connected, resolve: resolveConnected } = promiseWithResolvers<void>();
 

--- a/packages/gateway/tests/integration/connection.spec.ts
+++ b/packages/gateway/tests/integration/connection.spec.ts
@@ -17,10 +17,7 @@ describe('Gateway Integration', () => {
 
     await gateway.shutdown(ShardSocketCloseCodes.TestingFinished, 'Testing finished');
 
-    // To avoid needing to wait 1m to get the bucket refil timer to fire we cancel it
-    clearTimeout(gateway.shards.get(0)?.bucket.timeoutId);
-
-    close();
+    await close();
   });
 
   it('Can heartbeat', async () => {
@@ -47,9 +44,6 @@ describe('Gateway Integration', () => {
 
     await gateway.shutdown(ShardSocketCloseCodes.TestingFinished, 'Testing finished');
 
-    // To avoid needing to wait 1m to get the bucket refil timer to fire we cancel it
-    clearTimeout(gateway.shards.get(0)?.bucket.timeoutId);
-
     close();
   });
 });
@@ -69,6 +63,8 @@ function createGatewayManagerWithPort(port: number): GatewayManager {
     token: '',
     url: `ws://localhost:${port}`,
     intents: Intents.Guilds,
+    // we will never spawn more shards
+    spawnShardDelay: 0,
     resharding: {
       enabled: false,
       checkInterval: 0,

--- a/packages/gateway/tests/integration/websocket.ts
+++ b/packages/gateway/tests/integration/websocket.ts
@@ -77,7 +77,7 @@ export function creatWSServer(options: CreateWsServerOptions) {
 
   return {
     port: address.port,
-    close: () => server.close(),
+    close: () => new Promise<void>((res, rej) => server.close((e) => (e ? rej(e) : res()))),
   };
 }
 

--- a/packages/utils/src/bucket.ts
+++ b/packages/utils/src/bucket.ts
@@ -33,7 +33,7 @@ export class LeakyBucket implements LeakyBucketOptions {
 
   /** Refills the bucket as needed. */
   refillBucket(): void {
-    this.logger.debug(`[LeakyBucket] Timeout for leaky bucket requests executed. Refilling bucket.`);
+    this.logger.debug(`[LeakyBucket] Refilling bucket.`);
     // Lower the used amount by the refill amount
     this.used = this.refillAmount > this.used ? 0 : this.used - this.refillAmount;
     // Reset the refillsAt timestamp since it just got refilled


### PR DESCRIPTION
This fixes also the issue where integration tests took a long time to exit despite finishing all the tests: this is because the bucket created in the constructor of the shard had to naturally clear which takes 1 minute.

> [!WARNING]
> Since this does changes to the shard code i will test this for a while, if someone is available to test this it is appreciated