### PR TITLE
fix(bot): do not recurse forever on a sub command with no options

### DIFF
--- a/packages/bot/src/commandOptionsParser.ts
+++ b/packages/bot/src/commandOptionsParser.ts
@@ -22,7 +22,7 @@ export function commandOptionsParser<
     switch (option.type) {
       case ApplicationCommandOptionTypes.SubCommandGroup:
       case ApplicationCommandOptionTypes.SubCommand:
-        args[option.name] = commandOptionsParser(interaction, option.options) as InteractionResolvedData<TProps, TBehavior>;
+        args[option.name] = commandOptionsParser(interaction, option.options ?? []) as InteractionResolvedData<TProps, TBehavior>;
         break;
       case ApplicationCommandOptionTypes.Channel:
         args[option.name] = interaction.data.resolved?.channels?.get(BigInt(option.value!)) as InteractionResolvedData<TProps, TBehavior>;
@@ -70,7 +70,7 @@ export type InteractionResolvedData<TProps extends TransformersDesiredProperties
 
 export interface InteractionResolvedDataUser<TProps extends TransformersDesiredProperties, TBehavior extends DesiredPropertiesBehavior> {
   user: SetupDesiredProps<User, TProps, TBehavior>;
-  member: InteractionResolvedDataMember<TProps, TBehavior>;
+  member?: InteractionResolvedDataMember<TProps, TBehavior>;
 }
 
 export type InteractionResolvedDataChannel<TProps extends TransformersDesiredProperties, TBehavior extends DesiredPropertiesBehavior> = Pick<


### PR DESCRIPTION
`commandOptionsParser` recurses into sub commands with `option.options`:

```ts
if (!options) options = interaction.data.options ?? [];      // :17
...
case ApplicationCommandOptionTypes.SubCommand:
  args[option.name] = commandOptionsParser(interaction, option.options);   // :25
```

Discord omits the `options` key entirely for a sub command invoked with no arguments, and `transformInteractionDataOption` copies that absence straight through (`interaction.ts:210-216`, no `?? []`). So the recursive call gets `undefined`, line 17 re-seeds `options` from the **root** `interaction.data.options`, the loop reaches the same sub command again, and recurses with `undefined` again. There is no base case and no depth bound.

Feeding the real exported function a `/config reset` shaped payload:

```
SubCommand, options key ABSENT       -> THREW RangeError: Maximum call stack size exceeded
SubCommand, options: []              -> {"reset":{}}
SubCommandGroup, options key ABSENT  -> THREW RangeError: Maximum call stack size exceeded
SubCommand with a nested string opt  -> {"set":{"k":"v"}}
```

`[]` is truthy so it terminates correctly — only an absent key triggers it. Thrown from inside the async `INTERACTION_CREATE` handler, it surfaces as an unhandled rejection rather than a per-interaction failure.

`option.options ?? []` fixes it and keeps line 17's fallback reserved for the genuine top-level call.

Also in here: `InteractionResolvedDataUser.member` was declared required, but `resolved.members` is absent in DMs, so the parser hands back `undefined` under a non-optional type. Made optional.

---

Found by an AI-assisted audit of this codebase (Claude Opus 5). I reviewed the patch and re-ran biome, `tsc --noEmit` and the unit tests before opening this.
