### PR TITLE
fix(bot): keep an explicit lastShardId of 0 in bot.start()

### DIFF
--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -80,7 +80,9 @@ export function createBot<
 
         if (!options.gateway?.totalShards) bot.gateway.totalShards = bot.gateway.connection.shards;
 
-        if (!options.gateway?.lastShardId && !options.gateway?.totalShards) bot.gateway.lastShardId = bot.gateway.connection.shards - 1;
+        // `lastShardId: 0` is a valid single shard configuration, so an explicit id may not be treated as an absent one.
+        if (options.gateway?.lastShardId === undefined && options.gateway?.totalShards === undefined)
+          bot.gateway.lastShardId = bot.gateway.connection.shards - 1;
       }
 
       if (!bot.gateway.resharding.getSessionInfo) {


### PR DESCRIPTION
`bot.start()` fills in `lastShardId` from the recommended shard count when the caller did not pin it:

```ts
if (!options.gateway?.lastShardId && !options.gateway?.totalShards)
  bot.gateway.lastShardId = bot.gateway.connection.shards - 1;
```

`lastShardId: 0` is falsy, but it is also a perfectly valid single-shard configuration — the natural way to run shard 0 on its own. It gets treated as absent and overwritten, so a process configured for one shard connects **every** recommended shard instead.

With a session info recommending 8 shards:

```
createBot({ token, gateway: { firstShardId: 0, lastShardId: 0 } })
await bot.start()
// before: bot.gateway.lastShardId === 7   (8 shards spawned)
// after:  bot.gateway.lastShardId === 0
```

Comparing against `undefined` fixes it.

---

Found by an AI-assisted audit of this codebase (Claude Opus 5). I reviewed the patch and re-ran biome, `tsc --noEmit` and the unit tests before opening this.

