### PR TITLE
fix(rest): respect the global rate limit and keep queue keys stable

### DIFF
--- a/packages/rest/src/manager.ts
+++ b/packages/rest/src/manager.ts
@@ -148,15 +148,13 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       const global = rest.rateLimitedPaths.get('global');
       const now = Date.now();
 
-      if (ratelimited && now < ratelimited.resetTimestamp) {
-        return ratelimited.resetTimestamp - now;
-      }
+      // Whichever of the two lasts longer is the one that decides when this request may go out, a shorter per url limit does not make it
+      // alright to send while the global one is still running.
+      const urlWait = ratelimited && now < ratelimited.resetTimestamp ? ratelimited.resetTimestamp - now : 0;
+      const globalWait = global && now < global.resetTimestamp ? global.resetTimestamp - now : 0;
+      const wait = Math.max(urlWait, globalWait);
 
-      if (global && now < global.resetTimestamp) {
-        return global.resetTimestamp - now;
-      }
-
-      return false;
+      return wait > 0 ? wait : false;
     },
 
     async updateTokenQueues(oldToken, newToken) {
@@ -206,6 +204,10 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
 
           queue.waiting = [];
           queue.pending = [];
+
+          // The merged queue is not processing anything of its own, so nothing would ever look at what it was just handed.
+          newQueue.processWaiting();
+          newQueue.processPending();
 
           queue.cleanup();
         } else {
@@ -564,7 +566,11 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
       rest.invalidBucket.handleCompletedRequest(response.status, response.headers.get(RATE_LIMIT_SCOPE_HEADER) === 'shared');
 
       // Set the bucket id if it was available on the headers
-      const bucketId = rest.processHeaders(rest.simplifyUrl(options.route, options.method), response.headers, payload.headers.authorization);
+      const bucketId = rest.processHeaders(
+        options.simplifiedUrl ?? rest.simplifyUrl(options.route, options.method),
+        response.headers,
+        payload.headers.authorization,
+      );
 
       if (bucketId) options.bucketId = bucketId;
 
@@ -664,7 +670,8 @@ export function createRestManager(options: CreateRestManagerOptions): RestManage
     },
 
     async processRequest(request: SendRequestOptions) {
-      const url = rest.simplifyUrl(request.route, request.method);
+      request.simplifiedUrl ??= rest.simplifyUrl(request.route, request.method);
+      const url = request.simplifiedUrl;
 
       if (request.runThroughQueue === false) {
         await rest.sendRequest(request);

--- a/packages/rest/src/queue.ts
+++ b/packages/rest/src/queue.ts
@@ -133,7 +133,7 @@ export class Queue {
 
       const request = this.pending[0];
       if (request) {
-        const basicURL = this.rest.simplifyUrl(request.route, request.method);
+        const basicURL = request.simplifiedUrl ?? this.rest.simplifyUrl(request.route, request.method);
 
         // If this url is still rate limited, try again
         const urlResetIn = this.rest.checkRateLimits(basicURL, this.identifier);
@@ -202,8 +202,12 @@ export class Queue {
       return;
     }
 
-    this.pending.push(options);
-    this.processPending();
+    // `updateTokenQueues` may have re-keyed this queue while the request was waiting, which leaves this instance detached from the manager and
+    // unable to ever be given a rate limit slot back, so the request goes to whichever queue holds the key now.
+    const owner = this.rest.queues.get(`${this.identifier}${this.url}`) ?? this;
+
+    owner.pending.push(options);
+    owner.processPending();
   }
 
   /** Cleans up the queue by checking if there is nothing left and removing it. */
@@ -228,8 +232,10 @@ export class Queue {
 
       if (this.timeoutId) clearTimeout(this.timeoutId);
 
-      // No requests have been requested for this queue so we nuke this queue
-      this.rest.queues.delete(`${this.identifier}${this.url}`);
+      // `updateTokenQueues` can point this queue's key at another queue that is very much alive, so only the queue the manager actually holds
+      // under that key may delete it.
+      const key = `${this.identifier}${this.url}`;
+      if (this.rest.queues.get(key) === this) this.rest.queues.delete(key);
       this.rest.logger.debug(
         `[Queue] ${this.queueType} ${this.url}. Deleted! Remaining: (${this.rest.queues.size})`,
         [...this.rest.queues.values()].map((queue) => `${queue.queueType}${queue.url}`),

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -3528,6 +3528,14 @@ export interface SendRequestOptions {
   reject: (value: RestRequestRejection) => void;
   /** If this request has a bucket id which it falls under for rate limit */
   bucketId?: string;
+  /**
+   * The simplified url of this request, as `rest.simplifyUrl` returned it when the request was first handled.
+   *
+   * @remarks
+   * The simplified url of a message delete depends on how old the message is, so it has to be kept instead of being worked out again later,
+   * or the key the queue was found under and the key its response is credited to stop matching once the message crosses one of those ages.
+   */
+  simplifiedUrl?: string;
   /** Additional request options, used for things like overriding authorization header. */
   requestBodyOptions?: CreateRequestBodyOptions;
   /**

--- a/packages/rest/tests/unit/manager.spec.ts
+++ b/packages/rest/tests/unit/manager.spec.ts
@@ -169,7 +169,7 @@ describe('[rest] manager', () => {
     });
 
     describe('With both URL and Global rateLimitedPath', () => {
-      it('Will return URL time first if before resetTimestamp', () => {
+      it('Will return the global time when it is the longer of the two', () => {
         rest.rateLimitedPaths.set(`Bot ${token}/channel/555555555555555555`, {
           url: '/channel/555555555555555555',
           resetTimestamp: Date.now() + 6541,
@@ -178,7 +178,7 @@ describe('[rest] manager', () => {
           url: '/channel/555555555555555555',
           resetTimestamp: Date.now() + 9849,
         });
-        expect(rest.checkRateLimits('/channel/555555555555555555', `Bot ${token}`)).to.be.equal(6541);
+        expect(rest.checkRateLimits('/channel/555555555555555555', `Bot ${token}`)).to.be.equal(9849);
       });
     });
   });


### PR DESCRIPTION
Three rate limit accounting bugs. This is the subtlest of the batch — please read the two flags at the bottom.

**`checkRateLimits` ignored the global limit when a shorter per-url one existed.** It returned on the first match:

```ts
if (ratelimited && now < ratelimited.resetTimestamp) return ratelimited.resetTimestamp - now;
if (global && now < global.resetTimestamp) return global.resetTimestamp - now;
```

With a 6541ms url wait and a 9849ms global wait it returned 6541, and `processPending` dispatched 3.3s inside the active global window. Now returns the longer of the two.

**The queue key for a message delete depends on wall-clock time.** `simplifyUrl` suffixes a `DELETE /channels/x/messages/y` with `message-delete`, `message-delete-10s` or `message-delete-2w` based on how old the message is *right now*. A request enqueued under `…-10s` whose response arrives 11 seconds later gets its rate limit credit applied to `…-2w` — a key nobody owns. The queue's `remaining` then stays `0` instead of taking the header's `4`; `remaining: 0` with `interval: 0` is the permanent wedge. The simplified url is now computed once, stored on `SendRequestOptions`, and reused.

**`updateTokenQueues`' merge branch deleted the live queue.** After moving the old queue's work onto the queue that already holds the new key, it calls `queue.cleanup()` on the *old* instance — whose `identifier` has already been rewritten, so the key it deletes is the merged queue's. `rest.queues.get(key)` returned `undefined` afterwards. `cleanup` now only deletes a key the manager actually holds *this* queue under. A request parked on the detached old queue was also never sent (fetch count 2 instead of 3); `Queue.makeRequest` now resolves the owning queue from `rest.queues` after waiting, and `updateTokenQueues` starts the merged queue's `processWaiting`/`processPending`, which nothing did before.

**Two things to flag.**

1. This updates an existing test, which is the one test change left in this PR. `'Will return URL time first if before resetTimestamp'` asserted the old precedence (6541 with a 9849ms global wait set). It is renamed to `'Will return the global time when it is the longer of the two'` and its expectation changed to 9849, because the behaviour it pinned is the behaviour being fixed. `checkRateLimits` is public API, so its return value genuinely changes for a caller holding both limits at once.
2. `SendRequestOptions` gains one optional field, `simplifiedUrl?: string`. Additive, but it is a public interface.

Deliberately left out: turning `processPending`'s single `if (urlResetIn) await delay(urlResetIn)` into a re-checking loop. `Math.max` alone fixes the reported defect; the loop changes queue timing more broadly and is a maintainer call. Does not touch the lines #5274 touches.

---

Found by an AI-assisted audit of this codebase (Claude Opus 5). I reviewed the patch and re-ran biome, `tsc --noEmit` and the unit tests before opening this.

