### PR TITLE
fix(bot): route THREAD_MEMBER_UPDATE to its own handler

### DIFF
--- a/packages/bot/src/handlers.ts
+++ b/packages/bot/src/handlers.ts
@@ -64,7 +64,7 @@ export function createBotGatewayHandlers<TProps extends TransformersDesiredPrope
     THREAD_DELETE: _options.THREAD_DELETE ?? handlers.handleThreadDelete,
     THREAD_UPDATE: _options.THREAD_UPDATE ?? handlers.handleThreadUpdate,
     THREAD_LIST_SYNC: _options.THREAD_LIST_SYNC ?? handlers.handleThreadListSync,
-    THREAD_MEMBER_UPDATE: _options.THREAD_MEMBERS_UPDATE ?? handlers.handleThreadMembersUpdate,
+    THREAD_MEMBER_UPDATE: _options.THREAD_MEMBER_UPDATE ?? handlers.handleThreadMemberUpdate,
     THREAD_MEMBERS_UPDATE: _options.THREAD_MEMBERS_UPDATE ?? handlers.handleThreadMembersUpdate,
     TYPING_START: _options.TYPING_START ?? handlers.handleTypingStart,
     USER_UPDATE: _options.USER_UPDATE ?? handlers.handleUserUpdate,

--- a/packages/bot/src/handlers/channels/THREAD_LIST_SYNC.ts
+++ b/packages/bot/src/handlers/channels/THREAD_LIST_SYNC.ts
@@ -12,11 +12,6 @@ export async function handleThreadListSync(bot: Bot, data: DiscordGatewayPayload
     guildId,
     channelIds: payload.channel_ids?.map((id) => bot.transformers.snowflake(id)),
     threads: payload.threads.map((thread) => bot.transformers.channel(bot, thread, { guildId })),
-    members: payload.members.map((member) => ({
-      id: member.id ? bot.transformers.snowflake(member.id) : undefined,
-      userId: member.user_id ? bot.transformers.snowflake(member.user_id) : undefined,
-      joinTimestamp: Date.parse(member.join_timestamp),
-      flags: member.flags,
-    })),
+    members: payload.members.map((member) => bot.transformers.threadMember(bot, member, { guildId: payload.guild_id })),
   });
 }

--- a/packages/bot/src/handlers/misc/READY.ts
+++ b/packages/bot/src/handlers/misc/READY.ts
@@ -2,9 +2,13 @@ import type { DiscordGatewayPayload, DiscordReady } from '@discordeno/types';
 import type { Bot } from '../../bot.js';
 
 export async function handleReady(bot: Bot, data: DiscordGatewayPayload, shardId: number): Promise<void> {
+  const payload = data.d as DiscordReady;
+
+  bot.id = bot.transformers.snowflake(payload.user.id);
+  bot.applicationId = bot.transformers.snowflake(payload.application.id);
+
   if (!bot.events.ready) return;
 
-  const payload = data.d as DiscordReady;
   // Triggered on each shard
   bot.events.ready(
     {
@@ -18,7 +22,4 @@ export async function handleReady(bot: Bot, data: DiscordGatewayPayload, shardId
     },
     payload,
   );
-
-  bot.id = bot.transformers.snowflake(payload.user.id);
-  bot.applicationId = bot.transformers.snowflake(payload.application.id);
 }


### PR DESCRIPTION
Three handler-layer mistakes.

**`THREAD_MEMBER_UPDATE` is wired to the plural handler** (`handlers.ts:67`):

```ts
THREAD_MEMBER_UPDATE:  _options.THREAD_MEMBERS_UPDATE ?? handlers.handleThreadMembersUpdate,
THREAD_MEMBERS_UPDATE: _options.THREAD_MEMBERS_UPDATE ?? handlers.handleThreadMembersUpdate,
```

Both the override key and the default are the plural ones. `handleThreadMemberUpdate` exists (`handlers/channels/THREAD_MEMBER_UPDATE.ts`) and `threadMemberUpdate` is declared in `events.ts:44`, but neither can ever fire — and a user passing `THREAD_MEMBER_UPDATE` in `options.handlers` is silently ignored while their `THREAD_MEMBERS_UPDATE` override gets called for both events.

**`READY` skips the bot id assignment when no listener is registered.** `handleReady` returns early on `if (!bot.events.ready) return`, and the `bot.id` / `bot.applicationId` assignment sat *after* that guard, so a bot with no `ready` listener never learned its own id. Moved above the guard — which also means `bot.id` is now populated *during* the `ready` event rather than just after it.

**`THREAD_LIST_SYNC` hand-built its thread members** instead of calling `bot.transformers.threadMember`, so desired properties and any customizer were bypassed for that batch only.

---

Found by an AI-assisted audit of this codebase (Claude Opus 5). I reviewed the patch and re-ran biome, `tsc --noEmit` and the unit tests before opening this.

