### PR TITLE
fix(rest): keep a queue alive when a request throws

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -667,7 +667,17 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       const url = rest.simplifyUrl(request.route, request.method);
 
       if (request.runThroughQueue === false) {
-        await rest.sendRequest(request);
+        // This never reaches a queue, so this is the only place the invalid request bucket can be told about the request. `sendRequest` reports
+        // it as completed either way, and without this that report has nothing to match it: the bucket's count of active requests drifts one
+        // lower with every one of these, which raises the invalid request ceiling it exists to enforce.
+        await rest.invalidBucket.waitUntilRequestAvailable();
+
+        try {
+          await rest.sendRequest(request);
+        } catch (error) {
+          rest.invalidBucket.handleCompletedRequest(999, false);
+          throw error;
+        }
 
         return;
       }
@@ -801,7 +811,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
         }
       }
 
-      return await new Promise(async (resolve, reject) => {
+      return await new Promise((resolve, reject) => {
         const signal = options?.signal;
         const abortListener = () => {
           // Reject right away instead of waiting for the queue to reach the request. The signal is attached to the fetch itself as well, so an
@@ -842,7 +852,11 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
 
         signal?.addEventListener('abort', abortListener, { once: true });
 
-        await rest.processRequest(payload);
+        // The executor is not async on purpose: a promise returned from it is dropped, so a throw in here would leave the caller waiting forever
+        // on a promise that never settles, on top of the unhandled rejection it raises.
+        rest.processRequest(payload).catch((requestError) => {
+          payload.reject({ ok: false, status: 999, error: 'The request encountered an unexpected error.', errorObject: requestError });
+        });
       });
     },
 

--- a/packages/rest/src/queue.ts
+++ b/packages/rest/src/queue.ts
@@ -160,6 +160,11 @@ export class Queue {
 
         await this.rest.sendRequest(request).catch((e) => {
           this.rest.logger.debug(`Queue ${this.queueType} ${this.url} encountered an error when sending a request.`, e);
+          // A throw skipped the bookkeeping `sendRequest` does once it has a response, so both slots this attempt spent have to be handed back
+          // here. The rate limit slot is otherwise only restored by the rate limit headers of a response this queue will now never send, which
+          // leaves it unable to send anything again, and the invalid request bucket keeps one of its own for the life of the process.
+          this.remaining++;
+          this.rest.invalidBucket.handleCompletedRequest(999, false);
           request.reject({ ok: false, status: 999, error: 'The queue encontered an unexpected error sending a request.', errorObject: e });
         });
       }


### PR DESCRIPTION
A queue spends a rate limit slot before it sends. `sendRequest` hands that slot back from the rate limit headers of a response — so an attempt that **throws** instead of getting a response leaves the slot spent for good, the queue can never send again, and every later request on that route waits forever.

Reproducing it needs nothing exotic: an audit-log `reason` containing a lone surrogate (`'cleanup \ud83d'`) makes `encodeURIComponent` throw inside `createRequestBody` — after the queue has spent its slot, and outside everything `sendRequest` guards.

Three fixes, one theme:

- **`queue.ts:161`** — the `catch` around `sendRequest` only rejected the request. It now also hands back the rate limit slot and the `invalidBucket` slot the attempt spent. Before: a second, valid request on the same route never reached `fetch` and never settled; the mocha process would not even exit.
- **`manager.ts:811`** — `new Promise(async (resolve, reject) => …)`. A promise returned from an executor is dropped, so a throw out of `processRequest` left the caller hanging *and* raised an unhandled rejection. The executor is no longer `async`; the rejection is routed to `payload.reject`.
- **`manager.ts:670`** — the `runThroughQueue: false` branch never called `invalidBucket.waitUntilRequestAvailable()`, but `sendRequest` reports the request as completed either way. Every such request drove `activeRequests` one lower; it read `-1` after a single ordinary call, steadily raising the invalid-request ceiling the bucket exists to enforce.

**Relationship to #5274:** complementary, not overlapping. #5274 covers *`fetch` rejected* (inside `sendRequest`'s fetch catch, which returns normally and never reaches this one); this covers *`sendRequest` threw*. I deliberately did not add a `handleFailedRequest` method or touch the fetch catch. If #5274 lands first, this branch's inline `this.remaining++` could call `handleFailedRequest()` instead — a one-line follow-up.

---

Found by an AI-assisted audit of this codebase (Claude Opus 5). I reviewed the patch and re-ran biome, `tsc --noEmit` and the unit tests before opening this.
