### PR TITLE
fix(rest): correct routes and methods that do not match the API

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -1271,6 +1271,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
     async executeWebhook(webhookId, token, options) {
       return await rest.post<DiscordMessage>(rest.routes.webhooks.webhook(webhookId, token, options), {
         body: options,
+        files: options.files,
         unauthorized: true,
       });
     },
@@ -1615,6 +1616,8 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
     },
 
     async getReactions(channelId, messageId, reaction, options) {
+      reaction = processReactionString(reaction);
+
       return await rest.get<DiscordUser[]>(rest.routes.channels.reactions.message(channelId, messageId, reaction, options));
     },
 
@@ -1947,7 +1950,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
     },
 
     async modifyGuildSoundboardSound(guildId, soundId, options, reason) {
-      return await rest.post<DiscordSoundboardSound>(rest.routes.soundboard.guildSound(guildId, soundId), {
+      return await rest.patch<DiscordSoundboardSound>(rest.routes.soundboard.guildSound(guildId, soundId), {
         body: options,
         reason,
       });

--- a/packages/rest/src/routes.ts
+++ b/packages/rest/src/routes.ts
@@ -95,7 +95,7 @@ export function createRoutes(disableURIEncode: boolean = false): RestRoutes {
 
           if (options) {
             if (options.type) url += `type=${encode(options.type)}`;
-            if (options.after) url += `after=${encode(options.after)}`;
+            if (options.after) url += `&after=${encode(options.after)}`;
             if (options.limit) url += `&limit=${encode(options.limit)}`;
           }
 
@@ -322,7 +322,7 @@ export function createRoutes(disableURIEncode: boolean = false): RestRoutes {
           return url;
         },
         event: (guildId, eventId, withUserCount?: boolean) => {
-          let url = `/guilds/${encode(guildId)}/scheduled-events/${encode(eventId)}`;
+          let url = `/guilds/${encode(guildId)}/scheduled-events/${encode(eventId)}?`;
 
           if (withUserCount !== undefined) {
             url += `with_user_count=${encode(withUserCount)}`;
@@ -488,7 +488,7 @@ export function createRoutes(disableURIEncode: boolean = false): RestRoutes {
           return `/guilds/${encode(guildId)}/members/${encode(memberId)}/roles/${encode(roleId)}`;
         },
         memberCounts: (guildId) => {
-          return `/guilds/${guildId}/roles/member-counts`;
+          return `/guilds/${encode(guildId)}/roles/member-counts`;
         },
       },
       stickers: (guildId) => {
@@ -674,7 +674,7 @@ export function createRoutes(disableURIEncode: boolean = false): RestRoutes {
 
     soundboard: {
       sendSound: (channelId) => {
-        return `/channels/${encode(channelId)}`;
+        return `/channels/${encode(channelId)}/send-soundboard-sound`;
       },
       listDefault: () => {
         return `/soundboard-default-sounds`;


### PR DESCRIPTION
Seven places where the request we build is not the request Discord documents. Each is independent.

**Routes** (`routes.ts`)

| route | built | should be |
| --- | --- | --- |
| `soundboard.sendSound` | `/channels/{id}` | `/channels/{id}/send-soundboard-sound` |
| `channels.reactions.message` | `?type=1after=852…` | `?type=1&after=852…` |
| `guilds.events.event` | `/guilds/1/scheduled-events/2with_user_count=true` | `…/2?with_user_count=true` |
| `guilds.roles.memberCounts` | `/guilds/${guildId}/…` — no `encode()` | `/guilds/${encode(guildId)}/…` |

`sendSound` posts to a path with no `POST` handler. The missing `&` only bites when both `type` and `after` are given. The missing `?` corrupts the event id segment — note the sibling `events.events` five lines up does have it. `memberCounts` is the only route in the file that skips `encode()`.

**Helpers** (`manager.ts`)

- `executeWebhook` passed `body: options` but not `files`, so webhook attachments were dropped and the request went out as `application/json`. `sendMessage` one line away already does `{ body, files: body.files }`.
- `modifyGuildSoundboardSound` used `rest.post`; Discord documents `PATCH /guilds/{guild.id}/soundboard-sounds/{sound.id}`.
- `getReactions` was the only one of the five reaction methods not calling `processReactionString`, so it rejected the `<:name:id>` form its siblings accept. `processReactionString` only rewrites strings starting with `<:` / `<a:`, so unicode and `name:id` inputs are untouched.

---

Found by an AI-assisted audit of this codebase (Claude Opus 5). I reviewed the patch and re-ran biome, `tsc --noEmit` and the unit tests before opening this.

