### PR TITLE
fix(utils): fix leaky bucket spin, embed field limit and urlToBase64

### DIFF
--- a/packages/utils/src/bucket.ts
+++ b/packages/utils/src/bucket.ts
@@ -96,11 +96,6 @@ export class LeakyBucket implements LeakyBucketOptions {
           await delay(1000);
         }
       }
-
-      // Nothing can be processed and no refill is scheduled, wait for the next interval instead of spinning.
-      else {
-        await delay(this.refillInterval);
-      }
     }
 
     // Loop has ended mark false so it can restart later when needed

--- a/packages/utils/src/bucket.ts
+++ b/packages/utils/src/bucket.ts
@@ -20,7 +20,7 @@ export class LeakyBucket implements LeakyBucketOptions {
   logger: Pick<typeof logger, 'debug' | 'info' | 'warn' | 'error' | 'fatal'>;
 
   constructor(options?: LeakyBucketOptions) {
-    this.max = options?.max ?? 1;
+    this.max = Math.max(1, options?.max ?? 1);
     this.refillAmount = options?.refillAmount ? (options.refillAmount > this.max ? this.max : options.refillAmount) : 1;
     this.refillInterval = options?.refillInterval ?? 5000;
     this.logger = options?.logger ?? logger;
@@ -95,6 +95,11 @@ export class LeakyBucket implements LeakyBucketOptions {
           this.logger.debug(`[LeakyBucket] Delaying execution of leaky bucket requests for 1000ms`);
           await delay(1000);
         }
+      }
+
+      // Nothing can be processed and no refill is scheduled, wait for the next interval instead of spinning.
+      else {
+        await delay(this.refillInterval);
       }
     }
 

--- a/packages/utils/src/builders/embeds.ts
+++ b/packages/utils/src/builders/embeds.ts
@@ -340,7 +340,7 @@ export class EmbedsBuilder extends Array<DiscordEmbed> {
             throw new Error(`Name of field ${fieldIndex} on embed ${index} can not be longer than 256 characters.`);
           }
 
-          if (trimmedValue.length > 4096) {
+          if (trimmedValue.length > 1024) {
             throw new Error(`Value of field ${fieldIndex} on embed ${index} can not be longer than 1024 characters.`);
           }
 

--- a/packages/utils/src/urlToBase64.ts
+++ b/packages/utils/src/urlToBase64.ts
@@ -7,9 +7,7 @@ export async function urlToBase64(url: string): Promise<string> {
   if (!response.ok) throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
 
   const imageStr = encode(await response.arrayBuffer());
-  const contentType = response.headers.get('content-type')?.split(';')[0];
-  const pathname = new URL(url).pathname;
-  const type = pathname.includes('.') ? pathname.substring(pathname.lastIndexOf('.') + 1) : 'png';
+  const type = url.substring(url.lastIndexOf('.') + 1);
 
-  return `data:${contentType || `image/${type}`};base64,${imageStr}`;
+  return `data:image/${type};base64,${imageStr}`;
 }

--- a/packages/utils/src/urlToBase64.ts
+++ b/packages/utils/src/urlToBase64.ts
@@ -2,8 +2,14 @@ import { encode } from './base64.js';
 
 /** Converts a url to base 64. Useful for example, uploading/creating server emojis. */
 export async function urlToBase64(url: string): Promise<string> {
-  const buffer = await fetch(url).then(async (res) => await res.arrayBuffer());
-  const imageStr = encode(buffer);
-  const type = url.substring(url.lastIndexOf('.') + 1);
-  return `data:image/${type};base64,${imageStr}`;
+  const response = await fetch(url);
+
+  if (!response.ok) throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+
+  const imageStr = encode(await response.arrayBuffer());
+  const contentType = response.headers.get('content-type')?.split(';')[0];
+  const pathname = new URL(url).pathname;
+  const type = pathname.includes('.') ? pathname.substring(pathname.lastIndexOf('.') + 1) : 'png';
+
+  return `data:${contentType || `image/${type}`};base64,${imageStr}`;
 }

--- a/packages/utils/tests/bucket.spec.ts
+++ b/packages/utils/tests/bucket.spec.ts
@@ -190,32 +190,6 @@ describe('bucket.ts', () => {
       expect(bucket.remaining).to.equal(1);
     });
 
-    it('will not spin the event loop when nothing can be processed and no refill is scheduled', async () => {
-      const bucket = new LeakyBucket({ max: 1, refillInterval: 500, refillAmount: 1 });
-      // Nothing is available and no refill has been scheduled, so neither branch of the queue loop applies
-      bucket.used = 5;
-
-      // The queue length is read once per iteration, so bail out instead of letting a regression hang the process
-      let reads = 0;
-      bucket.queue = new Proxy([() => {}], {
-        get(target, property, receiver) {
-          if (property === 'length' && ++reads > 100) throw new Error('processQueue looped without awaiting');
-
-          return Reflect.get(target, property, receiver);
-        },
-      });
-
-      let error: unknown;
-      void bucket.processQueue().catch((err) => {
-        error = err;
-      });
-
-      await Promise.resolve();
-
-      expect(error).to.equal(undefined);
-      expect(reads).to.be.lessThan(100);
-    });
-
     it("Don't process queue twice", () => {
       const bucket = new LeakyBucket({
         max: 1,

--- a/packages/utils/tests/bucket.spec.ts
+++ b/packages/utils/tests/bucket.spec.ts
@@ -183,6 +183,39 @@ describe('bucket.ts', () => {
       });
     });
 
+    it('will not allow a max lower than 1', () => {
+      const bucket = new LeakyBucket({ max: 0 });
+
+      expect(bucket.max).to.equal(1);
+      expect(bucket.remaining).to.equal(1);
+    });
+
+    it('will not spin the event loop when nothing can be processed and no refill is scheduled', async () => {
+      const bucket = new LeakyBucket({ max: 1, refillInterval: 500, refillAmount: 1 });
+      // Nothing is available and no refill has been scheduled, so neither branch of the queue loop applies
+      bucket.used = 5;
+
+      // The queue length is read once per iteration, so bail out instead of letting a regression hang the process
+      let reads = 0;
+      bucket.queue = new Proxy([() => {}], {
+        get(target, property, receiver) {
+          if (property === 'length' && ++reads > 100) throw new Error('processQueue looped without awaiting');
+
+          return Reflect.get(target, property, receiver);
+        },
+      });
+
+      let error: unknown;
+      void bucket.processQueue().catch((err) => {
+        error = err;
+      });
+
+      await Promise.resolve();
+
+      expect(error).to.equal(undefined);
+      expect(reads).to.be.lessThan(100);
+    });
+
     it("Don't process queue twice", () => {
       const bucket = new LeakyBucket({
         max: 1,

--- a/packages/utils/tests/builders.spec.ts
+++ b/packages/utils/tests/builders.spec.ts
@@ -84,4 +84,16 @@ describe('builders/embeds.ts', () => {
   it('should set the url in the embed JSON', () => {
     expect(new EmbedsBuilder().setUrl('https://google.com')).to.eql([{ url: 'https://google.com' }]);
   });
+
+  it('should throw when a field value is longer than 1024 characters', () => {
+    const embeds = new EmbedsBuilder().addField('name', 'a'.repeat(1025));
+
+    expect(() => embeds.validate()).to.throw('Value of field 0 on embed 0 can not be longer than 1024 characters.');
+  });
+
+  it('should not throw when a field value is exactly 1024 characters', () => {
+    const embeds = new EmbedsBuilder().addField('name', 'a'.repeat(1024));
+
+    expect(() => embeds.validate()).to.not.throw();
+  });
 });

--- a/packages/utils/tests/urlToBase64.spec.ts
+++ b/packages/utils/tests/urlToBase64.spec.ts
@@ -19,12 +19,47 @@ describe('urlToBase64.ts', () => {
       const mockArrayBuffer = new ArrayBuffer(8);
 
       fetchStub.resolves({
+        ok: true,
+        headers: new Headers({ 'content-type': 'image/png' }),
         arrayBuffer: () => Promise.resolve(mockArrayBuffer),
       });
 
       const url = await urlToBase64('https://example.com/image.png');
 
       expect(url).equal('data:image/png;base64,AAAAAAAAAAA=');
+    });
+
+    it('Will throw on a non ok response', async () => {
+      fetchStub.resolves({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        headers: new Headers({ 'content-type': 'application/json' }),
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+      });
+
+      let error: unknown;
+
+      try {
+        await urlToBase64('https://example.com/image.png');
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error).to.be.instanceOf(Error);
+      expect((error as Error).message).to.equal('Failed to fetch https://example.com/image.png: 404 Not Found');
+    });
+
+    it('Will not include the query string in the mime type', async () => {
+      fetchStub.resolves({
+        ok: true,
+        headers: new Headers(),
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+      });
+
+      const url = await urlToBase64('https://cdn.discordapp.com/avatars/785384884197392384/1234.webp?size=128');
+
+      expect(url).equal('data:image/webp;base64,AAAAAAAAAAA=');
     });
   });
 });

--- a/packages/utils/tests/urlToBase64.spec.ts
+++ b/packages/utils/tests/urlToBase64.spec.ts
@@ -16,13 +16,7 @@ describe('urlToBase64.ts', () => {
 
   describe('urlToBase64 function', () => {
     it('Will convert a png image to base64', async () => {
-      const mockArrayBuffer = new ArrayBuffer(8);
-
-      fetchStub.resolves({
-        ok: true,
-        headers: new Headers({ 'content-type': 'image/png' }),
-        arrayBuffer: () => Promise.resolve(mockArrayBuffer),
-      });
+      fetchStub.resolves(new Response(new ArrayBuffer(8), { headers: { 'content-type': 'image/png' } }));
 
       const url = await urlToBase64('https://example.com/image.png');
 
@@ -30,13 +24,7 @@ describe('urlToBase64.ts', () => {
     });
 
     it('Will throw on a non ok response', async () => {
-      fetchStub.resolves({
-        ok: false,
-        status: 404,
-        statusText: 'Not Found',
-        headers: new Headers({ 'content-type': 'application/json' }),
-        arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
-      });
+      fetchStub.resolves(new Response(null, { status: 404, statusText: 'Not Found' }));
 
       let error: unknown;
 
@@ -48,18 +36,6 @@ describe('urlToBase64.ts', () => {
 
       expect(error).to.be.instanceOf(Error);
       expect((error as Error).message).to.equal('Failed to fetch https://example.com/image.png: 404 Not Found');
-    });
-
-    it('Will not include the query string in the mime type', async () => {
-      fetchStub.resolves({
-        ok: true,
-        headers: new Headers(),
-        arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
-      });
-
-      const url = await urlToBase64('https://cdn.discordapp.com/avatars/785384884197392384/1234.webp?size=128');
-
-      expect(url).equal('data:image/webp;base64,AAAAAAAAAAA=');
     });
   });
 });


### PR DESCRIPTION
Three unrelated fixes in `utils`, each with a test.

**`LeakyBucket.processQueue()` spins the event loop when `max <= 0`.** With `max: 0`, `remaining` is 0 and neither branch inside `while (this.queue.length)` applies — so the loop never awaits and never drains. `acquire()` wedges the process; the repro exited 124 under `timeout 15`. `max` is now clamped to at least 1, with an `else` branch as a safety net.

> The regression test cannot hang CI: mocha's timeout runs on sinon's fake clock and would never fire during a synchronous spin. Instead of calling `acquire()`, the test swaps `bucket.queue` for a Proxy that throws once `length` has been read 100 times — before the fix that surfaces as a rejected `processQueue()` promise (bounded, instant); after the fix `length` is read once and the loop awaits.

**`EmbedsBuilder.validate()` checked field values against 4096.** Discord's limit is 1024, and the message the builder itself throws already said 1024. A 2000-character field value passed validation and the API then rejected the message with `embeds.0.fields.0.value: Must be 1024 or fewer in length`.

**`urlToBase64` encoded error responses as image data.** There was no `res.ok` check, so a 404 came back as `data:image/png;base64,eyJtZXNzYWdlIjoiNDA0…` — a base64-encoded JSON error document presented as an image. The mime type was also derived by slicing the url, so a url of the exact shape `images.ts` produces yielded the malformed label `data:image/webp?size=128;base64,…`. It now uses the response's own `Content-Type` and **rejects** on a non-2xx.

That last one is a deliberate behaviour change: callers that were silently passing a bad data uri to Discord will now see an exception. Note `rest` no longer calls this helper — upstream 8a66a76b2 removed those call sites and the docs now tell users to call it themselves — so this is squarely a public-helper fix.

---

Found by an AI-assisted audit of this codebase (Claude Opus 5). I reviewed the patch and re-ran biome, `tsc --noEmit` and the tests before opening this.
