### PR TITLE
fix(types)!: correct request field names and payload shapes

### DIFF
--- a/packages/types/src/discord/guildTemplate.ts
+++ b/packages/types/src/discord/guildTemplate.ts
@@ -75,7 +75,7 @@ export type DiscordTemplateSerializedSourceGuild = Omit<
       'id' | 'permission_overwrites' | 'parent_id'
     > & {
       id: number;
-      permission_overwrites: DiscordOverwrite & { id: number };
+      permission_overwrites: Array<Omit<DiscordOverwrite, 'id'> & { id: number }>;
       parent_id: number | null;
     }
   >;

--- a/packages/types/src/discord/interactions.ts
+++ b/packages/types/src/discord/interactions.ts
@@ -32,7 +32,7 @@ export interface DiscordInteraction {
   /** The guild it was sent from */
   guild_id?: string;
   /** The channel it was sent from */
-  channel: Partial<DiscordChannel>;
+  channel?: Partial<DiscordChannel>;
   /**
    * The ID of channel it was sent from
    *

--- a/packages/types/src/discord/webhookEvents.ts
+++ b/packages/types/src/discord/webhookEvents.ts
@@ -15,7 +15,7 @@ export interface DiscordEventWebhookEvent {
   /** ID of your app */
   application_id: string;
   /** Type of webhook, either 0 for PING or 1 for webhook events */
-  type: DiscordWebhookEventType;
+  type: DiscordEventWebhookType;
   /** Event data payload */
   event?: DiscordEventWebhookEventBody;
 }

--- a/packages/types/src/discordeno/application.ts
+++ b/packages/types/src/discordeno/application.ts
@@ -4,6 +4,7 @@ import type {
   ApplicationFlags,
   DiscordApplicationEventWebhookStatus,
   DiscordApplicationIntegrationType,
+  DiscordApplicationIntegrationTypeConfiguration,
   DiscordInstallParams,
 } from '../discord/application.js';
 import type { DiscordWebhookEventType } from '../discord/webhookEvents.js';
@@ -19,7 +20,7 @@ export interface EditApplication {
   /** Settings for the app's default in-app authorization link, if enabled */
   installParams?: DiscordInstallParams;
   /** Default scopes and permissions for each supported installation context. */
-  integrationTypesConfig?: DiscordApplicationIntegrationType;
+  integrationTypesConfig?: Partial<Record<`${DiscordApplicationIntegrationType}`, DiscordApplicationIntegrationTypeConfiguration>>;
   /**
    * App's public flags
    *
@@ -39,7 +40,7 @@ export interface EditApplication {
    * @remarks
    * To update an Interactions endpoint URL via the API, the URL must be valid
    */
-  interactionEndpointUrl?: string;
+  interactionsEndpointUrl?: string;
   /**
    * List of tags describing the content and functionality of the app (max of 20 characters per tag)
    *

--- a/packages/types/src/discordeno/guild.ts
+++ b/packages/types/src/discordeno/guild.ts
@@ -352,7 +352,7 @@ export interface ModifyGuildWelcomeScreen {
   /** Whether the welcome screen is enabled */
   enabled?: boolean | null;
   /** Channels linked in the welcome screen and their display options */
-  welcome_screen?: DiscordWelcomeScreenChannel[] | null;
+  welcomeChannels?: DiscordWelcomeScreenChannel[] | null;
   /** The server description to show in the welcome screen */
   description?: string | null;
 }

--- a/packages/types/src/discordeno/message.ts
+++ b/packages/types/src/discordeno/message.ts
@@ -59,7 +59,7 @@ export interface AttachmentRequest {
    * @remarks
    * Required for voice messages
    */
-  waweform?: string;
+  waveform?: string;
   /**
    * Whether the attachment should be marked as a spoiler and blurred until clicked, this sets the `IS_SPOILER` attachment flag
    */


### PR DESCRIPTION
Seven type defects. Three of them put the **wrong key on the wire**, so the field is silently ignored by the API today.

`changeToDiscordFormat` camel→snake converts every key, but passes through any key that already contains `_`. Running the three renames through that exact mapping:

```
OLD  welcome_screen           -> welcome_screen              (Discord wants welcome_channels)
NEW  welcomeChannels          -> welcome_channels            ✓
OLD  interactionEndpointUrl   -> interaction_endpoint_url    (Discord wants interactions_endpoint_url)
NEW  interactionsEndpointUrl  -> interactions_endpoint_url   ✓
OLD  waweform                 -> waweform                    (typo; Discord wants waveform)
NEW  waveform                 -> waveform                    ✓
```

So `editWelcomeScreen({ welcome_screen: [...] })` never updated any channel, `editApplicationInfo` never set the interactions endpoint, and voice-message metadata was unspellable.

The other four are shape errors:

- `EditApplication.integrationTypesConfig` was a single `DiscordApplicationIntegrationType`; [the docs](https://discord.com/developers/docs/resources/application) describe a dictionary keyed by installation context.
- `DiscordEventWebhookEvent.type` used the string event-name enum `DiscordWebhookEventType`; the outer payload `type` is the numeric webhook type (PING = 0, Event = 1). The inner `DiscordEventWebhookEventBody.type` is left as the string enum, which is correct.
- `DiscordTemplateSerializedSourceGuild.channels[].permission_overwrites` was a single overwrite object, not an array. (The old `DiscordOverwrite & { id: number }` also collapsed `id` to `string & number` = `never`, hence the `Omit`.)
- `DiscordInteraction.channel` was required; Discord documents it optional, and an HTTP PING interaction carries no channel.

**Breaking.** Renamed: `AttachmentRequest.waweform` → `waveform`, `EditApplication.interactionEndpointUrl` → `interactionsEndpointUrl`, `ModifyGuildWelcomeScreen.welcome_screen` → `welcomeChannels`. Source-breaking shape changes: the four above — in particular `interaction.channel.id` now needs a guard, which is the point.

No consumer in `packages/rest` or `packages/bot` read any of the three renamed write-side keys (both helpers pass `body` straight to `patch`), and the read-side consumers are already guarded — `transformers/interaction.ts:165` is `if (props.channel && payload.channel)`. `tsc --noEmit` is clean for rest, gateway, bot and utils against these types.

Happy to soften the renames with `@deprecated` aliases for a release if you'd rather; I left them out to keep the wrong keys unspellable. No test added — `packages/types` has no type-assertion harness, so the wire proof above was done with a throwaway script that is not committed.

---

Found by an AI-assisted audit of this codebase (Claude Opus 5). I reviewed the patch and re-ran biome and `tsc --noEmit` across every consumer package before opening this.
