### PR TITLE
fix(rest): stop logging the authorization header

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -579,7 +579,7 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
         rest.logger.debug(`Request to ${url} was ratelimited.`);
         // Too many attempts, get rid of request from queue.
         if (options.retryCount >= rest.maxRetryCount) {
-          rest.logger.debug(`Request to ${url} exceeded the maximum allowed retries.`, 'with payload:', payload);
+          rest.logger.debug(`Request to ${url} exceeded the maximum allowed retries.`, 'with payload:', { ...payload, headers: loggingHeaders });
           // rest.debug(`[REST - RetriesMaxed] ${JSON.stringify(options)}`)
           options.reject({
             ok: false,


### PR DESCRIPTION
One changed line in `src`.

**The bot token was written to the debug log.** `manager.ts:499-503` builds a `loggingHeaders` copy with `authorization` replaced by `"<scheme> tokenhere"`, and line 520 uses it. The retry-exhaustion log four lines later passed the raw `payload`:

```ts
rest.logger.debug(`Request to ${url} exceeded the maximum allowed retries.`, 'with payload:', payload);
```

So a bot that hits `maxRetryCount` on a 429 — with `debug` enabled — writes its full token to wherever the logger goes. Now uses `loggingHeaders` like its neighbour.

I had also bundled an unrelated fix here for the proxy path parsing non-JSON bodies as JSON. It has nothing to do with the header being logged, so it is dropped from this PR to keep it to the one line; I will raise it separately if it is wanted.

---

Found by an AI-assisted audit of this codebase (Claude Opus 5). I reviewed the patch and re-ran biome, `tsc --noEmit` and the unit tests before opening this.

