### PR TITLE
fix(bot): correct member, guild and message transformers

### DIFF
--- a/packages/bot/src/transformers/message.ts
+++ b/packages/bot/src/transformers/message.ts
@@ -194,13 +194,15 @@ export function transformMessage(bot: Bot, payload: Partial<DiscordMessage>, ext
   if (payload.mention_everyone) message.mentionEveryone = true;
   if (props.mentionedChannelIds && payload.mention_channels?.length) {
     message.mentionedChannelIds = [
-      // Keep any ids tht discord sends
-      ...(payload.mention_channels ?? []).map((m) => bot.transformers.snowflake(m.id)),
-      // Add any other ids that can be validated in a channel mention format
-      ...(payload.content?.match(CHANNEL_MENTION_REGEX) ?? []).map((text) =>
-        // converts the <#123> into 123
-        bot.transformers.snowflake(text.substring(2, text.length - 1)),
-      ),
+      ...new Set([
+        // Keep any ids tht discord sends
+        ...(payload.mention_channels ?? []).map((m) => bot.transformers.snowflake(m.id)),
+        // Add any other ids that can be validated in a channel mention format
+        ...(payload.content?.match(CHANNEL_MENTION_REGEX) ?? []).map((text) =>
+          // converts the <#123> into 123
+          bot.transformers.snowflake(text.substring(2, text.length - 1)),
+        ),
+      ]),
     ];
   }
   if (props.mentionedRoleIds && payload.mention_roles?.length)

--- a/packages/bot/src/transformers/reverse/member.ts
+++ b/packages/bot/src/transformers/reverse/member.ts
@@ -33,7 +33,7 @@ export function transformMemberToDiscordMember(bot: Bot, payload: typeof bot.tra
     joined_at: _payload.joinedAt ? new Date(_payload.joinedAt).toISOString() : null,
     premium_since: _payload.premiumSince ? new Date(_payload.premiumSince).toISOString() : undefined,
     avatar: _payload.avatar ? iconBigintToHash(_payload.avatar) : undefined,
-    permissions: _payload.permissions?.toString(),
+    permissions: _payload.permissions?.toJSON(),
     communication_disabled_until: _payload.communicationDisabledUntil ? new Date(_payload.communicationDisabledUntil).toISOString() : undefined,
     deaf: _payload.toggles?.deaf ?? false,
     mute: _payload.toggles?.mute ?? false,

--- a/packages/bot/src/transformers/toggles/guild.ts
+++ b/packages/bot/src/transformers/toggles/guild.ts
@@ -26,6 +26,7 @@ export const guildFeatureNames = [
   'roleIcons',
   'roleSubscriptionsAvailableForPurchase',
   'roleSubscriptionsEnabled',
+  'soundboard',
   'ticketedEventsEnabled',
   'vanityUrl',
   'verified',


### PR DESCRIPTION
Three independent one-liners.

**`reverse.member` wrote `"[object Object]"` for permissions.** `permissions` is a `ToggleBitfieldBigint`, and `_payload.permissions?.toString()` hits `Object.prototype.toString`. The sibling flag fields already use `toJSON()`, which returns `this.bitfield.toString()`. Round-tripping a member through `transformers.member` → `transformers.reverse.member` produced `permissions: "[object Object]"`.

**`guild.features` never reported `SOUNDBOARD`.** `GuildToggle.soundboard` exists (`1n << 25n`) and the bit *is* set from `GuildFeatures.Soundboard` (`toggles/guild.ts:158`), but the `features` getter filters by membership in `guildFeatureNames`, and `'soundboard'` was missing from that list. So the toggle read `true` while the feature was absent from the array. (Position in the list carries no meaning — it is a membership filter, not a bit index.)

**`mentionedChannelIds` returned duplicates.** It concatenates the ids Discord sends in `mention_channels` with the ids it scrapes out of `content`, and any channel appearing in both was listed twice. Now deduplicated.

The scan is also gated behind `payload.mention_channels?.length`, so it never runs for an ordinary message. I had widened that condition here; per review that is a separate call about whether the content scan should exist at all, so this now leaves the condition alone and only fixes the duplicates.

---

Found by an AI-assisted audit of this codebase (Claude Opus 5). I reviewed the patch and re-ran biome, `tsc --noEmit` and the unit tests before opening this.

