### PR TITLE
fix(bot): stop message toggles from overwriting each other

### DIFF
--- a/packages/bot/src/transformers/message.ts
+++ b/packages/bot/src/transformers/message.ts
@@ -90,12 +90,12 @@ export const baseMessage: Message = {
     else this.bitfield.remove(2);
   },
   get pinned() {
-    return this.bitfield?.contains(3) ?? false;
+    return this.bitfield?.contains(4) ?? false;
   },
   set pinned(value: boolean) {
     if (!this.bitfield) return;
-    if (value) this.bitfield.add(3);
-    else this.bitfield.remove(3);
+    if (value) this.bitfield.add(4);
+    else this.bitfield.remove(4);
   },
   get sourceMessageDeleted() {
     return this.flags?.contains(MessageFlags.SourceMessageDeleted) ?? false;


### PR DESCRIPTION
`baseMessage` keeps `tts`, `mentionEveryone` and `pinned` in one `ToggleBitfield`, using the bit **values** 1, 2 and 3 (`message.ts:128`, `:85`, `:93`). But `ToggleBitfield.contains` is an any-bit test:

```ts
contains(bits: number): boolean {
  return Boolean(this.bitfield & bits);
}
```

So 3 is not a third flag — `0b11` is `tts | mentionEveryone`. All three are set straight from the gateway payload (`message.ts:194`, `:231`, `:251`), so this happens on ordinary `MESSAGE_CREATE`:

| payload from Discord | `.tts` | `.mentionEveryone` | `.pinned` |
| --- | --- | --- | --- |
| `{ tts: true }` | `true` | `false` | **`true`** |
| `{ mention_everyone: true }` | `false` | `true` | **`true`** |
| `{ pinned: true }` | **`true`** | **`true`** | `true` |

and setting `pinned = false` clears the other two, because `remove(3)` unsets both bits.

`pinned` needs the next free bit, `4`.

---

Found by an AI-assisted audit of this codebase (Claude Opus 5). I reviewed the patch and re-ran biome, `tsc --noEmit` and the unit tests before opening this.
