### PR TITLE
fix(utils): allow updates at maxSize and keep sweeper options intact

### DIFF
--- a/packages/utils/src/Collection.ts
+++ b/packages/utils/src/Collection.ts
@@ -22,10 +22,12 @@ export class Collection<K, V> extends Map<K, V> {
   startSweeper(options: CollectionSweeper<K, V>): NodeJS.Timeout {
     if (this.sweeper?.intervalId) clearInterval(this.sweeper.intervalId);
 
-    this.sweeper = options;
+    const sweeper = { ...options };
+
+    this.sweeper = sweeper;
     this.sweeper.intervalId = setInterval(() => {
       this.forEach((value, key) => {
-        if (!this.sweeper?.filter(value, key, options.bot)) return;
+        if (!this.sweeper?.filter(value, key, sweeper.bot)) return;
 
         this.delete(key);
         return key;
@@ -36,25 +38,27 @@ export class Collection<K, V> extends Map<K, V> {
   }
 
   stopSweeper(): void {
-    return clearInterval(this.sweeper?.intervalId);
+    clearInterval(this.sweeper?.intervalId);
+
+    if (this.sweeper) this.sweeper.intervalId = undefined;
   }
 
   changeSweeperInterval(newInterval: number): void {
     if (this.sweeper == null) return;
 
-    this.startSweeper({ filter: this.sweeper.filter, interval: newInterval });
+    this.startSweeper({ ...this.sweeper, interval: newInterval });
   }
 
   changeSweeperFilter(newFilter: (value: V, key: K, bot: PlaceHolderBot) => boolean): void {
     if (this.sweeper == null) return;
 
-    this.startSweeper({ filter: newFilter, interval: this.sweeper.interval });
+    this.startSweeper({ ...this.sweeper, filter: newFilter });
   }
 
   /** Add an item to the collection. Makes sure not to go above the maxSize. */
   set(key: K, value: V): this {
     // When this collection is maxSized make sure we can add first
-    if ((this.maxSize !== undefined || this.maxSize === 0) && this.size >= this.maxSize) {
+    if (this.maxSize !== undefined && this.size >= this.maxSize && !this.has(key)) {
       return this;
     }
 

--- a/packages/utils/src/Collection.ts
+++ b/packages/utils/src/Collection.ts
@@ -38,9 +38,10 @@ export class Collection<K, V> extends Map<K, V> {
   }
 
   stopSweeper(): void {
-    clearInterval(this.sweeper?.intervalId);
+    if (!this.sweeper) return;
 
-    if (this.sweeper) this.sweeper.intervalId = undefined;
+    clearInterval(this.sweeper.intervalId);
+    this.sweeper.intervalId = undefined;
   }
 
   changeSweeperInterval(newInterval: number): void {

--- a/packages/utils/tests/collection.spec.ts
+++ b/packages/utils/tests/collection.spec.ts
@@ -65,6 +65,16 @@ describe('collection.ts', () => {
           collection.set('this', 'not');
           expect(collection.size).to.be.equal(2);
         });
+
+        it('will update an existing key when at max size', () => {
+          collection.set('foo', 'bar');
+          collection.set('me', 'you');
+          expect(collection.size).to.be.equal(2);
+
+          collection.set('foo', 'baz');
+          expect(collection.size).to.be.equal(2);
+          expect(collection.get('foo')).to.be.equal('baz');
+        });
       });
     });
 
@@ -186,11 +196,46 @@ describe('collection.ts', () => {
         sweeperCollection.stopSweeper();
       });
 
+      it('will not keep a timer alive when two collections share one sweeper options object', async () => {
+        const options = { filter: () => true, interval: 50 };
+        const first = new Collection([['a', 1]]);
+        const second = new Collection([['b', 2]]);
+
+        first.startSweeper(options);
+        second.startSweeper(options);
+        first.stopSweeper();
+        second.stopSweeper();
+
+        await clock.tickAsync(100);
+
+        expect(first.size).to.be.equal(1);
+        expect(second.size).to.be.equal(1);
+      });
+
       describe('.changeSweeperInterval() method', () => {
         it('will call startSweeper with new interval', () => {
           collection.startSweeper({ filter: () => false, interval: 1000 });
           collection.changeSweeperInterval(20000);
           expect(collection.sweeper?.interval).to.equal(20000);
+        });
+
+        it('will keep passing the bot to the filter', async () => {
+          const bot = {};
+          let observed: unknown = 'filter was never called';
+
+          collection.startSweeper({
+            bot,
+            filter: (_value, _key, sweeperBot) => {
+              observed = sweeperBot;
+              return false;
+            },
+            interval: 1000,
+          });
+          collection.changeSweeperInterval(50);
+          await clock.tickAsync(50);
+          collection.stopSweeper();
+
+          expect(observed).to.be.equal(bot);
         });
 
         it('will not startsweeper if not started', () => {
@@ -205,6 +250,21 @@ describe('collection.ts', () => {
           collection.startSweeper({ filter: () => false, interval: 1000 });
           collection.changeSweeperFilter(newFilter);
           expect(collection.sweeper?.filter).to.equal(newFilter);
+        });
+
+        it('will keep passing the bot to the new filter', async () => {
+          const bot = {};
+          let observed: unknown = 'filter was never called';
+
+          collection.startSweeper({ bot, filter: () => false, interval: 50 });
+          collection.changeSweeperFilter((_value, _key, sweeperBot) => {
+            observed = sweeperBot;
+            return false;
+          });
+          await clock.tickAsync(50);
+          collection.stopSweeper();
+
+          expect(observed).to.be.equal(bot);
         });
 
         it('will not startsweeper if not started', () => {


### PR DESCRIPTION
Three `Collection` bugs, each with a test that fails on `main`.

**`set()` refuses to update a key it already holds once at `maxSize`.** The guard only looked at `size`:

```ts
new Collection([['foo', 'bar'], ['me', 'you']], { maxSize: 2 }).set('foo', 'baz')
// get('foo') === 'bar'
```

An update cannot grow the collection, so the cap is still honoured — it just should not block writes to existing keys. The value is silently dropped today, with no error.

**`changeSweeperInterval` / `changeSweeperFilter` drop `bot`.** They rebuild the options object from `interval` and `filter` only, so the filter's third argument became `undefined` on the next sweep — throwing `Cannot read properties of undefined (reading 'cache')` out of `setInterval`, i.e. as an uncaught exception.

**`startSweeper` stores the caller's options object by reference and mutates it.** Two Collections given one config shared a single `intervalId` field, so the second `startSweeper` overwrote the first's timer id. After both `stopSweeper()` calls the first collection's timer was still running and still sweeping. It now stores a copy.

**Behaviour changes:** a Collection at `maxSize` now accepts `set()` on an existing key; `collection.sweeper` is a copy rather than the caller's object, so mutating your own options object to reconfigure a live sweeper no longer has an effect (undocumented, and it never worked reliably). discordeno itself never constructs a `maxSize` Collection or a sweeper, so nothing in-repo is affected.

---

Found by an AI-assisted audit of this codebase (Claude Opus 5). I reviewed the patch and re-ran biome, `tsc --noEmit` and the tests before opening this.
